### PR TITLE
Zoom Fast Fourier Transform and Chirp Z-Transform

### DIFF
--- a/hcipy/fourier/__init__.py
+++ b/hcipy/fourier/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     'make_fourier_transform',
     'FourierTransform',
+    'ChirpZTransform',
     'make_fft_grid',
     'get_fft_parameters',
     'is_fft_grid',
@@ -11,6 +12,7 @@ __all__ = [
 ]
 
 from .fourier_transform import *
+from .chirp_z_transform import *
 from .fast_fourier_transform import *
 from .fourier_operations import *
 from .matrix_fourier_transform import *

--- a/hcipy/fourier/__init__.py
+++ b/hcipy/fourier/__init__.py
@@ -8,7 +8,8 @@ __all__ = [
     'FastFourierTransform',
     'FourierFilter',
     'MatrixFourierTransform',
-    'NaiveFourierTransform'
+    'NaiveFourierTransform',
+    'ZoomFastFourierTransform',
 ]
 
 from .fourier_transform import *
@@ -17,3 +18,4 @@ from .fast_fourier_transform import *
 from .fourier_operations import *
 from .matrix_fourier_transform import *
 from .naive_fourier_transform import *
+from .zoom_fast_fourier_transform import *

--- a/hcipy/fourier/chirp_z_transform.py
+++ b/hcipy/fourier/chirp_z_transform.py
@@ -1,0 +1,84 @@
+import numpy as np
+from scipy.fft import next_fast_len
+
+try:
+	import mkl_fft._numpy_fft as _fft_module
+except ImportError:
+	_fft_module = np.fft
+
+class ChirpZTransform:
+	'''The Chirp Z-transform (CZT).
+
+	This class evaluates:
+
+	.. math:: X_k = \sum_{n=0}^{N-1} x(n) z_k^{-n}
+
+	where :math:`N` is the number of points along the real space, :math:`M`
+	is the number of points in the Z-plane. The Chirp Z-transform samples
+	the Z-plane on equidistant points along spiral arcs, where the arcs are
+	given by the starting point :math:`A` and the complex ratio between points
+	:math:`W`:
+
+	.. math:: z_k = A * W^{-k}, k=0, 1, \ldots, M - 1
+
+	This implementation uses Bluestein's algorithm to compute the CZT using Fast
+	Fourier Transforms.
+
+	Parameters
+	----------
+	n : integer
+		The number of points in the real plane.
+	m : integer
+		The number of points in the Z-plane.
+	w : scalar
+		The complex ratio between points in the Z-plane.
+	a : scalar
+		The starting point in the complex Z-plane.
+	'''
+	def __init__(self, n, m, w, a):
+		self.n = n
+		self.m = m
+		self.w = w
+		self.a = a
+
+		k = np.arange(max(m, n))
+		self.k = k
+
+		wk2 = w**(k**2 / 2)
+
+		self.nfft = next_fast_len(n + m - 1)
+
+		self._Awk2 = a**-k[:n] * wk2[:n]
+		self._Fwk2 = _fft_module.fft(1 / np.hstack((wk2[n - 1:0:-1], wk2[:m])), self.nfft)
+		self._wk2 = wk2[:m]
+		self._yidx = slice(n - 1, n + m - 1)
+
+	def __call__(self, x):
+		'''Compute the Chirp Z-transform along the last axis.
+
+		The input is expected to have `n` points along the last axis.
+		This is assumed but not checked. The transform is multiplexed
+		along all other axes.
+
+		The return value has the same number of axes, with the last axis
+		having `m` elements.
+
+		Parameters
+		----------
+		x : array_like
+			The array to compute the chirp Z-transform for.
+
+		Returns
+		-------
+		array_like
+			The chirp Z-transformed array.
+		'''
+		x = x * self._Awk2
+
+		intermediate = _fft_module.fft(x, self.nfft)
+		intermediate *= self._Fwk2
+		res = _fft_module.ifft(intermediate)
+
+		res = res[..., self._yidx] * self._wk2
+
+		return res

--- a/hcipy/fourier/chirp_z_transform.py
+++ b/hcipy/fourier/chirp_z_transform.py
@@ -31,11 +31,18 @@ class ChirpZTransform:
 	m : integer
 		The number of points in the Z-plane.
 	w : scalar
