### PR TITLE
Add comparison (equality and inequality) operators to Grids.

### DIFF
--- a/hcipy/field/coordinates.py
+++ b/hcipy/field/coordinates.py
@@ -76,6 +76,21 @@ class Coords(object):
 		self *= 1 / f
 		return self
 
+	def __eq__(self, other):
+		'''Check if the coordinates are identical.
+
+		Parameters
+		----------
+		other : object
+			The object to which to compare.
+
+		Returns
+		-------
+		boolean
+			Whether the two objects are identical.
+		'''
+		return NotImplemented
+
 	def __getitem__(self, i):
 		'''The `i`-th point for these coordinates.
 		'''
@@ -201,6 +216,24 @@ class UnstructuredCoords(Coords):
 			self.coords[i] *= f[i]
 		return self
 
+	def __eq__(self, other):
+		'''Check if the coordinates are identical.
+
+		Parameters
+		----------
+		other : object
+			The object to which to compare.
+
+		Returns
+		-------
+		boolean
+			Whether the two objects are identical.
+		'''
+		if type(self) != type(other):
+			return False
+
+		return np.array_equal(self.coords, other.coords)
+
 	def reverse(self):
 		'''Reverse the ordering of points in-place.
 		'''
@@ -314,6 +347,24 @@ class SeparatedCoords(Coords):
 			for i in range(len(self)):
 				self.separated_coords[i] *= f[i]
 		return self
+
+	def __eq__(self, other):
+		'''Check if the coordinates are identical.
+
+		Parameters
+		----------
+		other : object
+			The object to which to compare.
+
+		Returns
+		-------
+		boolean
+			Whether the two objects are identical.
+		'''
+		if type(self) != type(other):
+			return False
+
+		return np.array_equal(self.separated_coords, other.separated_coords)
 
 	def reverse(self):
 		'''Reverse the ordering of points in-place.
@@ -454,6 +505,24 @@ class RegularCoords(Coords):
 		self.delta *= f
 		self.zero *= f
 		return self
+
+	def __eq__(self, other):
+		'''Check if the coordinates are identical.
+
+		Parameters
+		----------
+		other : object
+			The object to which to compare.
+
+		Returns
+		-------
+		boolean
+			Whether the two objects are identical.
+		'''
+		if type(self) != type(other):
+			return False
+
+		return np.array_equal(self.regular_coords, other.regular_coords)
 
 	def reverse(self):
 		'''Reverse the ordering of points in-place.

--- a/hcipy/field/grid.py
+++ b/hcipy/field/grid.py
@@ -476,7 +476,7 @@ class Grid(object):
 		boolean
 			Whether the two objects are identical.
 		'''
-		if type(self) != type(other):
+		if not isinstance(other, Grid):
 			return False
 
 		if self._coordinate_system != other._coordinate_system:

--- a/hcipy/field/grid.py
+++ b/hcipy/field/grid.py
@@ -459,6 +459,31 @@ class Grid(object):
 
 		return h.intdigest()
 
+	def __eq__(self, other):
+		'''Check equality of two grids.
+
+		.. note::
+			This will return False if the two grids have different coordinate systems or coordinate types,
+			even if the underlying points are identical
+
+		Parameters
+		----------
+		other : object
+			The object to which to compare to.
+
+		Returns
+		-------
+		boolean
+			Whether the two objects are identical.
+		'''
+		if type(self) != type(other):
+			return False
+
+		if self._coordinate_system != other._coordinate_system:
+			return False
+
+		return self.coords == other.coords
+
 	def closest_to(self, p):
 		'''Get the index of the point closest to point `p`.
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -200,6 +200,8 @@ def test_grid_hashing_and_comparison():
 	assert hash(grid1) != hash(grid3)
 	assert grid1 != grid3
 	assert grid3 != grid1
+	assert grid2 != grid3
+	assert grid3 != grid2
 
 	grid4 = make_pupil_grid(128)
 	print('start')

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -194,18 +194,22 @@ def test_grid_hashing_and_comparison():
 	grid2 = CartesianGrid(SeparatedCoords(copy.deepcopy(grid1.separated_coords)))
 	assert hash(grid1) != hash(grid2)
 	assert grid1 != grid2
+	assert grid2 != grid1
 
 	grid3 = CartesianGrid(UnstructuredCoords(copy.deepcopy(grid1.coords)))
 	assert hash(grid1) != hash(grid3)
 	assert grid1 != grid3
+	assert grid3 != grid1
 
 	grid4 = make_pupil_grid(128)
+	print('start')
 	assert hash(grid1) == hash(grid4)
 	assert grid1 == grid4
 
 	grid5 = PolarGrid(grid1.coords)
 	assert hash(grid1) != hash(grid5)
 	assert grid1 != grid5
+	assert grid5 != grid1
 
 	grid6 = CartesianGrid(copy.deepcopy(grid1.coords))
 	assert hash(grid1) == hash(grid6)
@@ -224,6 +228,13 @@ def test_grid_hashing_and_comparison():
 	grid9 = make_pupil_grid(256)
 	assert hash(grid1) != hash(grid9)
 	assert grid1 != grid9
+
+	grid10 = CartesianGrid(SeparatedCoords(copy.deepcopy(grid2.separated_coords)))
+	assert hash(grid2) == hash(grid10)
+	assert grid2 == grid10
+
+	assert grid1 != 0
+	assert grid1 != 'string'
 
 def test_grid_supersampled():
 	g = make_uniform_grid(128, [1, 1])

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -188,33 +188,42 @@ def test_field_svd():
 		assert np.allclose(s[..., i], svd2[1])
 		assert np.allclose(vh[..., i], svd2[2])
 
