### PR TITLE
Deterministic atmospheric phase screens

### DIFF
--- a/hcipy/atmosphere/atmospheric_model.py
+++ b/hcipy/atmosphere/atmospheric_model.py
@@ -8,42 +8,42 @@ import numpy as np
 from scipy.special import gamma, kv
 
 class AtmosphericLayer(OpticalElement):
+	'''A single infinitely-thin atmospheric layer.
+
+	This class serves as a base class for all atmospheric layers. Multiply
+	atmospheric layers can be combined into an :class:`MultiLayerAtmosphere` which
+	provides modelling of scintillation between layers.
+
+	Parameters
+	----------
+	input_grid : Grid
+		The grid on which the wavefront will be defined.
+	Cn_squared : scalar
+		The integrated value of Cn^2 for the layer.
+	L0 : scalar
+		The outer scale of the layer.
+	velocity : scalar or array_like
+		The velocity of the layer. If a scalar is given, its direction will be
+		along x.
+	height : scalar
+		The height of the atmospheric layer above the ground.
+
+	Attributes
+	----------
+	input_grid : Grid
+		The grid on which the wavefront will be defined.
+	t : scalar
+		The current time.
+	Cn_squared : scalar
+		The integrated value of Cn^2 for the layer.
+	L0 : scalar
+		The outer scale of the phase structure function.
+	velocity : array_like
+		The two-dimensional velocity of the layer.
+	height : scalar
+		The height of the atmospheric layer above the ground.
+	'''
 	def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0):
-		'''A single infinitely-thin atmospheric layer.
-
-		This class serves as a base class for all atmospheric layers. Multiply
-		atmospheric layers can be combined into an :class:`MultiLayerAtmosphere` which
-		provides modelling of scintillation between layers.
-
-		Parameters
-		----------
-		input_grid : Grid
-			The grid on which the wavefront will be defined.
-		Cn_squared : scalar
-			The integrated value of Cn^2 for the layer.
-		L0 : scalar
-			The outer scale of the layer.
-		velocity : scalar or array_like
-			The velocity of the layer. If a scalar is given, its direction will be
-			along x.
-		height : scalar
-			The height of the atmospheric layer above the ground.
-
-		Attributes
-		----------
-		input_grid : Grid
-			The grid on which the wavefront will be defined.
-		t : scalar
-			The current time.
-		Cn_squared : scalar
-			The integrated value of Cn^2 for the layer.
-		L0 : scalar
-			The outer scale of the phase structure function.
-		velocity : array_like
-			The two-dimensional velocity of the layer.
-		height : scalar
-			The height of the atmospheric layer above the ground.
-		'''
 		self.input_grid = input_grid
 		self.Cn_squared = Cn_squared
 		self.L0 = L0
@@ -151,23 +151,23 @@ class AtmosphericLayer(OpticalElement):
 		return wf
 
 class MultiLayerAtmosphere(OpticalElement):
+	'''A multi-layer atmospheric model.
+
+	This :class:`OpticalElement` can model turbulence and scintillation effects
+	due to atmospheric turbulence by propagating light through a series of
+	infinitely-thin atmospheric phase screens at different altitudes. The distance
+	between two phase screens can be propagated using Fresnel propagation, or using
+	no :class:`Propagator`.
+
+	Parameters
+	----------
+	layers : list of AtmosphericLayer objects
+		The series of atmospheric layers in this model.
+	scintillation : bool
+		If True, then the distance between two phase screens is propagated using
+		a :class:`FresnelPropagator`. Otherwise, no propagator will be used.
+	'''
 	def __init__(self, layers, scintillation=False, scintilation=None):
-		'''A multi-layer atmospheric model.
-
-		This :class:`OpticalElement` can model turbulence and scintillation effects
-		due to atmospheric turbulence by propagating light through a series of
-		infinitely-thin atmospheric phase screens at different altitudes. The distance
-		between two phase screens can be propagated using Fresnel propagation, or using
-		no :class:`Propagator`.
-
-		Parameters
-		----------
-		layers : list of AtmosphericLayer objects
-			The series of atmospheric layers in this model.
-		scintillation : bool
-			If True, then the distance between two phase screens is propagated using
-			a :class:`FresnelPropagator`. Otherwise, no propagator will be used.
-		'''
 		# Retain backwards compatibility.
 		if scintilation is not None:
 			import warnings

