### PR TITLE
Change CI test for thin lens to use FresnelPropagator.

### DIFF
--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -644,12 +644,12 @@ def test_thin_lens():
 	lens = ThinLens(focal_length, lambda x : 1.5, 1e-6)
 	aperture = evaluate_supersampled( circular_aperture(5e-2), grid, 8 )
 	assert abs((lens.focal_length - focal_length)/focal_length) < 1e-10
-	
+
 	nsteps = 20
 	dz = focal_length / (nsteps/2)
 	z = np.arange(nsteps+1) * dz
-	prop = AngularSpectrumPropagator(grid, dz)
-	
+	prop = FresnelPropagator(grid, dz)
+
 	wf = Wavefront(aperture, wavelength)
 	wf.total_power = 1
 	wf = lens(wf)
@@ -658,22 +658,27 @@ def test_thin_lens():
 	for i in range(nsteps):
 		wf = prop(wf)
 		peak.append(wf.power.max())
-	
+
 	lens.focal_length = 2.0 * focal_length
 
 	nsteps = 20
 	dz = 2.0 * focal_length / (nsteps/2)
 	z2 = np.arange(nsteps+1) * dz
-	prop = AngularSpectrumPropagator(grid, dz)
-	
+	prop = FresnelPropagator(grid, dz)
+
 	wf = Wavefront(aperture, wavelength)
 	wf.total_power = 1
 	wf = lens(wf)
-	
+
 	peak2 = [wf.power.max(),]
 	for i in range(nsteps):
 		wf = prop(wf)
 		peak2.append(wf.power.max())
 
-	assert abs(z[np.argmax(peak)]/focal_length - 1.0) < 0.01
-	assert abs(z2[np.argmax(peak2)]/(2.0 * focal_length) - 1.0) < 0.01
+	print('z', z)
+	print('peak', peak)
+	print('z2', z2)
+	print('peak2', peak2)
+
+	assert abs(z[np.argmax(peak)] / focal_length - 1.0) < 0.01
+	assert abs(z2[np.argmax(peak2)] / (2.0 * focal_length) - 1.0) < 0.01


### PR DESCRIPTION
Related to #116. This includes partially rewriting the test to make individual subtests independent.