### PR TITLE
Pin asdf version for Python 3.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
 		"imageio",
 		"xxhash",
 		"numexpr",
-		"asdf",
+		"asdf<=2.10 ; python_version<='3.7'",
+		"asdf ; python_version>'3.7'",
 		"importlib_metadata ; python_version<'3.7'",
 		"importlib_resources>=1.4 ; python_version<'3.9'"
 	],


### PR DESCRIPTION
The latest version of asdf no longer supports Python 3.7. We pin asdf to the latest working version, only for Python 3.7.

Thanks @WilliamJamieson for helping with this!