### PR TITLE
New-style Fields

### DIFF
--- a/hcipy/config/default_config.yaml
+++ b/hcipy/config/default_config.yaml
@@ -31,3 +31,7 @@ plotting:
 
   # The default colormap for imshow_pupil_phase().
   pupil_phase_colormap: 'RdBu'
+
+core:
+  # Whether to use new-style or old-style fields.
+  use_new_style_fields: false

--- a/hcipy/field/__init__.py
+++ b/hcipy/field/__init__.py
@@ -32,7 +32,8 @@ __all__ = [
     'subsample_field',
     'evaluate_supersampled',
     'make_uniform_vector_field',
-    'make_uniform_vector_field_generator'
+    'make_uniform_vector_field_generator',
+    'is_field',
 ]
 
 from .grid import *

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -1,6 +1,7 @@
 import numpy as np
+from ..config import Configuration
 
-class Field(np.ndarray):
+class OldStyleField(np.ndarray):
 	'''The value of some physical quantity for each point in some coordinate system.
 
 	Parameters
@@ -188,3 +189,11 @@ def _field_reconstruct(subtype, baseclass, baseshape, basetype):
 	grid = None
 
 	return subtype.__new__(subtype, data, grid)
+
+class NewStyleField:
+	pass
+
+if Configuration().core.use_new_style_fields:
+	Field = NewStyleField
+else:
+	Field = OldStyleField

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -171,7 +171,7 @@ class OldStyleField(Field, np.ndarray):
 		tuple
 			The state of the Field.
 		'''
-		data_state = super().__reduce__(self)[2]
+		data_state = np.ndarray.__reduce__(self)[2]
 		return data_state + (self.grid,)
 
 	def __setstate__(self, state):

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -18,7 +18,7 @@ class Field:
 	'''
 	def __new__(cls, arr, grid):
 		if Configuration().core.use_new_style_fields:
-			return NewStyleField.__new__(NewStyleField, arr, grid)
+			return super().__new__(NewStyleField)
 		else:
 			return OldStyleField.__new__(OldStyleField, arr, grid)
 
@@ -59,30 +59,6 @@ class Field:
 		}
 
 		return tree
-
-	def __getstate__(self):
-		'''Get the internal state for pickling.
-
-		Returns
-		-------
-		tuple
-			The state of the Field.
-		'''
-		data_state = super().__reduce__(self)[2]
-		return data_state + (self.grid,)
-
-	def __setstate__(self, state):
-		'''Set the internal state for pickling.
-
-		Parameters
-		----------
-		state : tuple
-			The state coming from a __getstate__().
-		'''
-		_, shp, typ, isf, raw, grid = state
-
-		super().__setstate__((shp, typ, isf, raw))
-		self.grid = grid
 
 	def __reduce__(self):
 		'''Return a 3-tuple for pickling the Field.
@@ -186,6 +162,30 @@ class OldStyleField(Field, np.ndarray):
 		if obj is None:
 			return
 		self.grid = getattr(obj, 'grid', None)
