### PR TITLE
FPS changed to duration in imageio dependency

### DIFF
--- a/hcipy/plotting/animation.py
+++ b/hcipy/plotting/animation.py
@@ -163,7 +163,7 @@ class GifWriter(object):
 	def convert(self):
 		'''Convert all frames into a gif file.
 		'''
-		imageio.mimsave(self.filename, self._frames, fps=self.framerate)
+		imageio.mimsave(self.filename, self._frames, duration=1 / self.framerate)
 
 	def close(self):
 		'''Close the animation and create the final gif file.


### PR DESCRIPTION
FPS was removed with imageio 2.28.0. I haven't been able to track down which commit exactly, but both fps and duration have been allowed before, so there is no disadvantage against changing this.