--- a/hcipy/atmosphere/atmospheric_model.py
+++ b/hcipy/atmosphere/atmospheric_model.py
@@ -24,8 +24,8 @@ class AtmosphericLayer(OpticalElement):
 		L0 : scalar
 			The outer scale of the layer.
 		velocity : scalar or array_like
-			The velocity of the layer. If a scalar is given, its direction is
-			chosen randomly.
+			The velocity of the layer. If a scalar is given, its direction will be
+			along x.
 		height : scalar
 			The height of the atmospheric layer above the ground.
 
@@ -120,14 +120,7 @@ class AtmosphericLayer(OpticalElement):
 	@velocity.setter
 	def velocity(self, velocity):
 		if np.isscalar(velocity):
-			if self._velocity is not None:
-				vel = np.sqrt(np.dot(self._velocity, self._velocity))
-				if vel > 0:
-					self._velocity *= velocity / vel
-					return
-
-			theta = np.random.rand() * 2 * np.pi
-			self._velocity = velocity * np.array([np.cos(theta), np.sin(theta)])
+			self._velocity = np.array([velocity, 0])
 		else:
 			self._velocity = np.array(velocity)
 

--- a/hcipy/atmosphere/finite_atmospheric_layer.py
+++ b/hcipy/atmosphere/finite_atmospheric_layer.py
@@ -5,6 +5,41 @@ from ..util import SpectralNoiseFactoryMultiscale
 import copy
 
 class FiniteAtmosphericLayer(AtmosphericLayer):
+	'''An atmospheric layer simulating atmospheric turbulence.
+
+	This atmospheric layer is finite. This means that it will wrap
+	after translation by more than `oversampling` times the extent of
+	the input grid.
+
+	Parameters
+	----------
+	input_grid : Grid
+		The grid on which the incoming wavefront is defined.
+	Cn_squared : scalar
+		The integrated strength of the turbulence for this layer.
+	L0 : scalar
+		The outer scale for the atmospheric turbulence of this layer.
+		The default is infinity.
+	velocity : scalar or array_like
+		The wind speed for this atmospheric layer. If this is a scalar,
+		the wind will be along x. If this is a 2D array, then the values
+		are interpreted as the wind speed along x and y. The default is
+		zero.
+	height : scalar
+		The height of the atmospheric layer. By itself, this value has no
+		influence, but it'll be used by the AtmosphericModel to perform
+		inter-layer propagations.
+	oversampling : scalar
+		The amount of oversampling in the Fourier space. The atmospheric layer
+		will wrap after translation by more than `oversampling` times the extent of
+		the input grid. The default is 2.
+	seed : None, int, array of ints, SeedSequence, BitGenerator, Generator
+		A seed to initialize the spectral noise. If None, then fresh, unpredictable
+		entry will be pulled from the OS. If an int or array of ints, then it will
+		be passed to a numpy.SeedSequency to derive the initial BitGenerator state.
+		If a BitGenerator or Generator are passed, these will be wrapped and used
+		instead. Default: None.
+	'''
 	def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0, oversampling=2, seed=None):
 		self._noise = None
 		self._achromatic_screen = None
@@ -19,6 +54,20 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 		self.reset()
 
 	def reset(self, make_independent_realization=False):
+		'''Reset the atmospheric layer to t=0.
+
+		Parameters
+		----------
+		make_independent_realization : boolean
+			Whether to start an independent realization of the noise for the
+			atmospheric layer or not. When this is False, the exact same phase
+			screens will be generated as in the first run, as long as the Cn^2
+			and outer scale are the same. This allows for testing of multiple
+			runs of a control system with different control parameters. When
+			this is True, an independent realization of the atmospheric layer
+			will be generated. This is useful for Monte-Carlo-style computations.
+			The default is False.
+		'''
 		if make_independent_realization:
 			# Reset the original random generator to the current one. This
 			# will essentially reset the randomness.
