### PR TITLE
Improve performance of MatrixFourierTransform

### DIFF
--- a/hcipy/config/config.py
+++ b/hcipy/config/config.py
@@ -41,8 +41,6 @@ class _ConfigurationItem(object):
 	def update(self, b):
 		for key in b.keys():
 			if key in self:
-				a = self[key]
-
 				if isinstance(b[key], dict) and isinstance(self._val[key], dict):
 					self[key].update(b[key])
 				else:

--- a/hcipy/config/config.py
+++ b/hcipy/config/config.py
@@ -1,12 +1,63 @@
 import os
 import yaml
+import pkg_resources
+
+class _ConfigurationItem(object):
+	def __init__(self, val):
+		self._val = val
+
+	def __getitem__(self, key):
+		val = self._val[key]
+
+		if isinstance(val, dict):
+			return _ConfigurationItem(val)
+		else:
+			return val
+
+	def __setitem__(self, key, value):
+		self._val[key] = value
+
+	def __contains__(self, key):
+		return key in self._val
+
+	def __getattr__(self, name):
+		if name == '_val':
+			return getattr(self, name)
+		else:
+			return self.__getitem__(name)
+
+	def __setattr__(self, name, value):
+		if name == '_val':
+			super().__setattr__(name, value)
+		else:
+			self.__setitem__(name, value)
+
+	def __str__(self):
+		return str(self._val)
+
+	def clear(self):
+		self._val.clear()
+
+	def update(self, b):
+		for key in b.keys():
+			if key in self:
+				a = self[key]
+
+				if isinstance(b[key], dict) and isinstance(self._val[key], dict):
+					self[key].update(b[key])
+				else:
+					self[key] = b[key]
+			else:
+				self[key] = b[key]
 
 class Configuration(object):
 	'''A configuration object that describes the current configuration status of the package.
 	'''
 	def __init__(self):
-		if not hasattr(Configuration, '_config'):
+		if Configuration._config is None:
 			self.reset()
+
+	_config = None
 
 	def __getitem__(self, key):
 		'''Get the value for the key.
@@ -30,53 +81,46 @@ class Configuration(object):
 		'''
 		Configuration._config[key] = value
 
-	def get_config_path(self):
-		'''Get the current path of the configuration file.
+	__getattr__ = __getitem__
+	__setattr__ = __setitem__
 
-		If no configuration file is present, a new one will be made,
-		and its path will be returned.
-
-		Returns
-		-------
-		string
-			The configuration directory.
-		'''
-		paths = ['./']
-		if 'XDG_CONFIG_HOME' in os.environ:
-			for p in os.environ['XDG_CONFIG_HOME'].split(os.pathsep):
-				paths.append(p + '/hcipy/')
-		if 'XDG_CONFIG_DIRS' in os.environ:
-			for p in os.environ['XDG_CONFIG_DIRS'].split(os.pathsep):
-				paths.append(p + '/hcipy/')
-		paths.append(os.path.expanduser('~/.config/hcipy/'))
-		paths.append(os.path.expanduser('~/.hcipy/'))
-		paths = [p + 'hcipy_config.yaml' for p in paths]
-
-		for path in paths:
-			if os.path.exists(path):
-				return path
-
-		# No configuration file is available, make a new one.
-		path = paths[-1]
-		directory = os.path.dirname(path)
-		if not os.path.exists(directory):
-			os.makedirs(directory)
-
-		f = open(path, 'w')
-		f.write(default_configuration)
-		f.close()
-
-		return path
+	def __str__(self):
+		return str(Configuration._config)
 
 	def reset(self):
-		'''Read the configuration file from the configuration directory.
+		'''Reset the configuration to the default configuration.
+
+		This default configuration consists of the default parameters in `hcipy/data/default_config.yaml`, which
+		can be overridden by a configuration file in `~/.hcipy/hcipy_config.yaml`. This can in turn be overridden
+		by a configuration file named `hcipy_config.yaml` located in the current working directory.
 		'''
-		with open(self.get_config_path()) as f:
-			Configuration._config = yaml.safe_load(f.read())
+		Configuration._config = _ConfigurationItem({})
 
-		if Configuration._config is None:
-			Configuration._config = {}
+		default_config = pkg_resources.resource_stream('hcipy', 'data/default_config.yaml')
+		user_config = os.path.expanduser('~/.hcipy/hcipy_config.yaml')
+		current_working_directory = './hcipy_config.yaml'
 
-default_configuration = '''# This is the configuration file for the high-contrast imaging for Python (HCIPy) library.
+		paths = [default_config, user_config, current_working_directory]
 
-'''
+		for path in paths:
+			try:
+				contents = path.read()
+			except AttributeError:
+				try:
+					with open(path) as f:
+						contents = f.read()
+				except IOError:
+					continue
+
+			new_config = yaml.safe_load(contents)
+			self.update(new_config)
+
+	def update(self, b):
+		'''Update the configuration with the configuration `b`, as a dictionary.
+
+		Parameters
+		---
+		b : dict
+			A dictionary containing the values to update in the configuration.
+		'''
+		Configuration._config.update(b)

--- a/hcipy/coronagraphy/vortex.py
+++ b/hcipy/coronagraphy/vortex.py
@@ -109,7 +109,7 @@ class VortexCoronagraph(OpticalElement):
 
 		for i, (mask, prop) in enumerate(zip(self.focal_masks, self.props)):
 			if i == 0:
-				lyot = Wavefront(prop.forward(wavefront.electric_field))
+				lyot = Wavefront(prop.forward(wavefront.electric_field), input_stokes_vector=wavefront.input_stokes_vector)
 			else:
 				focal = prop(wavefront)
 				focal.electric_field *= mask
@@ -147,7 +147,7 @@ class VortexCoronagraph(OpticalElement):
 
 		for i, (mask, prop) in enumerate(zip(self.focal_masks, self.props)):
 			if i == 0:
-				pup = Wavefront(prop.backward(wavefront.electric_field))
+				pup = Wavefront(prop.backward(wavefront.electric_field), input_stokes_vector=wavefront.input_stokes_vector)
 			else:
 				focal = prop(wavefront)
 				focal.electric_field *= mask.conj()

--- a/hcipy/coronagraphy/vortex.py
+++ b/hcipy/coronagraphy/vortex.py
@@ -30,13 +30,15 @@ class VortexCoronagraph(OpticalElement):
 		q for a high-accuracy vortex coronagraph depends on the charge of the vortex. For charge 2,
 		this can be as low as 32, but for charge 8 you need ~1024. Lower values give higher performance
 		as a smaller number of levels is needed, but increases the sampling errors near the singularity.
+		Charges not divisible by four require a much lower q. The default (q=1024) is conservative in
+		most cases.
 	scaling_factor : scalar
 		The fractional increase in spatial frequency sampling per level. Larger scaling factors
 		require a smaller number of levels, but each level requires a slower Fourier transform.
 		Factors of 2 or 4 usually perform the best.
 	window_size : integer
 		The size of the next level in the number of pixels on the current layer. Lowering this
-		increases performance in exchange for accuracy.
+		increases performance in exchange for accuracy. Values smaller than 4-8 are not recommended.
 	'''
 	def __init__(self, input_grid, charge, lyot_stop=None, q=1024, scaling_factor=4, window_size=32):
 		self.input_grid = input_grid
@@ -183,13 +185,15 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 		q for a high-accuracy vortex coronagraph depends on the charge of the vortex. For charge 2,
 		this can be as low as 32, but for charge 8 you need ~1024. Lower values give higher performance
 		as a smaller number of levels is needed, but increases the sampling errors near the singularity.
+		Charges not divisible by four require a much lower q. The default (q=1024) is conservative in
+		most cases.
 	scaling_factor : scalar
 		The fractional increase in spatial frequency sampling per level. Larger scaling factors
 		require a smaller number of levels, but each level requires a slower Fourier transform.
 		Factors of 2 or 4 usually perform the best.
 	window_size : integer
 		The size of the next level in the number of pixels on the current layer. Lowering this
-		increases performance in exchange for accuracy.
+		increases performance in exchange for accuracy. Values smaller than 4-8 are not recommended.
 	'''
 	def __init__(self, charge, lyot_stop=None, phase_retardation=np.pi, q=1024, scaling_factor=4, window_size=32):
 		self.charge = charge

--- a/hcipy/coronagraphy/vortex.py
+++ b/hcipy/coronagraphy/vortex.py
@@ -1,10 +1,11 @@
 import numpy as np
+from scipy.signal import windows
 
-from ..optics import OpticalElement, LinearRetarder, JonesMatrixOpticalElement, AgnosticOpticalElement, make_agnostic_forward, make_agnostic_backward
+from ..optics import OpticalElement, LinearRetarder, Apodizer, AgnosticOpticalElement, make_agnostic_forward, make_agnostic_backward, Wavefront
 from ..propagation import FraunhoferPropagator
-from ..field import make_focal_grid, Field
+from ..field import make_focal_grid, Field, field_dot
 from ..aperture import circular_aperture
-from ..fourier import FastFourierTransform, MatrixFourierTransform
+from ..fourier import FastFourierTransform, MatrixFourierTransform, FourierFilter
 
 class VortexCoronagraph(OpticalElement):
 	'''An optical vortex coronagraph.
@@ -20,33 +21,59 @@ class VortexCoronagraph(OpticalElement):
 		The grid on which the incoming wavefront is defined.
 	charge : integer
 		The charge of the vortex.
