### PR TITLE
Further speed improvements

### DIFF
--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ..optics import Apodizer, OpticalElement
 from ..propagation import FraunhoferPropagator
 
@@ -55,7 +57,11 @@ class LyotCoronagraph(OpticalElement):
 		wf_foc.electric_field -= self.focal_plane_mask.forward(wf_foc).electric_field
 
 		lyot = self.prop.backward(wf_foc)
-		lyot.electric_field[:] = wavefront.electric_field - lyot.electric_field
+
+		# The next line is equal to
+		#     lyot.electric_field = wavefront.electric_field - lyot.electric_field
+		# but doesn't copy a numpy array.
+		np.subtract(wavefront.electric_field, lyot.electric_field, out=lyot.electric_field)
 
 		if self.lyot_stop is not None:
 			lyot = self.lyot_stop.forward(lyot)
@@ -84,7 +90,11 @@ class LyotCoronagraph(OpticalElement):
 		wf_foc.electric_field -= self.focal_plane_mask.backward(wf_foc).electric_field
 
 		pup = self.prop.backward(wf_foc)
-		pup.electric_field[:] = wf.electric_field - pup.electric_field
+
+		# The next line is equal to
+		#     pup.electric_field = wf.electric_field - pup.electric_field
+		# but doesn't copy a numpy array.
+		np.subtract(wf.electric_field, pup.electric_field, out=pup.electric_field)
 
 		return pup
 

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -4,7 +4,7 @@ from .fast_fourier_transform import FastFourierTransform
 from ..field import Field, field_dot, field_conjugate_transpose
 
 try:
-	import mkl_fft._numpy_fft as _fft_module
+	import mkl_fft as _fft_module
 except ImportError:
 	_fft_module = np.fft
 
@@ -114,7 +114,7 @@ class FourierFilter(object):
 			c = tuple([slice(None)] * field.tensor_order) + self.cutout
 			f[c] = field.shaped
 
-		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)))
+		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=True)
 
 		if (self._transfer_function.ndim - self.internal_grid.ndim) == 2:
 			# The transfer function is a matrix field.
@@ -137,7 +137,7 @@ class FourierFilter(object):
 
 			f *= tf
 
-		f = _fft_module.ifftn(f, axes=tuple(range(-self.input_grid.ndim, 0)))
+		f = _fft_module.ifftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=True)
 
 		s = f.shape[:-self.internal_grid.ndim] + (-1,)
 		if self.cutout is None:

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -115,7 +115,7 @@ class FourierFilter(object):
 			f[c] = field.shaped
 
 		# Don't overwrite f if it's the input array.
-		overwrite_x = self.cutout is not None
+		overwrite_x = self.cutout is not None and field.grid.ndim > 1
 		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=overwrite_x)
 
 		if (self._transfer_function.ndim - self.internal_grid.ndim) == 2:

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -114,7 +114,9 @@ class FourierFilter(object):
 			c = tuple([slice(None)] * field.tensor_order) + self.cutout
 			f[c] = field.shaped
 
-		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=True)
+		# Don't overwrite f if it's the input array.
+		overwrite_x = self.cutout is not None
+		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=overwrite_x)
 
 		if (self._transfer_function.ndim - self.internal_grid.ndim) == 2:
 			# The transfer function is a matrix field.

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -5,8 +5,10 @@ from ..field import Field, field_dot, field_conjugate_transpose
 
 try:
 	import mkl_fft as _fft_module
+	_use_mkl = True
 except ImportError:
 	_fft_module = np.fft
+	_use_mkl = False
 
 class FourierFilter(object):
 	'''A filter in the Fourier domain.
@@ -115,8 +117,11 @@ class FourierFilter(object):
 			f[c] = field.shaped
 
 		# Don't overwrite f if it's the input array.
-		overwrite_x = self.cutout is not None and field.grid.ndim > 1
-		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=overwrite_x)
+		if _use_mkl:
+			kwargs = {'overwrite_x': self.cutout is not None and field.grid.ndim > 1}
+		else:
+			kwargs = {}
+		f = _fft_module.fftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), **kwargs)
 
 		if (self._transfer_function.ndim - self.internal_grid.ndim) == 2:
 			# The transfer function is a matrix field.
@@ -139,7 +144,11 @@ class FourierFilter(object):
 
 			f *= tf
 
-		f = _fft_module.ifftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), overwrite_x=True)
+		if _use_mkl:
+			kwargs = {'overwrite_x': True}
+		else:
+			kwargs = {}
+		f = _fft_module.ifftn(f, axes=tuple(range(-self.input_grid.ndim, 0)), **kwargs)
 
 		s = f.shape[:-self.internal_grid.ndim] + (-1,)
 		if self.cutout is None:

--- a/hcipy/optics/deformable_mirror.py
+++ b/hcipy/optics/deformable_mirror.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.sparse import csr_matrix
 import pkg_resources
+import numexpr as ne
 
 from .optical_element import OpticalElement
 from ..field import make_uniform_grid, evaluate_supersampled
@@ -182,7 +183,10 @@ class DeformableMirror(OpticalElement):
 			The reflected wavefront.
 		'''
 		wf = wavefront.copy()
-		wf.electric_field *= np.exp(2j * self.surface * wavefront.wavenumber)
+
+		variables = {'alpha': 2j * wavefront.wavenumber, 'surf': self.surface}
+		wf.electric_field *= ne.evaluate('exp(alpha * surf)', local_dict=variables)
+
 		return wf
 
 	def backward(self, wavefront):
@@ -199,7 +203,10 @@ class DeformableMirror(OpticalElement):
 			The reflected wavefront.
 		'''
 		wf = wavefront.copy()
-		wf.electric_field *= np.exp(-2j * self.surface * wavefront.wavenumber)
+
+		variables = {'alpha': -2j * wavefront.wavenumber, 'surf': self.surface}
+		wf.electric_field *= ne.evaluate('exp(alpha * surf)', local_dict=variables)
+
 		return wf
 
 	@property

--- a/hcipy/optics/wavefront.py
+++ b/hcipy/optics/wavefront.py
@@ -334,7 +334,13 @@ class Wavefront(object):
 	def power(self):
 		'''The power of each pixel in the wavefront.
 		'''
-		return self.intensity * self.grid.weights
+		if self.electric_field.is_scalar_field or self.electric_field.is_vector_field:
+			variables = {'field': self.electric_field, 'weights': self.grid.weights}
+			power = ne.evaluate('real(abs(field))**2 * weights', local_dict=variables)
+
+			return Field(power, self.grid)
+		else:
+			return self.intensity * self.grid.weights
 
 	@property
 	def total_power(self):

--- a/hcipy/optics/wavefront.py
+++ b/hcipy/optics/wavefront.py
@@ -113,7 +113,8 @@ class Wavefront(object):
 		'''
 		if self.is_scalar:
 			# This is a scaler field.
-			return np.abs(self.electric_field)**2
+			intensity = ne.evaluate('real(abs(elec))**2', local_dict={'elec': self.electric_field})
+			return Field(intensity, self.electric_field.grid)
 		elif self.is_partially_polarized:
 			# This is a tensor field.
 			x = self._electric_field[0, 0, :]


### PR DESCRIPTION
Summary of changes:

* Use numexpr more liberally throughout the codebase:
  * for deformable mirror surface to complex exponential
  * for calculating power of wavefronts
  * for the setup in Fresnel propagators.
* Use in-place FFTs where possible (enabled when using mkl_fft).
* Use in-place multiplication in Lyot coronagraph.
* Don't copy electric fields in the electric field property setter.
* Allow complex64 wavefronts.