@@ -37,6 +86,10 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 
 	@property
 	def noise(self):
+		'''The (unshifted) spectral noise of this layer.
+
+		This property is not intended to be used by the user.
+		'''
 		if self._noise is None:
 			self.reset()
 
@@ -44,20 +97,45 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 
 	@property
 	def achromatic_screen(self):
+		'''The phase of this layer for a wavelength of one.
+
+		This property is not intended to be used by the user.
+		'''
 		if self._achromatic_screen is None:
 			self._achromatic_screen = self.noise.shifted(self.center)()
 
 		return self._achromatic_screen
 
 	def phase_for(self, wavelength):
+		'''Compute the phase at a certain wavelength.
+
+		Parameters
+		----------
+		wavelength : scalar
+			The wavelength of the light for which to compute the phase screen.
+
+		Returns
+		-------
+		Field
+			The computed phase screen.
+		'''
 		return self.achromatic_screen / wavelength
 
 	def evolve_until(self, t):
+		'''Evolve the atmospheric layer until a certain time.
+
+		Parameters
+		----------
+		t : scalar
+			The new time to evolve the phase screen to.
+		'''
 		self.center = self.velocity * t
 		self._achromatic_screen = None
 
 	@property
 	def Cn_squared(self):  # noqa: N802
+		'''The integrated strength of the turbulence for this layer.
+		'''
 		return self._Cn_squared
 
 	@Cn_squared.setter
@@ -67,6 +145,8 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 
 	@property
 	def outer_scale(self):
+		'''The outer scale of the turbulence for this layer.
+		'''
 		return self._L0
 
 	@outer_scale.setter

--- a/hcipy/atmosphere/finite_atmospheric_layer.py
+++ b/hcipy/atmosphere/finite_atmospheric_layer.py
@@ -2,9 +2,11 @@ from .atmospheric_model import AtmosphericLayer, power_spectral_density_von_karm
 import numpy as np
 from ..util import SpectralNoiseFactoryMultiscale
 
+import copy
+
 class FiniteAtmosphericLayer(AtmosphericLayer):
-	def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0, oversampling=2):
-		self._dirty = True
+	def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0, oversampling=2, seed=None):
+		self._noise = None
 		self._achromatic_screen = None
 
 		AtmosphericLayer.__init__(self, input_grid, Cn_squared, L0, velocity, height)
@@ -12,24 +14,43 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 		self.oversampling = oversampling
 		self.center = np.zeros(2)
 
+		self._original_rng = np.random.default_rng(seed)
+
 		self.reset()
 
-	def reset(self):
+	def reset(self, make_independent_realization=False):
+		if make_independent_realization:
+			# Reset the original random generator to the current one. This
+			# will essentially reset the randomness.
+			self._original_rng = copy.copy(self.rng)
+		else:
+			# Make a copy of the original random generator. This copy will be
+			# used as the source for all randomness.
+			self.rng = copy.copy(self._original_rng)
+
 		self.psd = power_spectral_density_von_karman(fried_parameter_from_Cn_squared(self.Cn_squared, 1), self.L0)
 
 		self.noise_factory = SpectralNoiseFactoryMultiscale(self.psd, self.input_grid, self.oversampling)
-		self.noise = self.noise_factory.make_random()
+		self._noise = self.noise_factory.make_random()
 
-		self._dirty = False
+		self._achromatic_screen = None
 
-	def phase_for(self, wavelength):
-		if self._dirty:
+	@property
+	def noise(self):
+		if self._noise is None:
 			self.reset()
 
+		return self._noise
+
+	@property
+	def achromatic_screen(self):
 		if self._achromatic_screen is None:
 			self._achromatic_screen = self.noise.shifted(self.center)()
 
-		return self._achromatic_screen / wavelength
+		return self._achromatic_screen
+
+	def phase_for(self, wavelength):
+		return self.achromatic_screen / wavelength
 
 	def evolve_until(self, t):
 		self.center = self.velocity * t