-def test_grid_hashing():
+def test_grid_hashing_and_comparison():
 	grid1 = make_pupil_grid(128)
 
 	grid2 = CartesianGrid(SeparatedCoords(copy.deepcopy(grid1.separated_coords)))
 	assert hash(grid1) != hash(grid2)
+	assert grid1 != grid2
 
 	grid3 = CartesianGrid(UnstructuredCoords(copy.deepcopy(grid1.coords)))
 	assert hash(grid1) != hash(grid3)
+	assert grid1 != grid3
 
 	grid4 = make_pupil_grid(128)
 	assert hash(grid1) == hash(grid4)
+	assert grid1 == grid4
 
 	grid5 = PolarGrid(grid1.coords)
 	assert hash(grid1) != hash(grid5)
+	assert grid1 != grid5
 
 	grid6 = CartesianGrid(copy.deepcopy(grid1.coords))
 	assert hash(grid1) == hash(grid6)
+	assert grid1 == grid6
 
 	grid7 = grid1.scaled(2)
 	assert hash(grid1) != hash(grid7)
+	assert grid1 != grid7
 
 	grid8 = grid1.scaled(2)
 	assert hash(grid1) != hash(grid8)
 	assert hash(grid7) == hash(grid8)
+	assert grid1 != grid8
+	assert grid7 == grid8
 
 	grid9 = make_pupil_grid(256)
 	assert hash(grid1) != hash(grid9)
+	assert grid1 != grid9
 
 def test_grid_supersampled():
 	g = make_uniform_grid(128, [1, 1])

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -94,17 +94,25 @@ def test_make_fourier_transform():
 
 	ft = make_fourier_transform(input_grid, q=1, fov=1, shift=0.1, planner='estimate')
 	assert type(ft) == FastFourierTransform
+	assert ft.input_grid == input_grid
+	assert ft.output_grid == make_fft_grid(input_grid, q=1, fov=1)
 
 	fft_grid = make_fft_grid(input_grid, q=1, fov=1, shift=0.1)
 	ft = make_fourier_transform(input_grid, fft_grid, planner='estimate')
 	assert type(ft) == FastFourierTransform
+	assert ft.input_grid == input_grid
+	assert ft.output_grid == fft_grid
 
 	ft = make_fourier_transform(input_grid, q=8, fov=0.3, shift=0.1, planner='estimate')
 	assert type(ft) == MatrixFourierTransform
+	assert ft.input_grid == input_grid
+	assert ft.output_grid == make_fft_grid(input_grid, q=8, fov=0.3)
 
 	fft_grid = make_fft_grid(input_grid, q=8, fov=0.3, shift=0.1)
 	ft = make_fourier_transform(input_grid, fft_grid, planner='estimate')
 	assert type(ft) == MatrixFourierTransform
+	assert ft.input_grid == input_grid
+	assert ft.output_grid == fft_grid
 
 	ft = make_fourier_transform(input_grid, q=1, fov=1, shift=0.1, planner='measure')
 	ft = make_fourier_transform(input_grid, q=8, fov=0.1, shift=0.1, planner='measure')
@@ -112,6 +120,8 @@ def test_make_fourier_transform():
 	output_grid = CartesianGrid(UnstructuredCoords([np.random.randn(100), np.random.randn(100)]))
 	ft = make_fourier_transform(input_grid, output_grid)
 	assert type(ft) == NaiveFourierTransform
+	assert ft.input_grid == input_grid
+	assert ft.output_grid == output_grid
 
 def test_fft_grid_reconstruction():
 	for shift_input in [[0, 0], [0.1]]:

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -95,7 +95,7 @@ def test_make_fourier_transform():
 	ft = make_fourier_transform(input_grid, q=1, fov=1, shift=0.1, planner='estimate')
 	assert type(ft) == FastFourierTransform
 	assert ft.input_grid == input_grid
-	assert ft.output_grid == make_fft_grid(input_grid, q=1, fov=1)
+	assert ft.output_grid == make_fft_grid(input_grid, q=1, fov=1, shift=0.1)
 
 	fft_grid = make_fft_grid(input_grid, q=1, fov=1, shift=0.1)
 	ft = make_fourier_transform(input_grid, fft_grid, planner='estimate')
@@ -106,7 +106,7 @@ def test_make_fourier_transform():
 	ft = make_fourier_transform(input_grid, q=8, fov=0.3, shift=0.1, planner='estimate')
 	assert type(ft) == MatrixFourierTransform
 	assert ft.input_grid == input_grid
-	assert ft.output_grid == make_fft_grid(input_grid, q=8, fov=0.3)
+	assert ft.output_grid == make_fft_grid(input_grid, q=8, fov=0.3, shift=0.1)
 
 	fft_grid = make_fft_grid(input_grid, q=8, fov=0.3, shift=0.1)
 	ft = make_fourier_transform(input_grid, fft_grid, planner='estimate')


### PR DESCRIPTION
This allows grids to be compared for equality:

```python
if grid1 == grid2:
    print('These two grids are equal.')
else:
    print('These two grids are different.')
```

The inequality operator (`!=`) is defined implicitly by Python 3 based on the equality operator.

Note that even if Grids contain the same coordinates but are different types, then the comparison will return False. This is intentional.