### PR TITLE
Very small bug fix in Wavefront class

### DIFF
--- a/hcipy/optics/wavefront.py
+++ b/hcipy/optics/wavefront.py
@@ -101,7 +101,7 @@ class Wavefront(object):
 
 	@wavenumber.setter
 	def wavenumber(self, wavenumber):
-		self.wavelength = 2 * npf.pi / wavenumber
+		self.wavelength = 2 * np.pi / wavenumber
 
 	@property
 	def grid(self):


### PR DESCRIPTION
I found a code breaking typo in the Wavefront class. The wavenumber assignment method used npf.pi instead of np.pi. I fixed this.