-		The complex ratio between points in the Z-plane.
+		The complex ratio between points in the Z-plane. Note: ensure that its
+		absolute value is close to one, so that w**(max(n, m)**2) does not
+		overflow.
 	a : scalar
-		The starting point in the complex Z-plane.
+		The starting point in the complex Z-plane. Note: ensure that its absolute
+		value is close to one, so that a**max(n, m) does not overflow.
 	'''
 	def __init__(self, n, m, w, a):
+		# Ensure that w and a are complex scalars.
+		w = complex(w)
+		a = complex(a)
+
 		self.n = n
 		self.m = m
 		self.w = w

--- a/hcipy/fourier/chirp_z_transform.py
+++ b/hcipy/fourier/chirp_z_transform.py
@@ -105,4 +105,5 @@ class ChirpZTransform:
 
 		res = res[..., self._yidx] * self._wk2
 
-		return res
+		_, complex_dtype = _get_float_and_complex_dtype(x.dtype)
+		return res.astype(complex_dtype, copy=False)

--- a/hcipy/fourier/chirp_z_transform.py
+++ b/hcipy/fourier/chirp_z_transform.py
@@ -50,17 +50,32 @@ class ChirpZTransform:
 		self.w = w
 		self.a = a
 
-		k = np.arange(max(m, n))
+		k = np.arange(max(self.m, self.n))
 		self.k = k
 
-		wk2 = w**(k**2 / 2)
+		wk2 = self.w**(self.k**2 / 2)
 
-		self.nfft = next_fast_len(n + m - 1)
+		self.nfft = next_fast_len(self.n + self.m - 1)
 
-		self._Awk2 = a**-k[:n] * wk2[:n]
-		self._Fwk2 = _fft_module.fft(1 / np.hstack((wk2[n - 1:0:-1], wk2[:m])), self.nfft)
-		self._wk2 = wk2[:m]
-		self._yidx = slice(n - 1, n + m - 1)
+		self._Awk2 = self.a**-k[:self.n] * wk2[:self.n]
+		self._Fwk2 = _fft_module.fft(1 / np.hstack((wk2[self.n - 1:0:-1], wk2[:self.m])), self.nfft)
+		self._wk2 = wk2[:self.m]
+		self._yidx = slice(self.n - 1, self.n + self.m - 1)
+
+		self._current_dtype = None
+
+	def _compute_kernel_and_weights(self, dtype):
+		_, complex_dtype = _get_float_and_complex_dtype(dtype)
+
+		if complex_dtype != self._current_dtype:
+
+			self._Awk2_with_dtype = self._Awk2.astype(complex_dtype, copy=False)
+			self._Fwk2_with_dtype = self._Fwk2.astype(complex_dtype, copy=False)
+			self._wk2_with_dtype = self._wk2.astype(complex_dtype, copy=False)
+
+			self._current_dtype = complex_dtype
+
+		return self._Awk2_with_dtype, self._Fwk2_with_dtype, self._wk2_with_dtype
 
 	def __call__(self, x):
 		'''Compute the Chirp Z-transform along the last axis.
