### PR TITLE
Refactor LUVOIR aperture function for segment ModeBasis

### DIFF
--- a/hcipy/aperture/realistic.py
+++ b/hcipy/aperture/realistic.py
@@ -63,93 +63,102 @@ def make_magellan_aperture(normalized=False, with_spiders=True):
 def make_keck_aperture():
 	pass
 
-def make_luvoir_a_aperture(normalized=False, with_spiders=True, with_segment_gaps=True, segment_transmissions=1, return_segment_positions=False):
-	'''Make the LUVOIR A aperture.
+def make_luvoir_a_aperture(normalized=False, with_spiders=True, with_segment_gaps=True, segment_transmissions=1, return_segments=False):
+    '''Make the LUVOIR A aperture.
 
-	This aperture changes frequently. This one is based on [1]_. Spiders and segment gaps 
-	can be included or excluded, and the transmission for each of the segments can also be changed.
-	
-	.. [1] Ruane et al. 2018 "Fast linearized coronagraph optimizer (FALCO) IV: coronagraph design 
-		survey for obstructed and segmented apertures." Space Telescopes and Instrumentation 2018: 
-		Optical, Infrared, and Millimeter Wave. Vol. 10698. International Society for Optics and Photonics, 2018.
+    This aperture changes frequently. This one is based on [1]_. Spiders and segment gaps
+    can be included or excluded, and the transmission for each of the segments can also be changed.
 
-	Parameters
-	----------
-	normalized : boolean
-		If this is True, the outer diameter will be scaled to 1. Otherwise, the
-		diameter of the pupil will be 15.0 meters.
-	with_spiders : boolean
-		Include the secondary mirror support structure in the aperture.
-	with_segment_gaps : boolean
-		Include the gaps between individual segments in the aperture.
-	segment_transmissions : scalar or array_like
-		The transmission for each of the segments. If this is a scalar, this transmission will
-		be used for all segments.
-	return_segment_positions : boolean
-		If this is True, the centers of each of the segments will get returned as well.
-	
-	Returns
-	-------
-	Field generator
-		The LUVOIR A aperture.
-	CartesianGrid
-		The segment positions. Only returned when `return_segment_positions` is True.
-	'''
-	pupil_diameter = 15.0 # m
-	segment_circum_diameter = 2 / np.sqrt(3) * pupil_diameter / 12
-	num_rings = 6
-	segment_gap = 0.001 * pupil_diameter
-	spider_width = 0.005 * pupil_diameter
-	spider_relative_offset = 0.9 # as estimated from the paper, not an actual value
+    .. [1] Ruane et al. 2018 "Fast linearized coronagraph optimizer (FALCO) IV: coronagraph design
+    	survey for obstructed and segmented apertures." Space Telescopes and Instrumentation 2018:
+    	Optical, Infrared, and Millimeter Wave. Vol. 10698. International Society for Optics and Photonics, 2018.
 
-	if not with_segment_gaps:
-		segment_gap = 0
+    Parameters
+    ----------
+    normalized : boolean
+    	If this is True, the outer diameter will be scaled to 1. Otherwise, the
+    	diameter of the pupil will be 15.0 meters.
+    with_spiders : boolean
+    	Include the secondary mirror support structure in the aperture.
+    with_segment_gaps : boolean
+    	Include the gaps between individual segments in the aperture.
+    segment_transmissions : scalar or array_like
+    	The transmission for each of the segments. If this is a scalar, this transmission will
+    	be used for all segments.
+    return_segments : boolean
+    	If this is True, also return a ModeBasis with all segments.
 
-	if normalized:
-		segment_circum_diameter /= pupil_diameter
-		segment_gap /= pupil_diameter
-		spider_width /= pupil_diameter
-		pupil_diameter = 1.0
+    Returns
+    -------
+    Field generator
+    	The LUVOIR A aperture.
+    ModeBasis
+    	The segment mode basis. Only returned when `return_segments` is True.
+    '''
+    pupil_diameter = 15.0  # m
+    segment_circum_diameter = 2 / np.sqrt(3) * pupil_diameter / 12
+    num_rings = 6
+    segment_gap = 0.001 * pupil_diameter
+    spider_width = 0.005 * pupil_diameter
+    spider_relative_offset = 0.9  # as estimated from the paper, not an actual value
 
-	segment_positions = make_hexagonal_grid(segment_circum_diameter / 2 * np.sqrt(3), num_rings)
-	segment_positions = segment_positions.subset(circular_aperture(pupil_diameter * 0.98))
-	segment_positions = segment_positions.subset(lambda grid: ~(circular_aperture(segment_circum_diameter)(grid) > 0))
+    if not with_segment_gaps:
+        segment_gap = 0
 
-	hexagon = hexagonal_aperture(segment_circum_diameter - segment_gap, np.pi / 2)
-	def segment(grid):
-		return hexagon(grid)
-	
-	if with_spiders:
-		spider1 = make_spider_infinite([0, 0], 90, spider_width)
+    if normalized:
+        segment_circum_diameter /= pupil_diameter
+        segment_gap /= pupil_diameter
+        spider_width /= pupil_diameter
+        pupil_diameter = 1.0
 