@@ -42,7 +63,7 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 	@Cn_squared.setter
 	def Cn_squared(self, Cn_squared):  # noqa: N802
 		self._Cn_squared = Cn_squared
-		self._dirty = True
+		self._noise = None
 
 	@property
 	def outer_scale(self):
@@ -51,4 +72,4 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 	@outer_scale.setter
 	def L0(self, L0):  # noqa: N802
 		self._L0 = L0
-		self._dirty = True
+		self._noise = None

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -12,7 +12,72 @@ import warnings
 import copy
 
 class InfiniteAtmosphericLayer(AtmosphericLayer):
-	def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0, stencil_length=2, use_interpolation=True, seed=None):
+	'''An atmospheric layer that can be infinitely extended in any direction.
+
+	This is an implementation of [Assemat2006]_. Contrary to the
+	FiniteAtmosphericLayer class, this atmospheric layer uses an
+	autoregressive model for extending the phase screen by one
+	column or row in any direction. Each new row/column is based on
+	a  stencil, which contains the last few rows/columns in addition
+	to a few pixels spread out more into the phase screen to capture
+	the low-order aberrations.
+
+	.. [Assemat2006] François Assémat, Richard W. Wilson, and Eric
+		Gendron, "Method for simulating infinitely long and non
+		stationary phase screens with optimized memory storage,"
+		Opt. Express 14, 988-999 (2006)
+
+	.. note::
+		This algorithm does not work well with large outer scales.
+		This is an inherent flaw in the algorithm and so cannot be avoided
+		easily. It requires extremely large-scale correlations to be included
+		in the correlation matrices. These correlation matrices are inverted
+		by the algorithm, leading to ill-defined inversions.
+
+	Parameters
+	----------
+	input_grid : Grid
+		The grid on which the incoming wavefront is defined.
+	Cn_squared : scalar
+		The integrated strength of the turbulence for this layer.
+	L0 : scalar
+		The outer scale for the atmospheric turbulence of this layer.
+		The default is infinity.
+	velocity : scalar or array_like
+		The wind speed for this atmospheric layer. If this is a scalar,
+		the wind will be along x. If this is a 2D array, then the values
+		are interpreted as the wind speed along x and y. The default is
+		zero.
+	height : scalar
+		The height of the atmospheric layer. By itself, this value has no
+		influence, but it'll be used by the AtmosphericModel to perform
+		inter-layer propagations.
+	stencil_length : integer
+		The number of columns/rows to use for the extrapolation of the phase
+		along a column/row. Additionally, the stencil will contain one more
+		pixel a little away from these initial columns/rows. Note, do not
+		modify this parameter unless you know what you are doing. This parameter
+		can be unintuitive. The default value of 2 is usually sufficient in
+		most instances.
+	use_interpolation : boolean
+		whether to use sub-pixel interpolation of the phase screen. Bilinear
+		interpolation is used. Without interpolation, for short integration times
+		or fast loop speeds, the phase screen may stay on the same pixel for
+		multiple frames. With interpolation, these discrete pixel transitions
+		are smoothed out. The default is True.
+	seed : None, int, array of ints, SeedSequence, BitGenerator, Generator
+		A seed to initialize the spectral noise. If None, then fresh, unpredictable
+		entry will be pulled from the OS. If an int or array of ints, then it will
+		be passed to a numpy.SeedSequency to derive the initial BitGenerator state.
+		If a BitGenerator or Generator are passed, these will be wrapped and used
+		instead. Default: None.
+
+	Raises
+	------
+	ValueError
+		When the input grid is not cartesian, regularly spaced and two-dimensional.
+	'''
+	def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0, stencil_length=2, use_interpolation=True, seed=None):
 		self._initialized = False
 
 		AtmosphericLayer.__init__(self, input_grid, Cn_squared, L0, velocity, height)
@@ -177,9 +242,35 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 			self._achromatic_screen = screen.ravel()
 
 	def phase_for(self, wavelength):
+		'''Compute the phase at a certain wavelength.
+
+		Parameters
+		----------
+		wavelength : scalar
+			The wavelength of the light for which to compute the phase screen.
+
+		Returns
+		-------
+		Field
+			The computed phase screen.
+		'''
 		return self._shifted_achromatic_screen / wavelength
 
 	def reset(self, make_independent_realization=False):