-	levels : integer
-		The number of levels in the multi-scale sampling.
+	lyot_stop : Field or OpticalElement
+		The Lyot stop for the coronagraph. If it's a Field, it is converted to an
+		OpticalElement for convenience. If this is None (default), then no Lyot stop is used.
+	q : scalar
+		The minimum number of pixels per lambda/D. The number of levels in the multi-scale
+		Fourier transforms will be chosen to reach at least this number of samples. The required
+		q for a high-accuracy vortex coronagraph depends on the charge of the vortex. For charge 2,
+		this can be as low as 32, but for charge 8 you need ~1024. Lower values give higher performance
+		as a smaller number of levels is needed, but increases the sampling errors near the singularity.
 	scaling_factor : scalar
-		The fractional increase in spatial frequency sampling per level.
+		The fractional increase in spatial frequency sampling per level. Larger scaling factors
+		require a smaller number of levels, but each level requires a slower Fourier transform.
+		Factors of 2 or 4 usually perform the best.
+	window_size : integer
+		The size of the next level in the number of pixels on the current layer. Lowering this
+		increases performance in exchange for accuracy.
 	'''
-	def __init__(self, input_grid, charge=2, levels=4, scaling_factor=4):
+	def __init__(self, input_grid, charge, lyot_stop=None, q=1024, scaling_factor=4, window_size=32):
 		self.input_grid = input_grid
-
-		q_outer = 2
-		num_airy_outer = input_grid.shape[0] / 2
 		pupil_diameter = input_grid.shape * input_grid.delta
+
+		if hasattr(lyot_stop, 'forward') or lyot_stop is None:
+			self.lyot_stop = lyot_stop
+		else:
+			self.lyot_stop = Apodizer(lyot_stop)
+
+		levels = int(np.ceil(np.log(q / 2) / np.log(scaling_factor))) + 1
+		qs = [2 * scaling_factor**i for i in range(levels)]
+		num_airys = [input_grid.shape / 2]
 
 		focal_grids = []
 		self.focal_masks = []
 		self.props = []
 
+		for i in range(1, levels):
+			num_airys.append(num_airys[i - 1] * window_size / (2 * qs[i - 1] * num_airys[i - 1]))
+
 		for i in range(levels):
-			q = q_outer * scaling_factor**i
-			if i == 0:
-				num_airy = num_airy_outer
-			else:
-				num_airy = 32.0 / (q_outer * scaling_factor**(i-1))
+			q = qs[i]
+			num_airy = num_airys[i]
 
 			focal_grid = make_focal_grid(q, num_airy, pupil_diameter=pupil_diameter, reference_wavelength=1, focal_length=1)
 			focal_mask = Field(np.exp(1j * charge * focal_grid.as_('polar').theta), focal_grid)
 
 			focal_mask *= 1 - circular_aperture(1e-9)(focal_grid)
+
+			if i != levels - 1:
+				wx = windows.tukey(window_size, 1, False)
+				wy = windows.tukey(window_size, 1, False)
+				w = np.outer(wy, wx)
+
+				w = np.pad(w, (focal_grid.shape - w.shape) // 2, 'constant').ravel()
+				focal_mask *= 1 - w
 
 			for j in range(i):
 				fft = FastFourierTransform(focal_grids[j])
@@ -54,7 +81,10 @@ class VortexCoronagraph(OpticalElement):
 
 				focal_mask -= mft.backward(fft.forward(self.focal_masks[j]))
 
-			prop = FraunhoferPropagator(input_grid, focal_grid)
+			if i == 0:
+				prop = FourierFilter(input_grid, focal_mask, q)
+			else:
+				prop = FraunhoferPropagator(input_grid, focal_grid)
 
 			focal_grids.append(focal_grid)
 			self.focal_masks.append(focal_mask)
@@ -78,14 +108,19 @@ class VortexCoronagraph(OpticalElement):
 		wavefront.wavelength = 1
 
 		for i, (mask, prop) in enumerate(zip(self.focal_masks, self.props)):
-			focal = prop(wavefront)
-			focal.electric_field *= mask
 			if i == 0:
-				lyot = prop.backward(focal)
+				lyot = Wavefront(prop.forward(wavefront.electric_field))
 			else:
+				focal = prop(wavefront)
+				focal.electric_field *= mask
 				lyot.electric_field += prop.backward(focal).electric_field
 
 		lyot.wavelength = wavelength
+		wavefront.wavelength = wavelength
+
+		if self.lyot_stop is not None:
+			lyot = self.lyot_stop.forward(lyot)
+
 		return lyot
 
 	def backward(self, wavefront):
@@ -104,18 +139,23 @@ class VortexCoronagraph(OpticalElement):
 		Wavefront
 			The pupil-plane wavefront.
 		'''
+		if self.lyot_stop is not None:
+			wavefront = self.lyot_stop.backward(wavefront)
+
 		wavelength = wavefront.wavelength
 		wavefront.wavelength = 1
 
 		for i, (mask, prop) in enumerate(zip(self.focal_masks, self.props)):
-			focal = prop(wavefront)
-			focal.electric_field *= mask.conj()
 			if i == 0:
-				pup = prop.backward(focal)
+				pup = Wavefront(prop.backward(wavefront.electric_field))
 			else:
+				focal = prop(wavefront)
+				focal.electric_field *= mask.conj()
 				pup.electric_field += prop.backward(focal).electric_field
 
 		pup.wavelength = wavelength
+		wavefront.wavelength = wavelength
+
 		return pup
 
 class VectorVortexCoronagraph(AgnosticOpticalElement):
@@ -130,40 +170,60 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 	----------
 	charge : integer
 		The charge of the vortex.
+	lyot_stop : Field or OpticalElement
+		The Lyot stop for the coronagraph. If it's a Field, it is converted to an
+		OpticalElement for convenience. If this is None (default), then no Lyot stop is used.
 	phase_retardation : scalar or function
 		The phase retardation of the vector vortex plate, potentially as a
 		function of wavelength. Changes of the phase retardation as a function
 		of spatial position is not yet supported.
-	levels : integer
-		The number of levels in the multi-scale sampling.
+	q : scalar
+		The minimum number of pixels per lambda/D. The number of levels in the multi-scale
+		Fourier transforms will be chosen to reach at least this number of samples. The required
+		q for a high-accuracy vortex coronagraph depends on the charge of the vortex. For charge 2,
+		this can be as low as 32, but for charge 8 you need ~1024. Lower values give higher performance
+		as a smaller number of levels is needed, but increases the sampling errors near the singularity.
 	scaling_factor : scalar
