### PR TITLE
Fix `reset()` for atmospheric layers

### DIFF
--- a/hcipy/atmosphere/finite_atmospheric_layer.py
+++ b/hcipy/atmosphere/finite_atmospheric_layer.py
@@ -80,7 +80,7 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
 		self.psd = power_spectral_density_von_karman(fried_parameter_from_Cn_squared(self.Cn_squared, 1), self.L0)
 
 		self.noise_factory = SpectralNoiseFactoryMultiscale(self.psd, self.input_grid, self.oversampling)
-		self._noise = self.noise_factory.make_random()
+		self._noise = self.noise_factory.make_random(self.rng)
 
 		self._achromatic_screen = None
 

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -202,12 +202,12 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 
 		layer = FiniteAtmosphericLayer(self.input_grid, self.Cn_squared, self.outer_scale, self.velocity, self.height, oversampling, self.rng)
 
+		self._achromatic_screen = layer.phase_for(1)
+		self._shifted_achromatic_screen = self._achromatic_screen
+
 		# Reuse the rng from the temporary layer, since it "forwarded" the randomness.
 		# This avoids reusing the same randomness every call to reset().
 		self.rng = layer.rng
-
-		self._achromatic_screen = layer.phase_for(1)
-		self._shifted_achromatic_screen = self._achromatic_screen
 
 	def _extrude(self, where=None):
 		flipped = (where == 'top') or (where == 'right')

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -202,6 +202,10 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 
 		layer = FiniteAtmosphericLayer(self.input_grid, self.Cn_squared, self.outer_scale, self.velocity, self.height, oversampling, self.rng)
 
+		# Reuse the rng from the temporary layer, since it "forwarded" the randomness.
+		# This avoids reusing the same randomness every call to reset().
+		self.rng = layer.rng
+
 		self._achromatic_screen = layer.phase_for(1)
 		self._shifted_achromatic_screen = self._achromatic_screen
 


### PR DESCRIPTION
Fixes #189 and adds a test to ensure that this bug will keep being fixed in the future.

Thanks to @Oswald522 for providing some test code that made this super easy to debug and fix.