### PR TITLE
Bugfix for FFT parameters

### DIFF
--- a/hcipy/fourier/fourier_transform.py
+++ b/hcipy/fourier/fourier_transform.py
@@ -76,17 +76,35 @@ class FourierTransform(object):
 
 		return A
 
-def _time_it(function, t_max=1, n_max=100):
+def _time_it_iterative(function, num_iterations):
 	import time
 
-	start = time.time()
-	times = []
-
-	while (time.time() < start + t_max) and (len(times) < n_max):
-		t1 = time.time()
+	start = time.perf_counter()
+	for _ in range(num_iterations):
 		function()
-		t2 = time.time()
-		times.append(t2 - t1)
+	end = time.perf_counter()
+
+	return (end - start) / num_iterations
+
+def _time_it(function, t_max=0.1, repeat_max=5):
+	num_iterations = 1
+
+	while True:
+		time_per_iteration = _time_it_iterative(function, num_iterations)
+
+		if time_per_iteration * num_iterations > t_max:
+			break
+		else:
+			num_iterations *= 2
+
+	# Shortcut if one iteration of the function itself takes longer than repeat_max * t_max.
+	if num_iterations == 1 and time_per_iteration > (repeat_max * t_max):
+		return time_per_iteration
+
+	times = [time_per_iteration]
+
+	for _ in range(repeat_max - 1):
+		times.append(_time_it_iterative(function, num_iterations))
 
 	return np.median(times)
 


### PR DESCRIPTION
This fixes a bug where in rare circumstances, numerical errors lead to a different output shape in the FastFourierTransform object. Now, fov arguments of >1 are allowed, as long as they do not lead to an invalid cropping during the FFT itself.

This also improves the method used for timing FFTs and MFTs (if the "estimate" method is used). The current implementation behaves more like the timeit magic from IPython.