### PR TITLE
Fix usage of deprecated function in tests.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,4 @@ jobs:
         uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: nofilter

--- a/hcipy/aperture/generic.py
+++ b/hcipy/aperture/generic.py
@@ -5,7 +5,7 @@ import inspect
 import numpy as np
 from matplotlib.path import Path
 
-from ..field import Field, CartesianGrid, UnstructuredCoords, make_hexagonal_grid
+from ..field import Field, make_hexagonal_grid
 from ..dev import deprecated_name_changed
 
 def make_circular_aperture(diameter, center=None):

--- a/hcipy/dev.py
+++ b/hcipy/dev.py
@@ -37,8 +37,13 @@ def deprecated_name_changed(new_func):  # pragma: no cover
         The new function that emits a DeprecationWarning upon use.
     '''
     def decorator(old_func):
-        f = new_func
-        f.__name__ = old_func.__name__
+        # I'm sure there is a way to use deprecated() above, but I can't figure that out right now.
+        @functools.wraps(new_func)
+        def wrapped(*args, **kwargs):
+            message = f'{old_func.__name__} is deprecated. Its new name is {new_func.__name__}.'
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
 
-        return deprecated(f'Its new name is {new_func.__name__}.')(f)
+            return new_func(*args, **kwargs)
+
+        return wrapped
     return decorator

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -179,12 +179,12 @@ def test_lyot_coronagraph():
 
 def test_knife_edge_coronagraph():
 	grid = make_pupil_grid(64, 1.1)
-	aperture = circular_aperture(1)(grid)
+	aperture = make_circular_aperture(1)(grid)
 
 	focal_grid = make_focal_grid(q=5, num_airy=5)
 
 	prop = FraunhoferPropagator(grid, focal_grid)
-	lyot_aperture = circular_aperture(0.95)(grid)
+	lyot_aperture = make_circular_aperture(0.95)(grid)
 	lyot_stop = Apodizer(lyot_aperture)
 
 	wf = Wavefront(aperture)


### PR DESCRIPTION
Seems like I missed two instances in #141 due to post-merging #142.

Also fixes the deprecation warning message itself which didn't display the correct new function name due to mutable Python variables.

Also fixes two flake8 errors and modifies reviewdog to not filter out any flake8 errors (so that flake8 errors on lines that aren't modified by a PR are still included in the review).