### PR TITLE
Change interpolation default for `imshow_field()`

### DIFF
--- a/hcipy/plotting/field.py
+++ b/hcipy/plotting/field.py
@@ -4,7 +4,7 @@ import numpy as np
 from ..field import Field
 
 def imshow_field(
-		field, grid=None, ax=None, vmin=None, vmax=None, aspect='equal', norm=None, interpolation=None,
+		field, grid=None, ax=None, vmin=None, vmax=None, aspect='equal', norm=None, interpolation='nearest',
 		non_linear_axes=False, cmap=None, mask=None, mask_color='k', grid_units=1, *args, **kwargs):
 	'''Display a two-dimensional image on a matplotlib figure.
 


### PR DESCRIPTION
Matplotlib had a small change in their default plotting behavior. It changed the default interpolation style to anti-aliased by using bilinear interpolation, see https://github.com/matplotlib/matplotlib/issues/17345 . The default keyword for imshow_field was changed to retain the default plotting style of hcipy.