### PR TITLE
Add missing colon for conda installation

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,7 +10,7 @@ HCIPy may be installed in one of three different ways:
 
 .. code-block:: shell
 
-    conda install conda-forge:hcipy
+    conda install conda-forge::hcipy
 
 2. Using PyPI.
 


### PR DESCRIPTION
Conda channels need two colons when installing a package from them.