-		The fractional increase in spatial frequency sampling per level.
+		The fractional increase in spatial frequency sampling per level. Larger scaling factors
+		require a smaller number of levels, but each level requires a slower Fourier transform.
+		Factors of 2 or 4 usually perform the best.
+	window_size : integer
+		The size of the next level in the number of pixels on the current layer. Lowering this
+		increases performance in exchange for accuracy.
 	'''
-	def __init__(self, charge=2, phase_retardation=np.pi, levels=4, scaling_factor=4):
+	def __init__(self, charge, lyot_stop=None, phase_retardation=np.pi, q=1024, scaling_factor=4, window_size=32):
 		self.charge = charge
+
+		if hasattr(lyot_stop, 'forward') or lyot_stop is None:
+			self.lyot_stop = lyot_stop
+		else:
+			self.lyot_stop = Apodizer(lyot_stop)
+
 		self.phase_retardation = phase_retardation
-		self.levels = levels
+
+		self.q = q
 		self.scaling_factor = scaling_factor
+		self.window_size = window_size
 
 		AgnosticOpticalElement.__init__(self)
 
 	def make_instance(self, instance_data, input_grid, output_grid, wavelength):
-		q_outer = 2
-		num_airy_outer = input_grid.shape[0] / 2
 		pupil_diameter = input_grid.shape * input_grid.delta
 
+		levels = int(np.ceil(np.log(self.q / 2) / np.log(self.scaling_factor))) + 1
+		qs = [2 * self.scaling_factor**i for i in range(levels)]
+		num_airys = [input_grid.shape / 2]
+
 		focal_grids = []
-		jones_matrices = []
 		instance_data.props = []
-		instance_data.focal_masks = []
+		instance_data.jones_matrices = []
 
-		for i in range(self.levels):
-			q = q_outer * self.scaling_factor**i
+		for i in range(1, levels):
+			num_airys.append(num_airys[i - 1] * self.window_size / (2 * qs[i - 1] * num_airys[i - 1]))
 
-			if i == 0:
-				num_airy = num_airy_outer
-			else:
-				num_airy = 32.0 / (q_outer * self.scaling_factor**(i - 1))
+		for i in range(levels):
+			q = qs[i]
+			num_airy = num_airys[i]
 
 			focal_grid = make_focal_grid(q, num_airy, pupil_diameter=pupil_diameter, reference_wavelength=1, focal_length=1)
 
@@ -172,26 +232,30 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 
 			focal_mask_raw = LinearRetarder(retardance, fast_axis_orientation)
 			jones_matrix = focal_mask_raw.jones_matrix
+
 			jones_matrix *= 1 - circular_aperture(1e-9)(focal_grid)
 
-			def eval_jones(jones_matrix, jones_matrices, focal_grids):
-				mat = jones_matrix.copy()
+			if i != levels - 1:
+				wx = windows.tukey(self.window_size, 1, False)
+				wy = windows.tukey(self.window_size, 1, False)
+				w = np.outer(wy, wx)
 
-				for j in range(i):
-					fft = FastFourierTransform(focal_grids[j])
-					mft = MatrixFourierTransform(focal_grid, fft.output_grid)
+				w = np.pad(w, (focal_grid.shape - w.shape) // 2, 'constant').ravel()
+				jones_matrix *= 1 - w
 
-					mat -= mft.backward(fft.forward(jones_matrices[j]))
+			for j in range(i):
+				fft = FastFourierTransform(focal_grids[j])
+				mft = MatrixFourierTransform(focal_grid, fft.output_grid)
 
-				return mat
+				jones_matrix -= mft.backward(fft.forward(instance_data.jones_matrices[j]))
 
-			jones_matrices.append(focal_mask_raw.construct_function(eval_jones, jones_matrix, jones_matrices, focal_grids))
-			focal_mask = JonesMatrixOpticalElement(jones_matrices[-1])
-
-			prop = FraunhoferPropagator(input_grid, focal_grid)
+			if i == 0:
+				prop = FourierFilter(input_grid, jones_matrix, q)
+			else:
+				prop = FraunhoferPropagator(input_grid, focal_grid)
 
 			focal_grids.append(focal_grid)
-			instance_data.focal_masks.append(focal_mask)
+			instance_data.jones_matrices.append(jones_matrix)
 			instance_data.props.append(prop)
 
 	def get_input_grid(self, output_grid, wavelength):
@@ -252,19 +316,32 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 		wavelength = wavefront.wavelength
 		wavefront.wavelength = 1
 
-		for i, (mask, prop) in enumerate(zip(instance_data.focal_masks, instance_data.props)):
-			focal = prop(wavefront)
-
-			focal.wavelength = wavelength
-			focal = mask.forward(focal)
-			focal.wavelength = 1
-
+		for i, (jones_matrix, prop) in enumerate(zip(instance_data.jones_matrices, instance_data.props)):
 			if i == 0:
-				lyot = prop.backward(focal)
+				if not wavefront.is_polarized:
+					wf = Wavefront(wavefront.electric_field, input_stokes_vector=(1, 0, 0, 0))
+				else:
+					wf = wavefront
+
+				lyot = Wavefront(prop.forward(wf.electric_field), input_stokes_vector=wf.input_stokes_vector)
 			else:
-				lyot.electric_field += prop.backward(focal).electric_field
+				focal = prop(wavefront)
+
+				if not focal.is_polarized:
+					focal = Wavefront(focal.electric_field, input_stokes_vector=(1, 0, 0, 0))
+
+				focal.electric_field = field_dot(jones_matrix, focal.electric_field)
+				if i == 0:
+					lyot = prop.backward(focal)
+				else:
+					lyot.electric_field += prop.backward(focal).electric_field
 
 		lyot.wavelength = wavelength
+		wavefront.wavelength = wavelength
+
+		if self.lyot_stop is not None:
+			lyot = self.lyot_stop.forward(lyot)
+
 		return lyot
 
 	@make_agnostic_backward
@@ -284,23 +361,24 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 		Wavefront
 			The pupil-plane wavefront.
 		'''
+		if self.lyot_stop is not None:
+			wavefront = self.lyot_stop.backward(wavefront)
+
 		wavelength = wavefront.wavelength
 		wavefront.wavelength = 1
 
-		for i, (mask, prop) in enumerate(zip(instance_data.focal_masks, instance_data.props)):
-			focal = prop(wavefront)
-
-			focal.wavelength = wavelength
-			focal = mask.backward(focal)
-			focal.wavelength = 1
-
+		for i, (jones_matrix, prop) in enumerate(zip(instance_data.jones_matrices, instance_data.props)):
 			if i == 0:
-				pup = prop.backward(focal)
+				pup = Wavefront(prop.backward(wavefront.electric_field))
 			else:
+				focal = prop(wavefront)
+				focal.electric_field = field_dot(jones_matrix.conj(), focal.electric_field)
 				pup.electric_field += prop.backward(focal).electric_field
 