@@ -82,12 +97,7 @@ class ChirpZTransform:
 		array_like
 			The chirp Z-transformed array.
 		'''
-		# Set the correct complex and real data type, based on the input data type.
-		float_dtype, complex_dtype = _get_float_and_complex_dtype(x.dtype)
-
-		Awk2 = self._Awk2.astype(complex_dtype, copy=False)
-		Fwk2 = self._Fwk2.astype(complex_dtype, copy=False)
-		wk2 = self._wk2.astype(complex_dtype, copy=False)
+		Awk2, Fwk2, wk2 = self._compute_kernel_and_weights(x.dtype)
 
 		# Perform the CZT.
 		x = x * Awk2

--- a/hcipy/fourier/zoom_fast_fourier_transform.py
+++ b/hcipy/fourier/zoom_fast_fourier_transform.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+from .chirp_z_transform import ChirpZTransform
+from .fourier_transform import FourierTransform
+from ..field import Field
+
+class ZoomFastFourierTransform(FourierTransform):
+	'''A Zoom Fast Fourier transform (ZoomFFT) object.
+
+	This Fourier transform is a specialization of the Chirp Z-transform. It requires
+	both the input and output grid to be regularly spaced in Cartesian coordinates. However,
+	contrary to the Fast Fourier Transform (FFT), the spacing can be arbitrary and a small
+	region of Fourier space can be efficiently evaluated.
+
+	The ZoomFFT is asymptotically faster than a Matrix Fourier Transform (MFT) in cases where
+	both input and output grids are large, typically at 1k x 1k or bigger in each grid. It also
+	supports arbitrary dimenionality of the input and output grids.
+
+	Parameters
+	----------
+	input_grid : Grid
+		The grid that is expected for the input field.
+	output_grid : Grid
+		The grid that is produced by the Fourier transform.
+
+	Raises
+	------
+	ValueError
+		If the input grid is not separated in Cartesian coordinates, if it's not one- or two-
+		dimensional, or if the output grid has a different dimension than the input grid.
+	'''
+	def __init__(self, input_grid, output_grid):
+		if not input_grid.is_regular or not input_grid.is_('cartesian'):
+			raise ValueError('The input grid should be regularly spaced in Cartesian coordinates.')
+		if output_grid.is_regular or not output_grid.is_('cartesian'):
+			raise ValueError('The output grid should be regularly spaced in Cartesian coordinates.')
+		if input_grid.ndim != output_grid.ndim:
+			raise ValueError('The input_grid must have the same dimensions as the output_grid.')
+
+		self.input_grid = input_grid
+		self.output_grid = output_grid
+
+		w = np.exp(-1j * output_grid.delta * input_grid.delta)
+		a = np.exp(1j * output_grid.zero * input_grid.delta)
+
+		inv_w = np.exp(1j * input_grid.delta * output_grid.delta)
+		inv_a = np.exp(-1j * input_grid.zero * output_grid.delta)
+
+		self.czts = [ChirpZTransform(n, m, ww, aa) for n, m, ww, aa in zip(input_grid.dims, output_grid.dims, w, a)]
+		self.inv_czts = [ChirpZTransform(n, m, ww, aa) for n, m, ww, aa in zip(output_grid.dims, input_grid.dims, inv_w, inv_a)]
+
+		self.shifts = np.exp(-1j * np.array(output_grid.separated_coords) * input_grid.zero[:, np.newaxis])
+		self.inv_shifts = np.exp(1j * np.array(input_grid.separated_coords) * output_grid.zero[:, np.newaxis])
+
+	def forward(self, field):
+		'''Returns the forward Fourier transform of the :class:`Field` field.
+
+		Parameters
+		----------
+		field : Field
+			The field to Fourier transform.
+
+		Returns
+		--------
+		Field
+			The Fourier transform of the field.
+		'''
+		f = field.shaped
+
+		for i, (czt, shift) in enumerate(zip(self.czts, self.shifts)):
+			f = np.moveaxis(f, -i, 0)
+			f = czt(f) * shift
+			f = np.moveaxis(f, -i, 0)
+
+		shape = tuple(field.tensor_shape) + (-1,)
+
+		return Field(f.reshape(shape), self.output_grid)
+
+	def backward(self, field):
+		'''Returns the inverse Fourier transform of the :class:`Field` field.
+
+		Parameters
+		----------
+		field : Field
+			The field to inverse Fourier transform.
+
+		Returns
+		--------
+		Field
+			The inverse Fourier transform of the field.
+		'''
+		f = field.shaped
+
+		for i, (czt, shift) in enumerate(zip(self.inv_czts, self.inv_shifts)):
+			f = np.moveaxis(f, -i, 0)
+			f = czt(f) * shift
+			f = np.moveaxis(f, -i, 0)
+
+		shape = tuple(field.tensor_shape) + (-1,)
+
+		return Field(f.reshape(shape), self.input_grid)

--- a/hcipy/fourier/zoom_fast_fourier_transform.py
+++ b/hcipy/fourier/zoom_fast_fourier_transform.py
@@ -32,7 +32,7 @@ class ZoomFastFourierTransform(FourierTransform):
 	def __init__(self, input_grid, output_grid):
 		if not input_grid.is_regular or not input_grid.is_('cartesian'):
 			raise ValueError('The input grid should be regularly spaced in Cartesian coordinates.')
-		if output_grid.is_regular or not output_grid.is_('cartesian'):
+		if not output_grid.is_regular or not output_grid.is_('cartesian'):
 			raise ValueError('The output grid should be regularly spaced in Cartesian coordinates.')
 		if input_grid.ndim != output_grid.ndim:
 			raise ValueError('The input_grid must have the same dimensions as the output_grid.')

--- a/hcipy/fourier/zoom_fast_fourier_transform.py
+++ b/hcipy/fourier/zoom_fast_fourier_transform.py
@@ -55,14 +55,14 @@ class ZoomFastFourierTransform(FourierTransform):
 			self.czts = [ChirpZTransform(n, m, ww, aa) for n, m, ww, aa in zip(self.input_grid.dims, self.output_grid.dims, w, a)]
 			self.inv_czts = [ChirpZTransform(n, m, ww, aa) for n, m, ww, aa in zip(self.output_grid.dims, self.input_grid.dims, inv_w, inv_a)]
 
-			self.shifts = np.exp(-1j * np.array(self.output_grid.separated_coords) * self.input_grid.zero[:, np.newaxis])
-			self.inv_shifts = np.exp(1j * np.array(self.input_grid.separated_coords) * self.output_grid.zero[:, np.newaxis])
+			self.shifts = [np.exp(-1j * x * x0) for x, x0 in zip(self.output_grid.separated_coords, self.input_grid.zero)]
+			self.inv_shifts = [np.exp(1j * x * x0) for x, x0 in zip(self.input_grid.separated_coords, self.output_grid.zero)]
 
-			self.shifts = self.shifts.astype(complex_dtype, copy=False)
-			self.inv_shifts = self.inv_shifts.astype(complex_dtype, copy=False)
+			self.shifts = [s.astype(complex_dtype, copy=False) for s in self.shifts]
+			self.inv_shifts = [s.astype(complex_dtype, copy=False) for s in self.inv_shifts]
 
 			self.input_weights = self.input_grid.weights.astype(float_dtype)
-			self.output_weights = (self.output_grid.weights * (2 * np.pi)**self.output_grid.ndim).astype(float_dtype)
+			self.output_weights = (self.output_grid.weights / (2 * np.pi)**self.output_grid.ndim).astype(float_dtype)
 
 			self._current_dtype = complex_dtype
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 	],
 	install_requires=[
 		"numpy",
-		"scipy>=1.8.0",
+		"scipy",
 		"matplotlib>=2.0.0",
 		"Pillow",
 		"pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 	],
 	install_requires=[
 		"numpy",
-		"scipy",
+		"scipy>=1.8.0",
 		"matplotlib>=2.0.0",
 		"Pillow",
 		"pyyaml",

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -13,9 +13,9 @@ def make_all_fourier_transforms(input_grid, q, fov, shift):
 	mft4 = MatrixFourierTransform(input_grid, fft1.output_grid, precompute_matrices=False, allocate_intermediate=False)
 	nft1 = NaiveFourierTransform(input_grid, fft1.output_grid, precompute_matrices=True)
 	nft2 = NaiveFourierTransform(input_grid, fft1.output_grid, precompute_matrices=False)
-	zfft = ZoomFastFourierTransform(grid, fft1.output_grid)
+	zfft = ZoomFastFourierTransform(input_grid, fft1.output_grid)
 
-	return [fft1, fft2, mft1, mft2, mft3, mft4, nft1, nft2, zft]
+	return [fft1, fft2, mft1, mft2, mft3, mft4, nft1, nft2, zfft]
 
 def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims):
 	grid = make_uniform_grid(dims, 1, has_center=True).shifted(shift_input).scaled(scale)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -1,6 +1,7 @@
 from hcipy import *
 import numpy as np
 import pytest
+from packaging import version
 import scipy.signal
 
 def make_all_fourier_transforms(input_grid, q, fov, shift):
@@ -308,6 +309,8 @@ def check_czt_vs_scipy(x, m, w, a, dtype):
 	assert np.allclose(y_hcipy, y_scipy, rtol=rtol)
 
 @pytest.mark.parametrize('dtype', ['complex128', 'complex64'])
+@pytest.mark.skipif(version.parse(scipy.__version__) < version.parse('1.8.0'),
+                    reason="Requires scipy 1.8.0 or newer")
 def test_chirp_z_transform(dtype):
 	# Fix randomness.
 	np.random.seed(0)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -309,8 +309,10 @@ def check_czt_vs_scipy(x, m, w, a, dtype):
 	assert np.allclose(y_hcipy, y_scipy, rtol=rtol)
 
 @pytest.mark.parametrize('dtype', ['complex128', 'complex64'])
-@pytest.mark.skipif(version.parse(scipy.__version__) < version.parse('1.8.0'),
-	reason="Requires scipy 1.8.0 or newer")
+@pytest.mark.skipif(
+	version.parse(scipy.__version__) < version.parse('1.8.0'),
+	reason="Requires scipy 1.8.0 or newer"
+)
 def test_chirp_z_transform(dtype):
 	# Fix randomness.
 	np.random.seed(0)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -12,8 +12,9 @@ def make_all_fourier_transforms(input_grid, q, fov, shift):
 	mft4 = MatrixFourierTransform(input_grid, fft1.output_grid, precompute_matrices=False, allocate_intermediate=False)
 	nft1 = NaiveFourierTransform(input_grid, fft1.output_grid, precompute_matrices=True)
 	nft2 = NaiveFourierTransform(input_grid, fft1.output_grid, precompute_matrices=False)
+	zfft = ZoomFastFourierTransform(grid, fft1.output_grid)
 
-	return [fft1, fft2, mft1, mft2, mft3, mft4, nft1, nft2]
+	return [fft1, fft2, mft1, mft2, mft3, mft4, nft1, nft2, zft]
 
 def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims):
 	grid = make_uniform_grid(dims, 1, has_center=True).shifted(shift_input).scaled(scale)
@@ -48,11 +49,11 @@ def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, d
 		# When the full fov is retained, the pattern should be the same and energy should
 		# be conserved. We use different accuracy limits based on bit depth.
 		if np.dtype(dtype) == np.dtype('complex128'):
-			assert np.all(patterns_match < 1e-13)
-			assert np.all(np.abs(energy_ratios - 1) < 1e-14)
+			assert np.all(patterns_match < 1e-12)
+			assert np.all(np.abs(energy_ratios - 1) < 1e-12)
 		else:
 			assert np.all(patterns_match < 1e-6)
-			assert np.all(np.abs(energy_ratios - 1) < 1e-6)
+			assert np.all(np.abs(energy_ratios - 1) < 1e-5)
 	else:
 		# If the full fov is not retained, the pattern and energy loss should be the same
 		# for all fourier transform combinations.

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -310,7 +310,7 @@ def check_czt_vs_scipy(x, m, w, a, dtype):
 
 @pytest.mark.parametrize('dtype', ['complex128', 'complex64'])
 @pytest.mark.skipif(version.parse(scipy.__version__) < version.parse('1.8.0'),
-                    reason="Requires scipy 1.8.0 or newer")
+	reason="Requires scipy 1.8.0 or newer")
 def test_chirp_z_transform(dtype):
 	# Fix randomness.
 	np.random.seed(0)


### PR DESCRIPTION
The ZoomFFT is a Fourier transform based on the chirp Z-transform. Asymptotically it is faster than the MFT - since it's implemented using FFTs, its complexity is O(N^2 log(N)) for 2D transforms - the point of equality is only reached at array sizes of 1k x 1k (input) to 1k x 1k (output) or larger.

This Fourier transform will be added to the `make_fourier_transform()` function with a later PR. This PR is just for adding its implementation and the tests to support it long term.

One short-term caveat for the tests: the chirp Z-transform is tested by comparing with the scipy implementation of the CZT. We're not using that implementation since the FFTs that it uses are not accelerated. However, the scipy implementation is only available from version 1.8.0 onwards, which does not support Python 3.7. Therefore, I had to disable the CZT tests when scipy >=1.8.0 is not installed, so only on Python 3.8+. This caveat will be resolved when support for Python 3.7 will be dropped from HCIPy.