### PR TITLE
Fixes broadcast_as attribute error

### DIFF
--- a/hcipy/field/coordinates.py
+++ b/hcipy/field/coordinates.py
@@ -173,7 +173,7 @@ class SeparatedCoords(CoordsBase):
 		s0 = (1,) * len(self)
 		j = len(self) - i - 1
 		output = self.separated_coords[i].reshape(s0[:j] + (-1,) + s0[j + 1:])
-		return np.broadcast_as(output, self.shape).ravel()
+		return np.broadcast_to(output, self.shape).ravel()
 
 	@property
 	def size(self):

--- a/hcipy/fourier/fast_fourier_transform.py
+++ b/hcipy/fourier/fast_fourier_transform.py
@@ -67,9 +67,9 @@ class FastFourierTransform(FourierTransform):
 		from ..field import Field
 		
 		f = np.zeros(self.internal_shape, dtype='complex')
-		f[self.cutout_input] = (field.ravel() * self.weights * self.shift_output).reshape(self.shape_in)
+		f[tuple(self.cutout_input)] = (field.ravel() * self.weights * self.shift_output).reshape(self.shape_in)
 		res = np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(f)))
-		res = res[self.cutout_output].ravel() * self.shift_input
+		res = res[tuple(self.cutout_output)].ravel() * self.shift_input
 		
 		return Field(res, self.output_grid)
 	
@@ -78,8 +78,8 @@ class FastFourierTransform(FourierTransform):
 		from ..field import Field
 
 		f = np.zeros(self.internal_shape, dtype='complex')
-		f[self.cutout_output] = (field.ravel() / self.shift_input).reshape(self.shape_out)
+		f[tuple(self.cutout_output)] = (field.ravel() / self.shift_input).reshape(self.shape_out)
 		res = np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(f)))
-		res = res[self.cutout_input].ravel() / self.weights / self.shift_output
+		res = res[tuple(self.cutout_input)].ravel() / self.weights / self.shift_output
 		
 		return Field(res, self.input_grid)


### PR DESCRIPTION
This should resolve #5, it also fixes some non-tuple indexing warnings that fire when running the adaptive_optics example.