-			pup.wavelength = wavelength
-			return pup
+		pup.wavelength = wavelength
+		wavefront.wavelength = wavelength
+
+		return pup
 
 def make_ravc_masks(central_obscuration, charge=2, pupil_diameter=1, lyot_undersize=0):
 	'''Make field generators for the pupil and Lyot-stop masks for a

--- a/hcipy/data/default_config.yaml
+++ b/hcipy/data/default_config.yaml
@@ -10,7 +10,12 @@ fourier:
 
     # Whether to reserve memory for intermediate results.
     # This provides a 10% speedup, in exchange for higher memory usage.
-    allocate_intermediate_array: true
+    allocate_intermediate: true
+
+  nft:
+    # Whether to precompute the matrices used in the NFT.
+    # This provides a speedup, in exchange for higher memory usage.
+    precompute_matrices: false
 
 plotting:
   # The directory of the ffmpeg binary. If this is empty, ffmpeg has be available from PATH.

--- a/hcipy/data/default_config.yaml
+++ b/hcipy/data/default_config.yaml
@@ -1,0 +1,23 @@
+fourier:
+  fft:
+    # Whether to default to high-speed FFTs. This degrades accuracy of the resulting Fourier transform.
+    emulate_fftshifts: true
+
+  mft:
+    # Whether to precompute the matrices used in the MFT.
+    # This provides a 20-30% speedup, in exchange for higher memory usage.
+    precompute_matrices: true
+
+    # Whether to reserve memory for intermediate results.
+    # This provides a 10% speedup, in exchange for higher memory usage.
+    allocate_intermediate_array: true
+
+plotting:
+  # The directory of the ffmpeg binary. If this is empty, ffmpeg has be available from PATH.
+  ffmpeg_path:
+
+  # The default colormap for imshow_psf().
+  psf_colormap: 'inferno'
+
+  # The default colormap for imshow_pupil_phase().
+  pupil_phase_colormap: 'RdBu'

--- a/hcipy/data/default_config.yaml
+++ b/hcipy/data/default_config.yaml
@@ -1,6 +1,7 @@
 fourier:
   fft:
-    # Whether to default to high-speed FFTs. This degrades accuracy of the resulting Fourier transform.
+    # Whether to emulate FFTshifts in the FFT using field multiplications.
+    # This provides a 3x speedup, in exchange for a 10x reduction in accuracy.
     emulate_fftshifts: true
 
   mft:
@@ -9,12 +10,12 @@ fourier:
     precompute_matrices: true
 
     # Whether to reserve memory for intermediate results.
-    # This provides a 10% speedup, in exchange for higher memory usage.
+    # This provides a 5-10% speedup, in exchange for higher memory usage.
     allocate_intermediate: true
 
   nft:
     # Whether to precompute the matrices used in the NFT.
-    # This provides a speedup, in exchange for higher memory usage.
+    # Enabling this is not recommended, as it requires vast amounts of memory.
     precompute_matrices: false
 
 plotting:

--- a/hcipy/field/grid.py
+++ b/hcipy/field/grid.py
@@ -101,8 +101,14 @@ class Grid(object):
 			indices = criterium(self) != 0
 		else:
 			indices = criterium
+
 		new_coords = [c[indices] for c in self.coords]
-		new_weights = self.weights[indices]
+
+		if np.isscalar(self.weights):
+			new_weights = self.weights
+		else:
+			new_weights = self.weights[indices]
+
 		return self.__class__(UnstructuredCoords(new_coords), new_weights)
 
 	@property
@@ -213,10 +219,7 @@ class Grid(object):
 				self._weights = 1
 				warnings.warn('No automatic weights could be calculated for this grid.', stacklevel=2)
 
-		if np.isscalar(self._weights):
-			return np.ones(self.size) * self._weights
-		else:
-			return self._weights
+		return self._weights
 
 	@weights.setter
 	def weights(self, weights):

--- a/hcipy/fourier/__init__.py
+++ b/hcipy/fourier/__init__.py
@@ -3,10 +3,7 @@ __all__ = [
     'FourierTransform',
     'make_fft_grid',
     'FastFourierTransform',
-    'ConvolveFFT',
-    'ShearFFT',
-    'RotateFFT',
-    'FilterFFT',
+    'FourierFilter',
     'MatrixFourierTransform',
     'NaiveFourierTransform'
 ]

--- a/hcipy/fourier/fast_fourier_transform.py
+++ b/hcipy/fourier/fast_fourier_transform.py
@@ -2,10 +2,9 @@ from __future__ import division
 
 import numpy as np
 from .fourier_transform import FourierTransform, multiplex_for_tensor_fields
+from ..field import Field, CartesianGrid, RegularCoords
 
 def make_fft_grid(input_grid, q=1, fov=1):
-	from ..field import CartesianGrid, RegularCoords
-
 	q = np.ones(input_grid.ndim, dtype='float') * q
 	fov = np.ones(input_grid.ndim, dtype='float') * fov
 
@@ -32,7 +31,7 @@ class FastFourierTransform(FourierTransform):
 		self.input_grid = input_grid
 
 		self.shape_in = input_grid.shape
-		self.weights = input_grid.weights
+		self.weights = input_grid.weights[0]
 		self.size = input_grid.size
 		self.ndim = input_grid.ndim
 
@@ -40,46 +39,70 @@ class FastFourierTransform(FourierTransform):
 
 		self.shape_out = self.output_grid.shape
 		self.internal_shape = (self.shape_in * q).astype('int')
+		self.internal_array = np.zeros(self.internal_shape, 'complex')
 
-		cutout_start = (self.internal_shape / 2.).astype('int') - (self.shape_in / 2.).astype('int')
-		cutout_end = cutout_start + self.shape_in
-		self.cutout_input = [slice(start, end) for start, end in zip(cutout_start, cutout_end)]
-
-		cutout_start = (self.internal_shape / 2.).astype('int') - (self.shape_out / 2.).astype('int')
-		cutout_end = cutout_start + self.shape_out
-		self.cutout_output = [slice(start, end) for start, end in zip(cutout_start, cutout_end)]
-
-		center = input_grid.zero + input_grid.delta * (np.array(input_grid.dims) // 2)
-		if np.allclose(center, 0):
-			self.shift_input = 1
+		if np.allclose(self.internal_shape, self.shape_in):
+			self.cutout_input = None
 		else:
-			self.shift_input = np.exp(-1j * np.dot(center, self.output_grid.coords))
-			self.shift_input /= np.fft.ifftshift(self.shift_input.reshape(self.shape_out)).ravel()[0] # No piston shift (remove central shift phase)
+			cutout_start = (self.internal_shape / 2.).astype('int') - (self.shape_in / 2.).astype('int')
+			cutout_end = cutout_start + self.shape_in
+			self.cutout_input = tuple([slice(start, end) for start, end in zip(cutout_start, cutout_end)])
 
-		shift = np.ones(self.input_grid.ndim) * shift
-		if np.allclose(shift, 0):
-			self.shift_output = 1
+		if np.allclose(self.internal_shape, self.shape_out):
+			self.cutout_output = None
 		else:
-			self.shift_output = np.exp(-1j * np.dot(shift, self.input_grid.coords))
+			cutout_start = (self.internal_shape / 2.).astype('int') - (self.shape_out / 2.).astype('int')
+			cutout_end = cutout_start + self.shape_out
+			self.cutout_output = tuple([slice(start, end) for start, end in zip(cutout_start, cutout_end)])
+
+		center = input_grid.zero + input_grid.delta * (np.array(input_grid.dims) // 2) - input_grid.delta * (self.internal_shape // 2)
+
+		self.shift_input = np.exp(-1j * np.dot(center, self.output_grid.coords))
+		self.shift_input /= np.fft.ifftshift(self.shift_input.reshape(self.shape_out)).ravel()[0] # No piston shift (remove central shift phase)
+		if np.allclose(self.shift_input, 1):
+			self.shift_input = None
+
+		shift = np.ones(self.input_grid.ndim) * (shift - self.output_grid.delta * (np.array(self.output_grid.dims) // 2))
+		self.shift_output = np.exp(-1j * np.dot(shift, self.input_grid.coords)).reshape(self.shape_in)
+		if np.allclose(self.shift_output, 1):
+			self.shift_output = None
 
 	@multiplex_for_tensor_fields
 	def forward(self, field):
-		from ..field import Field
+		if self.cutout_input is None:
+			if self.shift_output is None:
+				f = field.reshape(self.shape_in)
+			else:
+				self.internal_array[:] = field.reshape(self.shape_in)
+				self.internal_array *= self.shift_output
 
-		f = np.zeros(self.internal_shape, dtype='complex')
-		f[tuple(self.cutout_input)] = (field.ravel() * self.weights * self.shift_output).reshape(self.shape_in)
-		res = np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(f)))
-		res = res[tuple(self.cutout_output)].ravel() * self.shift_input
+				f = self.internal_array
+		else:
+			self.internal_array[self.cutout_input] = field.reshape(self.shape_in)
+			if self.shift_output is not None:
+				self.internal_array[self.cutout_input] *= self.shift_output.reshape(self.shape_in)
 
-		return Field(res, self.output_grid).astype(field.dtype)
+			f = self.internal_array
+
+		fft_array = np.fft.fftn(f)
+
+		if self.cutout_output is None:
+			res = fft_array.ravel()
+		else:
+			res = fft_array[self.cutout_output].ravel()
+
+		if self.shift_input is not None:
+			res *= self.shift_input
+
+		res *= self.weights
+
+		return Field(res, self.output_grid).astype(field.dtype, copy=False)
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
-		from ..field import Field
-
 		f = np.zeros(self.internal_shape, dtype='complex')
-		f[tuple(self.cutout_output)] = (field.ravel() / self.shift_input).reshape(self.shape_out)
+		f[self.cutout_output] = (field.ravel() / self.shift_input).reshape(self.shape_out)
 		res = np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(f)))
-		res = res[tuple(self.cutout_input)].ravel() / self.weights / self.shift_output
+		res = res[self.cutout_input].ravel() / self.weights / self.shift_output
 
 		return Field(res, self.input_grid).astype(field.dtype)

--- a/hcipy/fourier/fast_fourier_transform.py
+++ b/hcipy/fourier/fast_fourier_transform.py
@@ -71,7 +71,7 @@ class FastFourierTransform(FourierTransform):
 		res = np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(f)))
 		res = res[tuple(self.cutout_output)].ravel() * self.shift_input
 
-		return Field(res, self.output_grid)
+		return Field(res, self.output_grid).astype(field.dtype)
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
@@ -82,4 +82,4 @@ class FastFourierTransform(FourierTransform):
 		res = np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(f)))
 		res = res[tuple(self.cutout_input)].ravel() / self.weights / self.shift_output
 
-		return Field(res, self.input_grid)
+		return Field(res, self.input_grid).astype(field.dtype)

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from .fast_fourier_transform import FastFourierTransform
-from .fourier_transform import multiplex_for_tensor_fields
 from ..field import Field, field_dot, field_conjugate_transpose
 
 class FourierFilter(object):
@@ -39,9 +38,9 @@ class FourierFilter(object):
 
 	def _compute_functions(self, field):
 		if self._transfer_function is None or self._transfer_function.dtype != field.dtype:
-			try:
+			if hasattr(self._transfer_function, '__call__'):
 				tf = self.transfer_function(self.internal_grid)
-			except:
+			else:
 				tf = self.transfer_function.copy()
 
 			tf = np.fft.ifftshift(tf.shaped, axes=tuple(range(-self.input_grid.ndim, 0)))

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -38,7 +38,7 @@ class FourierFilter(object):
 
 	def _compute_functions(self, field):
 		if self._transfer_function is None or self._transfer_function.dtype != field.dtype:
-			if hasattr(self._transfer_function, '__call__'):
+			if hasattr(self.transfer_function, '__call__'):
 				tf = self.transfer_function(self.internal_grid)
 			else:
 				tf = self.transfer_function.copy()

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -103,7 +103,7 @@ class FourierFilter(object):
 		self._compute_functions(field)
 
 		if self.cutout is None:
-			f = field.reshape(self.shape_in)
+			f = field.shaped
 		else:
 			f = self.internal_array
 			f[:] = 0

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -1,21 +1,27 @@
 import numpy as np
 
 from .fast_fourier_transform import FastFourierTransform
-from .matrix_fourier_transform import MatrixFourierTransform
 from .fourier_transform import multiplex_for_tensor_fields
 from ..field import Field
 
-class ConvolveFFT(object):
-	def __init__(self, input_grid, kernel):
-		pass
-
-class ShearFFT(object):
-	pass
-
-class RotateFFT(object):
-	pass
-
 class FourierFilter(object):
+	'''A filter in the Fourier domain.
+
+	The filtering is performed by Fast Fourier Transforms, but is quicker than
+	the equivalent multiplication in the Fourier domain using the FastFourierTransform
+	classes. It does this by avoiding redundant field multiplications that limit performance.
+
+	Parameters
+	----------
+	input_grid : Grid
+		The grid that is expected for the input field.
+	transfer_function : Field generator
+		The transfer function to use for the filter.
+	q : scalar
+		The amount of zeropadding to perform in the real domain. A value
+		of 1 denotes no zeropadding. Zeropadding increases the resolution in the
+		Fourier domain and therefore reduces aliasing/wrapping effects.
+	'''
 	def __init__(self, input_grid, transfer_function, q=1):
 		fft = FastFourierTransform(input_grid, q)
 
@@ -28,13 +34,51 @@ class FourierFilter(object):
 
 	@multiplex_for_tensor_fields
 	def forward(self, field):
+		'''Return the forward filtering of the input field.
+
+		Parmeters
+		---------
+		field : Field
+			The field to filter.
+
+		Returns
+		-------
+		Field
+			The filtered field.
+		'''
 		return self._operation(field, adjoint=False)
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
+		'''Return the backward (adjoint) filtering of the input field.
+
+		Parmeters
+		---------
+		field : Field
+			The field to filter.
+
+		Returns
+		-------
+		Field
+			The adjoint filtered field.
+		'''
 		return self._operation(field, adjoint=True)
 
 	def _operation(self, field, adjoint):
+		'''The internal filtering operation.
+
+		Parameters
+		----------
+		field : Field
+			The input field.
+		adjoint : boolean
+			Whether to perform a forward or adjoint filter.
+
+		Returns
+		-------
+		Field
+			The filtered field.
+		'''
 		if self.cutout is None:
 			f = field.reshape(self.shape_in)
 		else:

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from .fast_fourier_transform import FastFourierTransform
 from .matrix_fourier_transform import MatrixFourierTransform
+from .fourier_transform import multiplex_for_tensor_fields
+from ..field import Field
 
 class ConvolveFFT(object):
 	def __init__(self, input_grid, kernel):
@@ -13,5 +15,45 @@ class ShearFFT(object):
 class RotateFFT(object):
 	pass
 
-class FilterFFT(object):
-	pass
+class FourierFilter(object):
+	def __init__(self, input_grid, transfer_function, q=1):
+		fft = FastFourierTransform(input_grid, q)
+
+		self.input_grid = input_grid
+		self.cutout = fft.cutout_input
+		self.shape_in = input_grid.shape
+
+		self._transfer_function = np.fft.ifftshift(transfer_function(fft.output_grid).shaped)
+		self.internal_array = np.zeros_like(self._transfer_function)
+
+	@multiplex_for_tensor_fields
+	def forward(self, field):
+		return self._operation(field, adjoint=False)
+
+	@multiplex_for_tensor_fields
+	def backward(self, field):
+		return self._operation(field, adjoint=True)
+
+	def _operation(self, field, adjoint):
+		if self.cutout is None:
+			f = field.reshape(self.shape_in)
+		else:
+			f = self.internal_array
+			f[:] = 0
+			f[self.cutout] = field.reshape(self.shape_in)
+
+		f = np.fft.fftn(f)
+
+		if adjoint:
+			f *= self._transfer_function.conj()
+		else:
+			f *= self._transfer_function
+
+		f = np.fft.ifftn(f)
+
+		if self.cutout is None:
+			res = f.ravel()
+		else:
+			res = f[self.cutout].ravel()
+
+		return Field(res, self.input_grid)

--- a/hcipy/fourier/matrix_fourier_transform.py
+++ b/hcipy/fourier/matrix_fourier_transform.py
@@ -65,7 +65,7 @@ class MatrixFourierTransform(FourierTransform):
 				f = (field * self.weights_input).reshape(self.shape_input)
 				res = np.dot(np.dot(self.M1, f), self.M2).reshape(-1)
 
-		return Field(res, self.output_grid)
+		return Field(res, self.output_grid).astype(field.dtype)
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
@@ -97,4 +97,4 @@ class MatrixFourierTransform(FourierTransform):
 					f = (field * self.weights_output).reshape(self.shape_output)
 					res = np.dot(np.dot(self.M1.conj().T, f), self.M2.conj().T).reshape(-1)
 
-		return Field(res, self.input_grid)
+		return Field(res, self.input_grid).astype(field.dtype)

--- a/hcipy/fourier/matrix_fourier_transform.py
+++ b/hcipy/fourier/matrix_fourier_transform.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.linalg import blas
 from .fourier_transform import FourierTransform, multiplex_for_tensor_fields
 from ..field import Field
 
@@ -17,11 +18,13 @@ class MatrixFourierTransform(FourierTransform):
 		self.input_grid = input_grid
 		self.output_grid = output_grid
 
-		self.shape = input_grid.shape
+		self.shape_input = input_grid.shape
+		self.shape_output = output_grid.shape
+
 		self.ndim = input_grid.ndim
 
 		self.weights_input = input_grid.weights.ravel()
-		if np.allclose(self.weights_input, self.weights_input[0]):
+		if np.all(self.weights_input == self.weights_input[0]):
 			self.weights_input = self.weights_input[0]
 
 		self.weights_output = output_grid.weights.ravel()
@@ -29,10 +32,10 @@ class MatrixFourierTransform(FourierTransform):
 			self.weights_output = self.weights_output[0]
 
 		if self.ndim == 1:
-			self.M = np.exp(-1j * np.dot(output_grid.x[:,np.newaxis], input_grid.x[np.newaxis,:]))
+			self.M = np.exp(-1j * np.outer(output_grid.x, input_grid.x))
 		elif self.ndim == 2:
-			self.M1 = np.exp(-1j * np.dot(output_grid.coords.separated_coords[1][:,np.newaxis], input_grid.coords.separated_coords[1][np.newaxis,:]))
-			self.M2 = np.exp(-1j * np.dot(output_grid.coords.separated_coords[0][:,np.newaxis], input_grid.coords.separated_coords[0][np.newaxis,:])).T
+			self.M1 = np.exp(-1j * np.outer(output_grid.coords.separated_coords[1], input_grid.separated_coords[1]))
+			self.M2 = np.exp(-1j * np.outer(input_grid.coords.separated_coords[0], output_grid.separated_coords[0]))
 
 	@multiplex_for_tensor_fields
 	def forward(self, field):
@@ -40,8 +43,17 @@ class MatrixFourierTransform(FourierTransform):
 			f = field * self.weights_input
 			res = np.dot(self.M, f)
 		elif self.ndim == 2:
-			f = (field * self.weights_input).reshape(self.shape)
-			res = np.dot(np.dot(self.M1, f), self.M2).reshape(-1)
+			if np.isscalar(self.weights_input):
+				f = field.reshape(self.shape_input)
+				if np.dtype('complex128') == field.dtype:
+					res = blas.zgemm(self.weights_input, blas.zgemm(1, self.M2.T, f.T), self.M1.T)
+				elif self.input_grid.size > self.output_grid.size:
+					res = np.dot(np.dot(self.M1, f), self.M2).reshape(-1) * self.weights_input
+				else:
+					res = np.dot(np.dot(self.M1, f * self.weights_input), self.M2).reshape(-1)
+			else:
+				f = (field * self.weights_input).reshape(self.shape_input)
+				res = np.dot(np.dot(self.M1, f), self.M2).reshape(-1)
 
 		return Field(res, self.output_grid)
 
@@ -49,10 +61,23 @@ class MatrixFourierTransform(FourierTransform):
 	def backward(self, field):
 		if self.ndim == 1:
 			f = field * self.weights_output
-			res = np.dot(self.M.conj().T, f)
+			res = np.dot(self.M.conj().T, f) / (2 * np.pi)
 		elif self.ndim == 2:
-			f = (field * self.weights_output).reshape(self.output_grid.shape)
-			res = np.dot(np.dot(self.M1.conj().T, f), self.M2.conj().T).reshape(-1)
+			if np.dtype('complex128') == field.dtype:
+				if np.isscalar(self.weights_output):
+					f = field.reshape(self.shape_output)
+					w = self.weights_output / (2 * np.pi)**2
+					res = blas.zgemm(1, blas.zgemm(w, self.M2.T, f.T, trans_a=2), self.M1.T, trans_b=2).T.reshape(-1)
+				else:
+					f = (field * self.weights_output).reshape(self.shape_output)
+					w = 1 / (2 * np.pi)**2
+					res = blas.zgemm(1, blas.zgemm(w, self.M2.T, f.T, trans_a=2), self.M1.T, trans_b=2).T.reshape(-1)
+			else:
+				if np.isscalar(self.weights_output) and self.input_grid.size < self.output_grid.size:
+					f = field.reshape(self.shape_output)
+					res = np.dot(np.dot(self.M1.conj().T, f), self.M2.conj().T).reshape(-1) * self.weights_output
+				else:
+					f = (field * self.weights_output).reshape(self.shape_output)
+					res = np.dot(np.dot(self.M1.conj().T, f), self.M2.conj().T).reshape(-1)
 
-		res /= (2 * np.pi)**self.ndim
 		return Field(res, self.input_grid)

--- a/hcipy/fourier/matrix_fourier_transform.py
+++ b/hcipy/fourier/matrix_fourier_transform.py
@@ -6,6 +6,39 @@ from ..config import Configuration
 import numexpr as ne
 
 class MatrixFourierTransform(FourierTransform):
+	'''A Matrix Fourier Transform (MFT) object.
+
+	This Fourier transform is based on the MFT described in [Soummer2007]_. It requires both
+	the input and output grid to be separated in Cartesian coordinates. Additionally, due to
+	current implementation limitations, this Fourier transform only supports one- and two-dimensional
+	grids.
+
+	.. [Soummer2007] Soummer et al. 2007, "Fast computation of Lyot-style
+		coronagraph propagation".
+
+	Parameters
+	---
+	input_grid : Grid
+		The grid that is expected for the input field.
+	output_grid : Grid
+		The grid that is produced by the Fourier transform.
+	precompute_matrices : boolean or None
+		Whether to precompute the matrices used in the MFT. Turning this on will provide a 20-30%
+		speedup, in exchange for higher memory usage.If this is False, the matrices will be
+		calculated each time a Fourier transform is performed. If this is True, the matrices will be
+		calculated once, and reused for future evaluations. If this is None, the choice will be
+		determined by the configuration file.
+	allocate_intermediate : boolean or None
+		Whether to reserve memory for the intermediate result for the MFT. This provides a 5-10%
+		speedup in exchange for higher memory usage. If this is None, the choice will be determined
+		by the configuration file.
+
+	Raises
+	------
+	ValueError
+		If the input grid is not separated in Cartesian coordinates, if it's not one- or two-
+		dimensional, or if the output grid has a different dimension than the input grid.
+	'''
 	def __init__(self, input_grid, output_grid, precompute_matrices=None, allocate_intermediate=None):
 		# Check input grid assumptions
 		if not input_grid.is_separated or not input_grid.is_('cartesian'):
@@ -25,10 +58,12 @@ class MatrixFourierTransform(FourierTransform):
 
 		self.ndim = input_grid.ndim
 
+		# Get the value from the configuration file if left at default.
 		if precompute_matrices is None:
 			precompute_matrices = Configuration().fourier.mft.precompute_matrices
 		self.precompute_matrices = precompute_matrices
 
+		# Get the value from the configuration file if left at default.
 		if allocate_intermediate is None:
 			allocate_intermediate = Configuration().fourier.mft.allocate_intermediate
 		self.allocate_intermediate = allocate_intermediate
@@ -38,6 +73,14 @@ class MatrixFourierTransform(FourierTransform):
 		self._remove_matrices()
 
 	def _compute_matrices(self, dtype):
+		'''Compute the matrices for the MFT using the specified data type.
+
+		Parameters
+		---
+		dtype : numpy data type
+			The data type for which to calculate the matrices.
+		'''
+		# Set the correct complex and real data type, based on the input data type.
 		if dtype == np.dtype('float32') or dtype == np.dtype('complex64'):
 			complex_dtype = 'complex64'
 			float_dtype = 'float32'
@@ -45,6 +88,7 @@ class MatrixFourierTransform(FourierTransform):
 			complex_dtype = 'complex128'
 			float_dtype = 'float64'
 
+		# Check if the matrices need to be (re)calculated.
 		if self.matrices_dtype != complex_dtype:
 			self.weights_input = (self.input_grid.weights).astype(float_dtype, copy=False)
 			self.weights_output = (self.output_grid.weights / (2 * np.pi)**self.ndim).astype(float_dtype, copy=False)
@@ -72,6 +116,7 @@ class MatrixFourierTransform(FourierTransform):
 
 			self.matrices_dtype = complex_dtype
 
+		# Checki if the intermediate array needs to be (re)allocated.
 		if self.intermediate_dtype != complex_dtype:
 			if self.ndim == 2:
 				self.intermediate_array = np.empty((self.input_grid.shape[0], self.M2.shape[1]), dtype=complex_dtype)
@@ -79,6 +124,10 @@ class MatrixFourierTransform(FourierTransform):
 				self.intermediate_dtype = complex_dtype
 
 	def _remove_matrices(self):
+		'''Remove the matrices after a Fourier transform.
+
+		This is is used to clean up the used matrices after a Fourier transform operation.
+		'''
 		if not self.precompute_matrices:
 			if self.ndim == 1:
 				self.M = None
@@ -91,11 +140,22 @@ class MatrixFourierTransform(FourierTransform):
 		if not self.allocate_intermediate:
 			if self.ndim == 2:
 				self.intermediate_array = None
-
 				self.intermediate_dtype = None
 
 	@multiplex_for_tensor_fields
 	def forward(self, field):
+		'''Returns the forward Fourier transform of the :class:`Field` field.
+
+		Parameters
+		----------
+		field : Field
+			The field to Fourier transform.
+
+		Returns
+		--------
+		Field
+			The Fourier transform of the field.
+		'''
 		self._compute_matrices(field.dtype)
 		field = field.astype(self.matrices_dtype, copy=False)
 
@@ -130,6 +190,18 @@ class MatrixFourierTransform(FourierTransform):
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
+		'''Returns the inverse Fourier transform of the :class:`Field` field.
+
+		Parameters
+		----------
+		field : Field
+			The field to inverse Fourier transform.
+
+		Returns
+		--------
+		Field
+			The inverse Fourier transform of the field.
+		'''
 		self._compute_matrices(field.dtype)
 		field = field.astype(self.matrices_dtype, copy=False)
 
@@ -156,6 +228,7 @@ class MatrixFourierTransform(FourierTransform):
 				f = (field * self.weights_output).reshape(self.shape_output)
 				alpha = 1
 
+			# Use trans_a=2 and trans_b=2 to apply the conjugte transpose on the a and b arrays.
 			gemm(1, f.T, self.M1.T, trans_b=2, c=self.intermediate_array.T, overwrite_c=True)
 			res = gemm(alpha, self.M2.T, self.intermediate_array.T, trans_a=2).T.reshape(-1)
 

--- a/hcipy/fourier/naive_fourier_transform.py
+++ b/hcipy/fourier/naive_fourier_transform.py
@@ -39,17 +39,17 @@ class NaiveFourierTransform(FourierTransform):
 	def forward(self, field):
 		if self.cache_matrices:
 			res = self.T_forward.dot(field.ravel())
-			return Field(res, self.output_grid)
+			return Field(res, self.output_grid).astype(field.dtype)
 		else:
 			res = np.array([(field * self.input_grid.weights).dot(np.exp(-1j * np.dot(p, self.coords_in))) for p in self.coords_out.T])
-			return Field(res, self.output_grid)
+			return Field(res, self.output_grid).astype(field.dtype)
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
 		if self.cache_matrices:
 			res = self.T_backward.dot(field.ravel())
-			return Field(res, self.input_grid)
+			return Field(res, self.input_grid).astype(field.dtype)
 		else:
 			res = np.array([(field * self.output_grid.weights).dot(np.exp(1j * np.dot(p, self.coords_out))) for p in self.coords_in.T])
 			res /= (2*np.pi)**self.input_grid.ndim
-			return Field(res, self.input_grid)
+			return Field(res, self.input_grid).astype(field.dtype)

--- a/hcipy/fourier/naive_fourier_transform.py
+++ b/hcipy/fourier/naive_fourier_transform.py
@@ -5,7 +5,43 @@ from ..field import Field
 from ..config import Configuration
 
 class NaiveFourierTransform(FourierTransform):
+	'''The naive Fourier transform (NFT).
+
+	This Fourier transform can operate on any types of coordinates, and calculates
+	the Fourier integral using brute force. This class is written as generally as
+	possible to act as a "ground truth" for the other Fourier transforms. As such,
+	it has terrible performance.
+
+	.. note::
+		In almost all cases, you should not use this class. The FastFourierTransform and
+		MatrixFourierTransform classes, if applicable, are multiple orders of magnitudes faster
+		and use multiple orders of magnitude less memory. This class should only be used in a last
+		resort and if you know what you are doing.
+
+	.. note::
+		The transformation matrices can be very large, quickly overwhelming any computer even
+		for relatively small input or output grids.
+
+	Parameters
+	----------
+	input_grid : Grid
+		The grid that is expected for the input field.
+	output_grid : Grid
+		The grid that is produced by the Fourier transform.
+	precompute_matrices : boolean or None
+		Whether to precompute the matrices used in the NFT. Turning this on will cache calculated matrices
+		for future evaluations of the Fourier transform. This will use a large amount of memory. If this is
+		None, the choice will be determined by the configuration file.
+
+	Raises
+	------
+	ValueError
+		If the output grid has a different dimension than the input grid.
+	'''
 	def __init__(self, input_grid, output_grid, precompute_matrices=None):
+		if input_grid.ndim != output_grid.ndim:
+			raise ValueError('The input_grid must have the same dimensions as the output_grid.')
+
 		self.input_grid = input_grid
 		self.output_grid = output_grid
 
@@ -21,6 +57,8 @@ class NaiveFourierTransform(FourierTransform):
 
 	@property
 	def T_forward(self):
+		'''The cached forward propagation matrix.
+		'''
 		if not self.precompute_matrices:
 			return self.get_transformation_matrix_forward()
 
@@ -31,8 +69,10 @@ class NaiveFourierTransform(FourierTransform):
 
 	@property
 	def T_backward(self):
+		'''The cached backward propagation matrix.
+		'''
 		if not self.precompute_matrices:
-			self.get_transformation_matrix_backward()
+			return self.get_transformation_matrix_backward()
 
 		if self._T_backward is None:
 			self._T_backward = self.get_transformation_matrix_backward()
@@ -41,19 +81,43 @@ class NaiveFourierTransform(FourierTransform):
 
 	@multiplex_for_tensor_fields
 	def forward(self, field):
+		'''Returns the forward Fourier transform of the :class:`Field` field.
+
+		Parameters
+		----------
+		field : Field
+			The field to Fourier transform.
+
+		Returns
+		--------
+		Field
+			The Fourier transform of the field.
+		'''
 		if self.precompute_matrices:
 			res = self.T_forward.dot(field.ravel())
-			return Field(res, self.output_grid).astype(field.dtype)
 		else:
 			res = np.array([(field * self.input_grid.weights).dot(np.exp(-1j * np.dot(p, self.coords_in))) for p in self.coords_out.T])
-			return Field(res, self.output_grid).astype(field.dtype)
+
+		return Field(res, self.output_grid).astype(field.dtype)
 
 	@multiplex_for_tensor_fields
 	def backward(self, field):
+		'''Returns the inverse Fourier transform of the :class:`Field` field.
+
+		Parameters
+		----------
+		field : Field
+			The field to inverse Fourier transform.
+
+		Returns
+		--------
+		Field
+			The inverse Fourier transform of the field.
+		'''
 		if self.precompute_matrices:
 			res = self.T_backward.dot(field.ravel())
-			return Field(res, self.input_grid).astype(field.dtype)
 		else:
 			res = np.array([(field * self.output_grid.weights).dot(np.exp(1j * np.dot(p, self.coords_out))) for p in self.coords_in.T])
-			res /= (2*np.pi)**self.input_grid.ndim
-			return Field(res, self.input_grid).astype(field.dtype)
+			res /= (2 * np.pi)**self.input_grid.ndim
+
+		return Field(res, self.input_grid).astype(field.dtype)

--- a/hcipy/plotting/util.py
+++ b/hcipy/plotting/util.py
@@ -1,5 +1,6 @@
 from .field import imshow_field
 from ..field import Field
+from ..config import Configuration
 
 import numpy as np
 
@@ -71,6 +72,9 @@ def imshow_psf(psf, grid=None, vmin=1e-8, vmax=1e-1, scale='log',
 		psf_norm = 1
 	else:
 		psf_norm = normalization
+
+	if cmap is None:
+		cmap = Configuration().plotting.psf_colormap
 
 	img = psf / psf_norm
 
@@ -192,7 +196,7 @@ def imshow_pupil_phase(pupil_phase, grid=None, phase_limits=None, vmin=None, vma
 		vmax = phase_limits
 
 	if cmap is None:
-		cmap = 'RdBu'
+		cmap = Configuration().plotting.pupil_phase_colormap
 
 	im = imshow_field(phase, ax=ax, cmap=cmap, mask=mask, vmin=vmin, vmax=vmax, **kwargs)
 

--- a/hcipy/propagation/fresnel.py
+++ b/hcipy/propagation/fresnel.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ..optics import Wavefront, AgnosticOpticalElement, make_agnostic_forward, make_agnostic_backward
 from ..field import Field
-from ..fourier import FastFourierTransform
+from ..fourier import FastFourierTransform, make_fft_grid, FourierFilter
 from ..field import evaluate_supersampled, make_pupil_grid
 
 class FresnelPropagator(AgnosticOpticalElement):
@@ -42,29 +42,32 @@ class FresnelPropagator(AgnosticOpticalElement):
 		if not input_grid.is_regular or not input_grid.is_('cartesian'):
 			raise ValueError('The input grid must be a regular, Cartesian grid.')
 
-		instance_data.fft = FastFourierTransform(input_grid, q=2)
-
 		k = 2 * np.pi / wavelength * self.evaluate_parameter(self.refractive_index, input_grid, output_grid, wavelength)
 		L_max = np.max(input_grid.dims * input_grid.delta)
 
 		if np.any(input_grid.delta < wavelength * self.distance / L_max):
-			enlarged_input_grid = make_pupil_grid(2 * input_grid.dims, 2 * input_grid.delta * (input_grid.dims - 1))
-			fft_up_scale = FastFourierTransform(enlarged_input_grid)
+			def transfer_function(fourier_grid):
+				enlarged_grid = make_fft_grid(fourier_grid)
+				fft_upscale = FastFourierTransform(enlarged_grid)
 
-			def impulse_response_generator(grid):
-				r_squared = grid.x**2 + grid.y**2
-				return Field(np.exp(1j * k * self.distance) / (1j * wavelength * self.distance) * np.exp(1j * k * r_squared / (2 * self.distance)), grid)
+				def impulse_response(grid):
+					r_squared = grid.x**2 + grid.y**2
+					return Field(np.exp(1j * k * self.distance) / (1j * wavelength * self.distance) * np.exp(1j * k * r_squared / (2 * self.distance)), grid)
 
-			impulse_response = evaluate_supersampled(impulse_response_generator, enlarged_input_grid, self.num_oversampling)
+				impulse_response = evaluate_supersampled(impulse_response, enlarged_grid, self.num_oversampling)
 
-			instance_data.transfer_function = fft_up_scale.forward(impulse_response)
+				return fft_upscale.forward(impulse_response)
 		else:
-			def transfer_function_generator(grid):
-				k_squared = grid.as_('polar').r**2
+			def transfer_function_native(fourier_grid):
+				k_squared = fourier_grid.as_('polar').r**2
 				phase_factor = np.exp(1j * k * self.distance)
-				return Field(np.exp(-0.5j * self.distance * k_squared / k) * phase_factor, grid)
 
-			instance_data.transfer_function = evaluate_supersampled(transfer_function_generator, instance_data.fft.output_grid, self.num_oversampling)
+				return Field(np.exp(-0.5j * self.distance * k_squared / k) * phase_factor, fourier_grid)
+
+			def transfer_function(fourier_grid):
+				return evaluate_supersampled(transfer_function_native, fourier_grid, self.num_oversampling)
+
+		instance_data.fourier_filter = FourierFilter(input_grid, transfer_function, q=2)
 
 	@property
 	def distance(self):
@@ -116,10 +119,13 @@ class FresnelPropagator(AgnosticOpticalElement):
 		Wavefront
 			The wavefront after the propagation.
 		'''