+		'''Reset the atmospheric layer to t=0.
+
+		Parameters
+		----------
+		make_independent_realization : boolean
+			Whether to start an independent realization of the noise for the
+			atmospheric layer or not. When this is False, the exact same phase
+			screens will be generated as in the first run, as long as the Cn^2
+			and outer scale are the same. This allows for testing of multiple
+			runs of a control system with different control parameters. When
+			this is True, an independent realization of the atmospheric layer
+			will be generated. This is useful for Monte-Carlo-style computations.
+			The default is False.
+		'''
 		if make_independent_realization:
 			# Reset the original random generator to the current one. This
 			# will essentially reset the randomness.
@@ -195,9 +286,31 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 		self._t = 0
 
 	def evolve_until(self, t):
+		'''Evolve the atmospheric layer until a certain time.
+
+		.. note::
+			Backwards evolution is not allowed. The information about previous
+			parts of the phase screen are inherently lost. If you want to replay the
+			same atmospheric noise again, please use `reset()` to reset the layer
+			to its starting position.
+
+		Parameters
+		----------
+		t : scalar
+			The new time to evolve the phase screen to. This should be larger or equal to
+			the current time of the atmospheric layer.
+
+		Raises
+		------
+		ValueError
+			When the time `t` is smaller than the current time of the layer.
+		'''
 		if t is None:
 			self.reset()
 			return
+
+		if t < self._t:
+			raise ValueError('Backwards temporal evolution is not allowed.')
 
 		# Get the old and new center positions
 		old_center = np.round(self.center / self.input_grid.delta).astype('int')
@@ -241,6 +354,8 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 
 	@property
 	def Cn_squared(self):  # noqa: N802
+		'''The integrated strength of the turbulence for this layer.
+		'''
 		return self._Cn_squared
 
 	@Cn_squared.setter
@@ -249,6 +364,8 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 
 	@property
 	def outer_scale(self):
+		'''The outer scale of the turbulence for this layer.
+		'''
 		return self._L0
 
 	@outer_scale.setter

--- a/hcipy/util/spectral_noise.py
+++ b/hcipy/util/spectral_noise.py
@@ -4,54 +4,89 @@ import copy
 from ..field import Field
 
 class SpectralNoiseFactory(object):
-	def __init__(self, psd, output_grid, psd_args=(), psd_kwargs=None):
-		if psd_kwargs is None:
-			psd_kwargs = {}
+	def __init__(self, psd, output_grid):
+		'''A factory class for spectral noise.
 
+		Parameters
+		----------
+		psd : Field generator
+			The power spectral density of the noise.
+		output_grid : Grid
+			The grid on which to compute the noise.
+		'''
 		self.psd = psd
-		self.psd_args = psd_args
-		self.psd_kwargs = psd_kwargs
 		self.output_grid = output_grid
 
-	def make_random(self):
-		raise NotImplementedError()
+	def make_random(self, seed=None):
+		'''Make a single realization of the spectral noise.
 
-	def make_zero(self):
+		This function needs to be implemented in all child classes.
+
+		Parameters
+		----------
+		seed : None, int, array of ints, SeedSequence, BitGenerator, Generator
+			A seed to initialize the spectral noise. If None, then fresh, unpredictable
+			entry will be pulled from the OS. If an int or array of ints, then it will
+			be passed to a numpy.SeedSequency to derive the initial BitGenerator state.
+			If a BitGenerator or Generator are passed, these will be wrapped and used
+			instead. Default: None.
+		'''
 		raise NotImplementedError()
 
 class SpectralNoise(object):
+	'''A spectral noise object.
+
+	This object should not be used directly, but rather be made by a SpectralNoiseFactory object.
+	'''
 	def copy(self):
+		'''Return a copy.
+
+		Returns
+		-------
+		SpectralNoise
+			A copy of ourselves.
+		'''
 		return copy.deepcopy(self)
 
 	def shift(self, shift):
