### PR TITLE
Fix miscellaneous documentation warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,7 +72,7 @@ version = release
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/hcipy/fourier/fourier_transform.py
+++ b/hcipy/fourier/fourier_transform.py
@@ -20,7 +20,7 @@ class FourierTransform(object):
 			The field to Fourier transform.
 
 		Returns
-		--------
+		-------
 		Field
 			The Fourier transform of the field.
 		'''
@@ -35,7 +35,7 @@ class FourierTransform(object):
 			The field to inverse Fourier transform.
 
 		Returns
-		--------
+		-------
 		Field
 			The inverse Fourier transform of the field.
 		'''
@@ -46,7 +46,7 @@ class FourierTransform(object):
 		Fourier transform.
 
 		Returns
-		--------
+		-------
 		ndarray
 			A matrix representing the Fourier transform.
 		'''
@@ -63,7 +63,7 @@ class FourierTransform(object):
 		Fourier transform.
 
 		Returns
-		--------
+		-------
 		ndarray
 			A matrix representing the Fourier transform.
 		'''

--- a/hcipy/optics/detector.py
+++ b/hcipy/optics/detector.py
@@ -51,7 +51,7 @@ class Detector(object):
 		No noise will be added to the image.
 
 		Returns
-		----------
+		-------
 		Field
 			The final detector image.
 		'''
@@ -73,7 +73,7 @@ class Detector(object):
 			Weight of every unit of integration time.
 
 		Returns
-		----------
+		-------
 		Field
 			The final detector image.
 		'''
@@ -128,7 +128,7 @@ class NoiselessDetector(Detector):
 		No noise will be added to the image.
 
 		Returns
-		----------
+		-------
 		Field
 			The final detector image.
 		'''
@@ -235,7 +235,7 @@ class NoisyDetector(Detector):
 		read-out noise are applied. After the read out the power is reset.
 
 		Returns
-		----------
+		-------
 		Field
 			The final detector image.
 		'''


### PR DESCRIPTION
* Default language set to English (en).
* Removed oversized underlined headings (Parameters and Returns) in docstrings.