### PR TITLE
Fix bug in interpolating big-endian ndarray read from fits file.

### DIFF
--- a/hcipy/optics/deformable_mirror.py
+++ b/hcipy/optics/deformable_mirror.py
@@ -128,7 +128,7 @@ def make_xinetics_influence_functions(pupil_grid, num_actuators_across_pupil, ac
 	# Read in actuator shape from file.
 	f = files('hcipy.optics').joinpath('influence_dm5v2.fits')
 	with f.open('rb') as fp:
-		actuator = np.squeeze(read_fits(fp))
+		actuator = np.squeeze(read_fits(fp)).astype('float')
 	actuator /= actuator.max()
 
 	# Convert actuator into linear interpolator.


### PR DESCRIPTION
This PR fixes a bug in the Xinetics influence functions where the influence function file was read into a big-endian array, and the interpolation function doesn't support that anymore. The quick fix is to cast to a little-endian array before doing any interpolation. This is a minimal computational cost.