+		'''Shift the noise along the grid axes.
+
+		This function needs to be implemented by the child class.
+
+		Parameters
+		----------
+		shift : array_like
+			The shift in the grid axes.
+		'''
 		raise NotImplementedError()
 
 	def shifted(self, shift):
+		'''Return a copy, shifted by `shift`.
+
+		Parameters
+		----------
+		shift : array_like
+			The shift in the grid axes.
+
+		Returns
+		-------
+		SpectralNoise
+			A copy of ourselves, shifted by `shift`.
+		'''
 		a = self.copy()
 		a.shift(shift)
-		return a
 
-	def __iadd__(self, b):
-		return NotImplemented
-
-	def __add__(self, b):
-		a = self.copy()
-		a += b
-		return a
-
-	def __imul__(self, f):
-		return NotImplemented
-
-	def __mul__(self, f):
-		a = self.copy()
-		a *= f
 		return a
 
 	def __call__(self):
-		raise NotImplementedError()
+		'''Evaluate the noise on the pre-specified grid.
 
-	def evaluate(self):
-		return self()
+		Returns
+		-------
+		Field
+			The computed spectral noise.
+		'''
+		raise NotImplementedError()
 
 class SpectralNoiseFactoryFFT(SpectralNoiseFactory):
 	def __init__(self, psd, output_grid, oversample=1, psd_args=(), psd_kwargs=None):

--- a/hcipy/util/spectral_noise.py
+++ b/hcipy/util/spectral_noise.py
@@ -30,6 +30,11 @@ class SpectralNoiseFactory(object):
 			be passed to a numpy.SeedSequency to derive the initial BitGenerator state.
 			If a BitGenerator or Generator are passed, these will be wrapped and used
 			instead. Default: None.
+
+		Returns
+		-------
+		SpectralNoise
+			A realization of the spectral noise, that can be shifted and evaluated.
 		'''
 		raise NotImplementedError()
 
@@ -49,7 +54,7 @@ class SpectralNoise(object):
 		return copy.deepcopy(self)
 
 	def shift(self, shift):
-		'''Shift the noise along the grid axes.
+		'''In-place shift the noise along the grid axes.
 
 		This function needs to be implemented by the child class.
 
@@ -80,6 +85,8 @@ class SpectralNoise(object):
 
 	def __call__(self):
 		'''Evaluate the noise on the pre-specified grid.
+
+		This function should be implemented by all child classes.
 
 		Returns
 		-------

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -53,7 +53,7 @@ def check_total_variance(wavelength, D_tel, fried_parameter, outer_scale, propag
 	total_variance = []
 
 	for it in range(num_iterations):
-		layer.reset()
+		layer.reset(make_independent_realization=True)
 		if propagate_phase_screen:
 			layer.t = np.sqrt(2) * D_tel / velocity
 
@@ -90,7 +90,7 @@ def check_zernike_variances(wavelength, D_tel, fried_parameter, outer_scale, pro
 	mode_coeffs = []
 
 	for it in range(num_iterations):
-		layer.reset()
+		layer.reset(make_independent_realization=True)
 		if propagate_phase_screen:
 			layer.t = np.sqrt(2) * D_tel / velocity
 


### PR DESCRIPTION
This PR adds seeds to the spectral noise factories and the atmospheric phase screens. This makes these atmospheric phase screens deterministic.

Fixes #169.

There are a few important choices that had to be made with this PR. Reviewer, beware:
* I replaced the interpretation of a scalar wind velocity. Before, if a scalar velocity was given to an atmospheric layer, the layer would choose a random wind direction and use the given wind velocity with it. With the phase screens needing to be deterministic, I changed this interpretation to a velocity along x. So: after this PR, scalar wind velocities are along x, array wind velocities are along x and y.
* Calling `screen.reset()` resets the phase screen to its initial state. This is true, even when you don't specify a seed. This is a change from before, where `reset()` would create an independent phase screen. This change was made to be consistent with the behaviour of `reset()` when a seed _was_ given.
* This PR adds a parameter to `reset()` to force it to give create a brand-new independent phase screen. This parameter should be set to `True` when the old behaviour is desired.