### PR TITLE
Remove codecov from dev requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
 	extras_require={
 		"dev": [
 			"pytest",
-			"codecov",
 			"coverage",
 			"mpmath",
 			"dill",


### PR DESCRIPTION
Fixes #184.

CodeCov removed their PyPI package (and profusely apologized for it, see https://about.codecov.io/blog/message-regarding-the-pypi-package/), so we have to drop that dependency. Apparently, they now do not need that package anymore to upload CI results, so we can safely drop that dependency.