-		p1 = np.array([-segment_circum_diameter * 0.5 * spider_relative_offset, 0])
-		p2 = np.array([p1[0], -np.sqrt(3) * segment_circum_diameter + (segment_circum_diameter * 0.5 * (1 - spider_relative_offset)) * np.sqrt(3)])
-		spider2 = make_spider(p1, p2, spider_width)
+    segment_positions = make_hexagonal_grid(segment_circum_diameter / 2 * np.sqrt(3), num_rings)
+    segment_positions = segment_positions.subset(circular_aperture(pupil_diameter * 0.98))
+    segment_positions = segment_positions.subset(lambda grid: ~(circular_aperture(segment_circum_diameter)(grid) > 0))
 
-		p3 = p2 - np.array([pupil_diameter / 2, pupil_diameter * np.sqrt(3) / 2])
-		spider3 = make_spider(p2, p3, spider_width)
+    hexagon = hexagonal_aperture(segment_circum_diameter - segment_gap, np.pi / 2)
 
-		p4 = p1 * np.array([-1, 1])
-		p5 = p2 * np.array([-1, 1])
-		p6 = p3 * np.array([-1, 1])
+    def segment(grid):
+        return hexagon(grid)
 
-		spider4 = make_spider(p4, p5, spider_width)
-		spider5 = make_spider(p5, p6, spider_width)
-	
-	segmented_aperture = make_segmented_aperture(segment, segment_positions, segment_transmissions)
+    segmented_aperture = make_segmented_aperture(segment, segment_positions, segment_transmissions, return_segments)
 
-	def func(grid):
-		res = segmented_aperture(grid)
-		
-		if with_spiders:
-			res *= spider1(grid) * spider2(grid) * spider3(grid) * spider4(grid) * spider5(grid)
+    if return_segments:
+        segmented_aperture, segments = segmented_aperture
 
-		return Field(res, grid)
+    if with_spiders:
+        spider1 = make_spider_infinite([0, 0], 90, spider_width)
 
-	if return_segment_positions:
-			return func, segment_positions
+        p1 = np.array([-segment_circum_diameter * 0.5 * spider_relative_offset, 0])
+        p2 = np.array([p1[0], -np.sqrt(3) * segment_circum_diameter + (
+                segment_circum_diameter * 0.5 * (1 - spider_relative_offset)) * np.sqrt(3)])
+        spider2 = make_spider(p1, p2, spider_width)
 
-	return func
+        p3 = p2 - np.array([pupil_diameter / 2, pupil_diameter * np.sqrt(3) / 2])
+        spider3 = make_spider(p2, p3, spider_width)
+
+        p4 = p1 * np.array([-1, 1])
+        p5 = p2 * np.array([-1, 1])
+        p6 = p3 * np.array([-1, 1])
+
+        spider4 = make_spider(p4, p5, spider_width)
+        spider5 = make_spider(p5, p6, spider_width)
+
+    if return_segments:
+        for i, s in enumerate(segments):
+            s = lambda grid: s(grid) * spider1(grid) * spider2(grid) * spider3(grid) * spider4(grid) * spider5(grid)
+
+    def aperture(grid):
+        res = segmented_aperture(grid)
+
+        if with_spiders:
+            res *= spider1(grid) * spider2(grid) * spider3(grid) * spider4(grid) * spider5(grid)
+
+        return Field(res, grid)
+
+    if return_segments:
+        return aperture, segments
+    else:
+        return aperture
 
 def make_hicat_aperture(normalized=False, with_spiders=True, with_segment_gaps=True, segment_transmissions=1, return_segments=False):
 	'''Make the HiCAT pupil mask.
@@ -169,15 +178,15 @@ def make_hicat_aperture(normalized=False, with_spiders=True, with_segment_gaps=T
 	segment_transmissions : scalar or array_like
 		The transmission for each of the segments. If this is a scalar, this transmission will
 		be used for all segments.
-	return_segment_positions : boolean
-		If this is True, the centers of each of the segments will get returned as well.
+	return_segments : boolean
+		If this is True, also return a ModeBasis with all segments.
 	
 	Returns
 	-------
 	Field generator
 		The HiCAT aperture.
-	CartesianGrid
-		The segment positions. Only returned when `return_segment_positions` is True.
+	ModeBasis
+		The segment mode basis. Only returned when `return_segments` is True.
 	'''
 	pupil_diameter = 0.019725 # m
 	segment_circum_diameter = 2 / np.sqrt(3) * pupil_diameter / 7
@@ -225,7 +234,7 @@ def make_hicat_aperture(normalized=False, with_spiders=True, with_segment_gaps=T
 		return Field(res, grid)
 	
 	if return_segments:
-			return aperture, segments
+		return aperture, segments
 	else:
 		return aperture
 


### PR DESCRIPTION
PR #15 introduced the return of a segment ModeBasis to the `make_hicat_aperture()` that I also added to the `make_luvoir_a_aperture()` function here, plus some updates to respective docstrings.

This is in pretty high conflict with PR #20 and will have to be merged very carefully, attention @ehpor. I realized to late that the giant red and green block because of tab vs. 4spaces indentation will not make this any easier, although I am not sure how to deal with that except for retyping the sections. Can definitely change that if someone has advice.

Tested with:
```py
import hcipy
import matplotlib.pyplot as plt

pupil_grid = hcipy.make_pupil_grid(dims=500, diameter=15.)

aper, segments = hcipy.make_luvoir_a_aperture(normalized=False, with_spiders=False, return_segments=True)
aper = hcipy.evaluate_supersampled(aper, pupil_grid, 1)
segments = hcipy.evaluate_supersampled(segments, pupil_grid, 1)

plt.figure(figsize=(10, 10))
hcipy.imshow_field(aper)
plt.show()
```