### PR TITLE
Bugfix for missing shift during finding best FT method

### DIFF
--- a/hcipy/fourier/fourier_transform.py
+++ b/hcipy/fourier/fourier_transform.py
@@ -157,7 +157,7 @@ def make_fourier_transform(input_grid, output_grid=None, q=1, fov=1, planner='es
 		if input_grid.ndim not in [1, 2]:
 			method = 'fft'
 		else:
-			output_grid = make_fft_grid(input_grid, q, fov)
+			output_grid = make_fft_grid(input_grid, q, fov, shift)
 
 			if planner == 'estimate':
 				# Estimate analytically from complexities.

--- a/hcipy/fourier/fourier_transform.py
+++ b/hcipy/fourier/fourier_transform.py
@@ -108,7 +108,7 @@ def _time_it(function, t_max=0.1, repeat_max=5):
 
 	return np.median(times)
 
-def make_fourier_transform(input_grid, output_grid=None, q=1, fov=1, planner='estimate'):
+def make_fourier_transform(input_grid, output_grid=None, q=1, fov=1, shift=0, planner='estimate'):
 	'''Construct a FourierTransform object.
 
 	The most time-efficient Fourier transform method will be chosen according to actual or estimated performance.
@@ -119,10 +119,12 @@ def make_fourier_transform(input_grid, output_grid=None, q=1, fov=1, planner='es
 		The grid that will be used for the Field passed to the Fourier transform.
 	output_grid : None or Grid
 		The grid of the resulting field. If it is None, a optimal grid will be chosen, according to `q` and `fov`.
-	q : scalar
+	q : scalar or ndarray
 		Describes how many samples to take in the Fourier domain. A value of 1 means critcally sampled in the Fourier domain.
-	fov : scalar
+	fov : scalar or ndarray
 		Describes how far out the Fourier domain extends. A value of 1 means the same amount of samples as the spatial domain.
+	shift : scalar or ndarray
+		Describes by how much the Fourier domain should be shifted compared to the native sampling of FFT.
 	planner : string
 		If it is 'estimate', performance of the different methods will be estimated from theoretical complexity estimates.
 		If it is 'measure', actual Fourier transforms will be performed to get the actual performance. The latter takes longer,
@@ -198,7 +200,7 @@ def make_fourier_transform(input_grid, output_grid=None, q=1, fov=1, planner='es
 
 	# Make the Fourier transform
 	if method == 'fft':
-		return FastFourierTransform(input_grid, q, fov)
+		return FastFourierTransform(input_grid, q, fov, shift)
 	elif method == 'mft':
 		return MatrixFourierTransform(input_grid, output_grid)
 	elif method == 'naive':

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -92,22 +92,22 @@ def test_fourier_symmetries_2d():
 def test_make_fourier_transform():
 	input_grid = make_pupil_grid(128)
 
-	ft = make_fourier_transform(input_grid, q=1, fov=1, planner='estimate')
+	ft = make_fourier_transform(input_grid, q=1, fov=1, shift=0.1, planner='estimate')
 	assert type(ft) == FastFourierTransform
 
-	fft_grid = make_fft_grid(input_grid, q=1, fov=1)
+	fft_grid = make_fft_grid(input_grid, q=1, fov=1, shift=0.1)
 	ft = make_fourier_transform(input_grid, fft_grid, planner='estimate')
 	assert type(ft) == FastFourierTransform
 
-	ft = make_fourier_transform(input_grid, q=8, fov=0.3, planner='estimate')
+	ft = make_fourier_transform(input_grid, q=8, fov=0.3, shift=0.1, planner='estimate')
 	assert type(ft) == MatrixFourierTransform
 
-	fft_grid = make_fft_grid(input_grid, q=8, fov=0.3)
+	fft_grid = make_fft_grid(input_grid, q=8, fov=0.3, shift=0.1)
 	ft = make_fourier_transform(input_grid, fft_grid, planner='estimate')
 	assert type(ft) == MatrixFourierTransform
 
-	ft = make_fourier_transform(input_grid, q=1, fov=1, planner='measure')
-	ft = make_fourier_transform(input_grid, q=8, fov=0.1, planner='measure')
+	ft = make_fourier_transform(input_grid, q=1, fov=1, shift=0.1, planner='measure')
+	ft = make_fourier_transform(input_grid, q=8, fov=0.1, shift=0.1, planner='measure')
 
 	output_grid = CartesianGrid(UnstructuredCoords([np.random.randn(100), np.random.randn(100)]))
 	ft = make_fourier_transform(input_grid, output_grid)


### PR DESCRIPTION
Previously, the shift was ignored in the output grid of the `make_fourier_transform()` function. This PR includes the shift in the output grid which caused problems in a select case:

In cases where the possibility of an FFT was detected for the specified output grid, the output grid was replaced with an FFT grid. This FFT grid did not include the shift, which is strictly speaking not needed for calculating the performance of the FFT itself. The function would then do a performance comparison between FFT and MFT to select the fastest method. In cases where the MFT still was to be preferred, the MFT would be constructed using the FFT grid used for estimating the performance rather than the original requested output grid. The former didn't include the shift, which leads to an MFT being constructed for the wrong output grid.