### PR TITLE
Fix Numpy 1.20 deprecation warnings

### DIFF
--- a/doc/tutorial_notebooks/PyramidWFS/PyramidWFS.ipynb
+++ b/doc/tutorial_notebooks/PyramidWFS/PyramidWFS.ipynb
@@ -328,7 +328,7 @@
     "        wf_pyr = pwfs.forward(wf_dm)\n",
     "\n",
     "        camera.integrate(wf_pyr, 1)\n",
-    "        wfs_image = large_poisson(camera.read_out()).astype(np.float)\n",
+    "        wfs_image = large_poisson(camera.read_out()).astype('float')\n",
     "        wfs_image /= np.sum(wfs_image)\n",
     "\n",
     "        diff_image = wfs_image-image_ref\n",

--- a/hcipy/optics/glass.py
+++ b/hcipy/optics/glass.py
@@ -118,6 +118,6 @@ def _parse_sellmeier_glass_catalogue(filename):
 
 	database = {}
 	for di in data:
-		database[di[0].replace(" ", "")] = make_sellmeier_glass(1, di[1:4].astype(np.float), di[4::].astype(np.float))
+		database[di[0].replace(" ", "")] = make_sellmeier_glass(1, di[1:4].astype('float'), di[4::].astype('float'))
 
 	return database

--- a/hcipy/optics/glass.py
+++ b/hcipy/optics/glass.py
@@ -114,7 +114,7 @@ def _build_glass_catalogue():
 	_glass_catalogue.update(_parse_sellmeier_glass_catalogue(pkg_resources.resource_stream('hcipy', 'data/ohara_glass_catalogue_2019_08.csv')))
 
 def _parse_sellmeier_glass_catalogue(filename):
-	data = np.loadtxt(filename, dtype=np.str, delimiter=',', skiprows=1)
+	data = np.loadtxt(filename, dtype=str, delimiter=',', skiprows=1)
 
 	database = {}
 	for di in data:


### PR DESCRIPTION
Numpy 1.20 has deprecated the use of np.float and other data types. See https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated.