### PR TITLE
Fix a typo in docs

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -64,7 +64,7 @@ or
 
 .. code-block:: shell
 
-    pip intall hcipy[dev]
+    pip install hcipy[dev]
 
 depending on the way you originally installed HCIPy. You can then run the full test suite by running the following in the HCIPy directory.
 


### PR DESCRIPTION
Found by Elisa Deflandre, currently interning at LESIA, while installing hcipy for the first time.