-		ft = instance_data.fft.forward(wavefront.electric_field)
-		ft *= instance_data.transfer_function
+		#ft = instance_data.fft.forward(wavefront.electric_field)
+		#ft *= instance_data.transfer_function
 
-		return Wavefront(instance_data.fft.backward(ft), wavefront.wavelength, wavefront.input_stokes_vector)
+		#return Wavefront(instance_data.fft.backward(ft), wavefront.wavelength, wavefront.input_stokes_vector)
+
+		filtered = instance_data.fourier_filter.forward(wavefront.electric_field)
+		return Wavefront(filtered, wavefront.wavelength, wavefront.input_stokes_vector)
 
 	@make_agnostic_backward
 	def backward(self, instance_data, wavefront):
@@ -135,7 +141,10 @@ class FresnelPropagator(AgnosticOpticalElement):
 		Wavefront
 			The wavefront after the propagation.
 		'''
-		ft = instance_data.fft.forward(wavefront.electric_field)
-		ft *= np.conj(instance_data.transfer_function)
+		#ft = instance_data.fft.forward(wavefront.electric_field)
+		#ft *= np.conj(instance_data.transfer_function)
 
-		return Wavefront(instance_data.fft.backward(ft), wavefront.wavelength, wavefront.input_stokes_vector)
+		#return Wavefront(instance_data.fft.backward(ft), wavefront.wavelength, wavefront.input_stokes_vector)
+
+		filtered = instance_data.fourier_filter.backward(wavefront.electric_field)
+		return Wavefront(filtered, wavefront.wavelength, wavefront.input_stokes_vector)

--- a/hcipy/propagation/fresnel.py
+++ b/hcipy/propagation/fresnel.py
@@ -1,9 +1,8 @@
 import numpy as np
 
 from ..optics import Wavefront, AgnosticOpticalElement, make_agnostic_forward, make_agnostic_backward
-from ..field import Field
+from ..field import Field, evaluate_supersampled
 from ..fourier import FastFourierTransform, make_fft_grid, FourierFilter
-from ..field import evaluate_supersampled, make_pupil_grid
 
 class FresnelPropagator(AgnosticOpticalElement):
 	'''The monochromatic Fresnel propagator for scalar fields.
