### PR TITLE
Print out the versions for all installed packages.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
       python -c "import scipy; print('Scipy', scipy.__version__)"
       python -c "import matplotlib; print('Matplotlib', matplotlib.__version__)"
       python -c "import hcipy; print('HCIPy', hcipy.__version__)"
+      conda list
     displayName: Print package versions
 
   - bash: |
@@ -98,6 +99,7 @@ jobs:
       python -c "import scipy; print('Scipy', scipy.__version__)"
       python -c "import matplotlib; print('Matplotlib', matplotlib.__version__)"
       python -c "import hcipy; print('HCIPy', hcipy.__version__)"
+      conda list
     displayName: Print package versions
 
   - bash: |
@@ -154,6 +156,7 @@ jobs:
       python -c "import scipy; print('Scipy', scipy.__version__)"
       python -c "import matplotlib; print('Matplotlib', matplotlib.__version__)"
       python -c "import hcipy; print('HCIPy', hcipy.__version__)"
+      conda list
     displayName: Print package versions
 
   - script: |
@@ -202,6 +205,7 @@ jobs:
       python -c "import scipy; print('Scipy', scipy.__version__)"
       python -c "import matplotlib; print('Matplotlib', matplotlib.__version__)"
       python -c "import hcipy; print('HCIPy', hcipy.__version__)"
+      conda list
     displayName: Print package versions
 
   - bash: |


### PR DESCRIPTION
This makes it easier to find bugs related to dependency versions during CI.