+
+	def __getstate__(self):
+		'''Get the internal state for pickling.
+
+		Returns
+		-------
+		tuple
+			The state of the Field.
+		'''
+		data_state = super().__reduce__(self)[2]
+		return data_state + (self.grid,)
+
+	def __setstate__(self, state):
+		'''Set the internal state for pickling.
+
+		Parameters
+		----------
+		state : tuple
+			The state coming from a __getstate__().
+		'''
+		_, shp, typ, isf, raw, grid = state
+
+		super().__setstate__((shp, typ, isf, raw))
+		self.grid = grid
 
 def _field_reconstruct(subtype, baseclass, baseshape, basetype):
 	'''Internal function for building a new Field object for pickling.

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -2,6 +2,20 @@ import numpy as np
 from ..config import Configuration
 
 class Field:
+	'''The value of some physical quantity for each point in some coordinate system.
+
+	Parameters
+	----------
+	arr : array_like
+		An array of values or tensors for each point in the :class:`Grid`.
+	grid : Grid
+		The corresponding :class:`Grid` on which the values are set.
+
+	Attributes
+	----------
+	grid : Grid
+		The grid on which the values are defined.
+	'''
 	def __new__(cls, arr, grid):
 		if Configuration().core.use_new_style_fields:
 			return NewStyleField.__new__(NewStyleField, arr, grid)

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -366,11 +366,11 @@ class NewStyleField(Field, np.lib.mixins.NDArrayOperatorsMixin):
 	def __len__(self):
 		return len(self.data)
 
-	def conj(self):
-		return np.conj(self)
+	def conj(self, *args, **kwargs):
+		return np.conj(self, *args, **kwargs)
 
-	def conjugate(self):
-		return np.conjugate(self)
+	def conjugate(self, *args, **kwargs):
+		return np.conjugate(self, *args, **kwargs)
 
 	@property
 	def flags(self):

--- a/hcipy/field/operations.py
+++ b/hcipy/field/operations.py
@@ -282,7 +282,7 @@ def field_inverse_truncated_modal(f, num_modes):
 
 		res = np.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
 		for i in range(f.grid.size):
-			res[..., i] = inverse_truncated_modal(f[..., i], num_modes)
+			res[..., i] = inverse_truncated_modal(np.asarray(f[..., i]), num_modes)
 		return Field(res, f.grid)
 	else:
 		return inverse_truncated_modal(f, num_modes)

--- a/hcipy/interpolation/linear.py
+++ b/hcipy/interpolation/linear.py
@@ -27,7 +27,7 @@ def make_linear_interpolator_separated(field, grid=None, fill_value=np.nan):
         field = Field(field, grid)
 
     axes_reversed = np.array(grid.separated_coords)
-    interp = RegularGridInterpolator(axes_reversed, field.shaped, 'linear', False, fill_value)
+    interp = RegularGridInterpolator(axes_reversed, np.asarray(field.shaped), 'linear', False, fill_value)
 
     def interpolator(evaluated_grid):
         evaluated_coords = np.flip(np.array(evaluated_grid.coords), 0)
@@ -62,7 +62,7 @@ def make_linear_interpolator_unstructured(field, grid=None, fill_value=np.nan):
     else:
         field = Field(field, grid)
 
-    interp = LinearNDInterpolator(grid.points, field, fill_value)
+    interp = LinearNDInterpolator(grid.points, np.asarray(field), fill_value)
 
     def interpolator(evaluated_grid):
         res = interp(evaluated_grid.points)

--- a/hcipy/mode_basis/mode_basis.py
+++ b/hcipy/mode_basis/mode_basis.py
@@ -41,9 +41,9 @@ class ModeBasis(object):
                 self._transformation_matrix = transformation_matrix.tocsc()
         else:
             if is_list:
-                self._transformation_matrix = np.stack(transformation_matrix, axis=-1)
+                self._transformation_matrix = np.asarray(np.stack(transformation_matrix, axis=-1))
             else:
-                self._transformation_matrix = transformation_matrix
+                self._transformation_matrix = np.asarray(transformation_matrix)
 
         if grid is not None:
             self.grid = grid

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -150,7 +150,7 @@ def test_field_inverse_truncated_modal():
         BB = np.empty_like(B)
 
         for i in range(grid.size):
-            BB[..., i] = inverse_truncated_modal(A[..., i], num_modes)
+            BB[..., i] = inverse_truncated_modal(np.asarray(A[..., i]), num_modes)
 
         assert np.allclose(B, BB)
 


### PR DESCRIPTION
This PR starts the transition to a new implementation of Fields that is more amenable to backend changes later on. We will refer to the current style of Fields as OldStyleField and the new implementation as NewStyleField. The OldStyleFields are based on [subclassing numpy arrays](https://numpy.org/doc/stable/user/basics.subclassing.html). At the time HCIPy was written, subclassing was the only way to associate a Grid with a Field. Subclassing has several disadvantages, most notably that we fully rely on Numpy to "remember" that the array is in fact a Field. This has been a problem early-on, with the `np.angle()` function, which would not properly call `__array_finalize__()`. 

Recent NEPs have made it more and more possible to avoid subclassing, and instead create a completely new class that behaves just like a numpy array. This approach has been successfully used by Dask, CuPy and others, and is now fully mature. The NewStyleField class uses this implementation, with a `Field.data` attribute that contains the values and a `Field.grid` attribute that contains the grid as before.

Since this is a huge transition, that will affect everyone if done improperly, this will be done with feature flags, which will be turned off for now. This allows everyone to test their code, on an opt-in basis, until we deem that the feature is mature enough to enable by default. Even later, the old-style fields and the corresponding feature flag will be removed.

Open questions:
- [x] How to properly test with feature flags? Currently, tests are only run for the default configuration. Tests should most likely be run for both old- and new-style Fields.