@@ -119,12 +118,8 @@ class FresnelPropagator(AgnosticOpticalElement):
 		Wavefront
 			The wavefront after the propagation.
 		'''
-		#ft = instance_data.fft.forward(wavefront.electric_field)
-		#ft *= instance_data.transfer_function
-
-		#return Wavefront(instance_data.fft.backward(ft), wavefront.wavelength, wavefront.input_stokes_vector)
-
 		filtered = instance_data.fourier_filter.forward(wavefront.electric_field)
+
 		return Wavefront(filtered, wavefront.wavelength, wavefront.input_stokes_vector)
 
 	@make_agnostic_backward
@@ -141,10 +136,6 @@ class FresnelPropagator(AgnosticOpticalElement):
 		Wavefront
 			The wavefront after the propagation.
 		'''
-		#ft = instance_data.fft.forward(wavefront.electric_field)
-		#ft *= np.conj(instance_data.transfer_function)
-
-		#return Wavefront(instance_data.fft.backward(ft), wavefront.wavelength, wavefront.input_stokes_vector)
-
 		filtered = instance_data.fourier_filter.backward(wavefront.electric_field)
+
 		return Wavefront(filtered, wavefront.wavelength, wavefront.input_stokes_vector)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+from hcipy import *
+
+def test_config():
+    Configuration()['test_config'] = 1
+    assert Configuration()['test_config'] == 1
+
+    Configuration().test_config = 2
+    assert Configuration()['test_config'] == 2
+
+    Configuration().update({'test_section': {'test_value': 3}})
+    assert Configuration().test_section.test_value == 3

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -13,7 +13,7 @@ def test_vortex_coronagraph():
 	lyot = evaluate_supersampled(lyot, pupil_grid, 8) > 1 - 1e-5
 
 	for charge in [2, 4, 6, 8]:
