### PR TITLE
Vortex fix for apertures smaller than the grid size

### DIFF
--- a/hcipy/coronagraphy/vortex.py
+++ b/hcipy/coronagraphy/vortex.py
@@ -37,7 +37,7 @@ class VortexCoronagraph(OpticalElement):
 		grid_fill_fraction = pupil_diameter / grid_size
 
 		num_airy_outer = input_grid.shape[0] / 2 * grid_fill_fraction
-		q_outer = max(2, max(grid_size / pupil_diameter))
+		q_outer = max(2, max(2/grid_fill_fraction))
 
 		focal_grids = []
 		self.focal_masks = []
@@ -158,10 +158,6 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 		AgnosticOpticalElement.__init__(self)
 
 	def make_instance(self, instance_data, input_grid, output_grid, wavelength):
-		#q_outer = 2
-		#num_airy_outer = input_grid.shape[0] / 2
-		#pupil_diameter = input_grid.shape * input_grid.delta
-
 		grid_size = input_grid.shape * input_grid.delta 
 		if self.pupil_diameter is None:
 			pupil_diameter = input_grid.shape * input_grid.delta
@@ -169,7 +165,7 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
 		grid_fill_fraction = pupil_diameter / grid_size
 
 		num_airy_outer = input_grid.shape[0] / 2 * grid_fill_fraction
-		q_outer = max(2, max(grid_size / pupil_diameter))
+		q_outer = max(2, max(2/grid_fill_fraction))
 
 		focal_grids = []
 		jones_matrices = []

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -2,56 +2,64 @@ from hcipy import *
 import numpy as np
 
 def test_vortex_coronagraph():
-	pupil_grid = make_pupil_grid(256)
-	focal_grid = make_focal_grid(4, 32)
-	prop = FraunhoferPropagator(pupil_grid, focal_grid)
+	pupil_grid = make_pupil_grid(512)
+	
+	aperture_sizes = [0.5, 1]
+	for aperture_size in aperture_sizes:
+		focal_grid = make_focal_grid(4, 32, spatial_resolution=1/aperture_size)
+		prop = FraunhoferPropagator(pupil_grid, focal_grid)
 
-	aperture = circular_aperture(1)
-	aperture = evaluate_supersampled(aperture, pupil_grid, 8)
+		aperture = circular_aperture(aperture_size)
+		aperture = evaluate_supersampled(aperture, pupil_grid, 16)
 
-	lyot = circular_aperture(0.99)
-	lyot = evaluate_supersampled(lyot, pupil_grid, 8) > 1 - 1e-5
+		lyot = circular_aperture(0.99 * aperture_size)
+		lyot = evaluate_supersampled(lyot, pupil_grid, 8) > 1 - 1e-5
 
-	for charge in [2, 4, 6, 8]:
-		vortex = VortexCoronagraph(pupil_grid, charge, levels=6)
+		for charge in [2, 4, 6, 8]:
+			vortex = VortexCoronagraph(pupil_grid, charge, levels=6)
 
-		wf = Wavefront(aperture)
-		wf.total_power = 1
+			wf = Wavefront(aperture)
+			wf.total_power = 1
 
-		img_ref = prop(wf)
+			img_ref = prop(wf)
 
-		wf = vortex(wf)
-		wf.electric_field *= lyot
-		img = prop(wf)
-
-		assert img.total_power < 1e-6
-		assert img.intensity.max() / img_ref.intensity.max() < 1e-8
+			wf = vortex(wf)
+			wf.electric_field *= lyot
+			img = prop(wf)
+			
+			assert img.total_power < 1e-6
+			assert img.intensity.max() / img_ref.intensity.max() < 1e-8
 
 def test_vector_vortex_coronagraph():
-	pupil_grid = make_pupil_grid(256)
-	focal_grid = make_focal_grid(4, 32)
-	prop = FraunhoferPropagator(pupil_grid, focal_grid)
+	pupil_grid = make_pupil_grid(512)
+	
+	aperture_sizes = [0.5, 1]
+	for aperture_size in aperture_sizes:
+		focal_grid = make_focal_grid(4, 32, spatial_resolution=1/aperture_size)
+		prop = FraunhoferPropagator(pupil_grid, focal_grid)
 
-	aperture = circular_aperture(1)
-	aperture = evaluate_supersampled(aperture, pupil_grid, 8)
+		aperture = circular_aperture(aperture_size)
+		aperture = evaluate_supersampled(aperture, pupil_grid, 8)
 
-	lyot = circular_aperture(0.99)
-	lyot = evaluate_supersampled(lyot, pupil_grid, 8) > 1 - 1e-5
+		lyot = circular_aperture(0.99 * aperture_size)
+		lyot = evaluate_supersampled(lyot, pupil_grid, 8) > 1 - 1e-5
 
-	for charge in [2, 4, 6, 8]:
-		vortex = VectorVortexCoronagraph(charge, levels=6)
+		for charge in [2, 4, 6, 8]:
+			vortex = VectorVortexCoronagraph(charge, levels=6)
 
-		wf = Wavefront(aperture)
-		wf.total_power = 1
+			wf = Wavefront(aperture)
+			wf.total_power = 1
 
-		img_ref = prop(wf)
+			img_ref = prop(wf)
 
-		wf = vortex(wf)
-		wf.electric_field *= lyot
-		img = prop(wf)
+			wf = vortex(wf)
+			wf.electric_field *= lyot
+			img = prop(wf)
 
-		assert img.total_power < 1e-6
-		assert img.intensity.max() / img_ref.intensity.max() < 1e-8
+			assert img.total_power < 1e-6
+			assert img.intensity.max() / img_ref.intensity.max() < 1e-8
+
+test_vector_vortex_coronagraph()
 
 def test_ravc():
 	pupil_grid = make_pupil_grid(256)


### PR DESCRIPTION
The implementation of the vortex coronagraph assumed that the pupil diameter was the same as the grid diameter. The proposed update fixes this to include pupil diameters smaller than the grid.

I have modified the tests of the vortex and the new implementation still passes them.