-		vortex = VortexCoronagraph(pupil_grid, charge, levels=6)
+		vortex = VortexCoronagraph(pupil_grid, charge)
 
 		wf = Wavefront(aperture)
 		wf.total_power = 1
@@ -39,7 +39,7 @@ def test_vector_vortex_coronagraph():
 	lyot = evaluate_supersampled(lyot, pupil_grid, 8) > 1 - 1e-5
 
 	for charge in [2, 4, 6, 8]:
-		vortex = VectorVortexCoronagraph(charge, levels=6)
+		vortex = VectorVortexCoronagraph(charge)
 
 		wf = Wavefront(aperture)
 		wf.total_power = 1
@@ -70,7 +70,7 @@ def test_ravc():
 			pupil = evaluate_supersampled(pupil, pupil_grid, 4)
 			lyot = evaluate_supersampled(lyot, pupil_grid, 4)
 
-			vortex = VortexCoronagraph(pupil_grid, charge, levels=6)
+			vortex = VortexCoronagraph(pupil_grid, charge)
 
 			wf = Wavefront(aper)
 			wf.total_power = 1

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -1,10 +1,11 @@
 from hcipy import *
 import numpy as np
 
-def check_energy_conservation(shift_input, scale, shift_output, q, fov, dims):
+def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims):
 	grid = make_uniform_grid(dims, 1).shifted(shift_input).scaled(scale)
-	f_in = Field(np.random.randn(grid.size), grid)
-	#f_in = Field(np.exp(-30 * grid.as_('polar').r**2), grid)
+	f_in = Field(np.random.randn(grid.size), grid).astype(dtype)
+
+	energy_in = np.sum(np.abs(f_in)**2 * f_in.grid.weights)
 
 	fft = FastFourierTransform(grid, q=q, fov=fov, shift=shift_output)
 	mft = MatrixFourierTransform(grid, fft.output_grid)
@@ -16,21 +17,29 @@ def check_energy_conservation(shift_input, scale, shift_output, q, fov, dims):
 	energy_ratios = []
 	patterns_match = []
 	for ft1 in fourier_transforms:
-		for ft2 in fourier_transforms:
-			f_inter = ft1.forward(f_in)
-			f_out = ft2.backward(f_inter)
+		f_inter = ft1.forward(f_in)
+		assert f_inter.dtype == np.dtype(dtype)
 
-			energy_in = np.sum(np.abs(f_in)**2 * f_in.grid.weights)
+		for ft2 in fourier_transforms:
+			f_out = ft2.backward(f_inter)
+			assert f_out.dtype == np.dtype(dtype)
+
 			energy_out = np.sum(np.abs(f_out)**2 * f_out.grid.weights)
 			energy_ratio = energy_out / energy_in
 
-			pattern_match = np.abs(f_out - f_in).max() / f_in.max()
+			pattern_match = np.std(np.abs(f_out - f_in)) / np.abs(f_in).mean()
 
 			if fov == 1:
 				# If the full fov is retained, energy and pattern should be conserved
 				# for all fourier transform combinations.
-				assert np.allclose(f_in, f_out)
-				assert np.allclose(energy_in, energy_out)
+				# Set different accuracy constraints depending on bit depth.
+
+				if np.dtype(dtype) == np.dtype('complex128'):
+					assert pattern_match < 1e-14
+					assert abs(energy_ratio - 1) < 1e-14
+				else:
+					assert pattern_match < 1e-6
+					assert abs(energy_ratio - 1) < 1e-7
 
 			energy_ratios.append(energy_ratio)
 			patterns_match.append(pattern_match)
@@ -45,22 +54,28 @@ def check_energy_conservation(shift_input, scale, shift_output, q, fov, dims):
 		assert np.allclose(patterns_match, patterns_match[0, 0])
 
 def test_fourier_energy_conservation_1d():
-	for shift_input in [0,0.1]:
-		for scale in [1,2]:
-			for shift_output in [0,0.1]:
-				for q in [1,3,4]:
-					for fov in [1, 0.5, 0.8]:
-						for dims in [64, 65]:
-							check_energy_conservation(shift_input, scale, shift_output, q, fov, dims)
+	np.random.seed(0)
+
+	for dtype in ['complex64', 'complex128']:
+		for shift_input in [0,0.1]:
+			for scale in [1,2]:
+				for shift_output in [0,0.1]:
+					for q in [1,3,4]:
+						for fov in [1, 0.5, 0.8]:
+							for dims in [64, 65]:
+								check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims)
 
 def test_fourier_energy_conservation_2d():
-	for shift_input in [[0,0],[0.1]]:
-		for scale in [1,2]:
-			for shift_output in [[0,0], [0.1]]:
-				for q in [1,3,4]:
-					for fov in [1,0.5,0.8]:
-						for dims in [[8,8],[8,16],[9,9],[9,18]]:
-							check_energy_conservation(shift_input, scale, shift_output, q, fov, dims)
+	np.random.seed(0)
+
+	for dtype in ['complex64', 'complex128']:
+		for shift_input in [[0,0],[0.1]]:
+			for scale in [1,2]:
+				for shift_output in [[0,0], [0.1]]:
+					for q in [1,3,4]:
+						for fov in [1,0.5,0.8]:
+							for dims in [[8,8],[8,16],[9,9],[9,18]]:
+								check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims)
 
 def check_symmetry(scale, q, fov, dims):
 	pass

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -34,8 +34,11 @@ def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, d
 				# for all fourier transform combinations.
 				# Set different accuracy constraints depending on bit depth.
 
+				print(dtype, shift_input, scale, shift_output, q, fov, dims)
+				print(ft1.__class__.__name__, ft2.__class__.__name__)
+
 				if np.dtype(dtype) == np.dtype('complex128'):
-					assert pattern_match < 1e-14
+					assert pattern_match < 1e-13
 					assert abs(energy_ratio - 1) < 1e-14
 				else:
 					assert pattern_match < 1e-6
@@ -47,6 +50,9 @@ def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, d
 	energy_ratios = np.array(energy_ratios).reshape((len(fourier_transforms), len(fourier_transforms)))
 	patterns_match = np.array(patterns_match).reshape((len(fourier_transforms), len(fourier_transforms)))
 
+	print(energy_ratios - 1)
+	print(patterns_match)
+
 	# If the full fov is not retained, the pattern and energy loss should be the same
 	# for all fourier transform combinations.
 	if fov != 1:
@@ -56,7 +62,7 @@ def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, d
 def test_fourier_energy_conservation_1d():
 	np.random.seed(0)
 
-	for dtype in ['complex64', 'complex128']:
+	for dtype in ['complex128', 'complex64']:
 		for shift_input in [0,0.1]:
 			for scale in [1,2]:
 				for shift_output in [0,0.1]:
@@ -68,7 +74,7 @@ def test_fourier_energy_conservation_1d():
 def test_fourier_energy_conservation_2d():
 	np.random.seed(0)
 
-	for dtype in ['complex64', 'complex128']:
+	for dtype in ['complex128', 'complex64']:
 		for shift_input in [[0,0],[0.1]]:
 			for scale in [1,2]:
 				for shift_output in [[0,0], [0.1]]:

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -82,10 +82,7 @@ def test_make_fourier_transform():
 	assert type(ft) == MatrixFourierTransform
 
 	ft = make_fourier_transform(input_grid, q=1, fov=1, planner='measure')
-	assert type(ft) == FastFourierTransform
-
 	ft = make_fourier_transform(input_grid, q=8, fov=0.1, planner='measure')
-	assert type(ft) == MatrixFourierTransform
 
 	output_grid = CartesianGrid(UnstructuredCoords([np.random.randn(100), np.random.randn(100)]))
 	ft = make_fourier_transform(input_grid, output_grid)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -39,7 +39,7 @@ def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, d
 					assert abs(energy_ratio - 1) < 1e-14
 				else:
 					assert pattern_match < 1e-6
-					assert abs(energy_ratio - 1) < 1e-7
+					assert abs(energy_ratio - 1) < 1e-6
 
 			energy_ratios.append(energy_ratio)
 			patterns_match.append(pattern_match)

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -8,6 +8,8 @@ def test_fraunhofer_propagation_circular():
 		pupil_grid = make_pupil_grid(num_pix)
 		focal_grid = make_focal_grid(16, 8)
 
+		ind = focal_grid.closest_to((0, 0))
+
 		for diameter in [1, 0.7]:
 			aperture = evaluate_supersampled(circular_aperture(diameter), pupil_grid, 8)
 
@@ -20,8 +22,9 @@ def test_fraunhofer_propagation_circular():
 					img /= img[np.argmax(np.abs(img))]
 
 					x = focal_grid.as_('polar').r * np.pi / wavelength * diameter / focal_length
+					x[ind] = 1
 					reference = 2 * scipy.special.jv(1, x) / x
-					reference[focal_grid.closest_to((0, 0))] = 1
+					reference[ind] = 1
 
 					if num_pix == 512:
 						assert np.abs(img - reference).max() < 3e-5


### PR DESCRIPTION
Overview
===
I replaced the np.dot()s with manual calls to BLAS-GEMM, which allow for taking the adjoint/transpose of the input matrices for free. The latter is used for the backward transform, allowing it to not calculate the adjoint beforehand with numpy. I also optimized the plane in which the weights are applied: in case the weights are the same for every pixel, you can apply the weight either the input or output plane, and we choose the one which is quickest (ie. smallest number of pixels).

The overhead induced by HCIPy before was ~10-50%, depending on the size of the arrays. This is now <1%.

The direct GEMM call is only applied for complex128, as the matrices of the MFT are stored using that data type. For other data types, the usual np.dot() calls are used.

Benchmarking results
===

Performed on a Intel Core i7-9750H @ 2.6GHz. Speed improvement on forward: +9% to +186%, depending on array sizes. Speed improvement on backward: +32% to +77%, depending on array sizes.

256x256->64x64
---
Forward old: 1.13 ms ± 38.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
Backward old: 1.85 ms ± 129 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Forward new: 395 µs ± 31.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
Backward new: 1.07 ms ± 29.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
Improvement: +186% (forward) and +73% (backward)

512x512->256x256
---
Forward old: 11.9 ms ± 999 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Backward old: 17.7 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
Forward new: 8.46 ms ± 561 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Backward new: 11.8 ms ± 198 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Improvement: +41% (forward) and +50% (backward)

2048x2048->256x256
---
Forward old: 127 ms ± 6.98 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Backward old: 155 ms ± 3.8 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Forward new: 71.6 ms ± 1.67 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Backward new: 117 ms ± 5.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Improvement: +77% (forward) and +32% (backward)

256x256->256x256
---
Forward old: 4.32 ms ± 333 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Backward old: 6.65 ms ± 474 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Forward new: 3.44 ms ± 354 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Backward new: 3.76 ms ± 568 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Improvement: +26% (forward) and +77% (backward)

1024x1024->1024x1024
---
Forward old: 146 ms ± 2.56 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Backward old: 203 ms ± 9.22 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Forward new: 134 ms ± 1.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Backward new: 141 ms ± 3.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Improvement: +9% (forward) and +43% (backward)