### PR TITLE
replace asdf.fits_embed

### DIFF
--- a/hcipy/util/io.py
+++ b/hcipy/util/io.py
@@ -156,11 +156,11 @@ def read_grid(filename, fmt=None):
 			raise ValueError('Format not given and could not be guessed based on the file extension.')
 
 	if fmt == 'fits':
-		with fits.open(filename) as f:
+		with fits.open(filename, memmap=False) as f:
 			af = _bintable_to_asdf(f['ASDF'])
 			return Grid.from_dict(af.tree['grid'])
 	elif fmt == 'asdf':
-		with asdf.open(filename) as f:
+		with asdf.open(filename, copy_arrays=True) as f:
 			return Grid.from_dict(f.tree['grid'])
 	elif fmt == 'pickle':
 		with open(filename, 'rb') as f:
@@ -238,10 +238,10 @@ def read_field(filename, fmt=None):
 			raise ValueError('Format not given and could not be guessed based on the file extension.')
 
 	if fmt == 'asdf':
-		with asdf.open(filename) as f:
+		with asdf.open(filename, copy_arrays=True) as f:
 			return Field.from_dict(f.tree['field'])
 	elif fmt == 'fits':
-		with fits.open(filename) as f:
+		with fits.open(filename, memmap=False) as f:
 			af = _bintable_to_asdf(f['ASDF'])
 			tree = af.tree['field']
 			if f[0].data is not None:
@@ -343,10 +343,10 @@ def read_mode_basis(filename, fmt=None):
 			raise ValueError('Format not given and could not be guessed based on the file extension.')
 
 	if fmt == 'asdf':
-		with asdf.open(filename) as f:
+		with asdf.open(filename, copy_arrays=True) as f:
 			return ModeBasis.from_dict(f.tree['mode_basis'])
 	elif fmt == 'fits':
-		with fits.open(filename) as f:
+		with fits.open(filename, memmap=False) as f:
 			af = _bintable_to_asdf(f['ASDF'])
 			tree = af.tree['mode_basis']
 

--- a/hcipy/util/io.py
+++ b/hcipy/util/io.py
@@ -238,11 +238,8 @@ def read_field(filename, fmt=None):
 			raise ValueError('Format not given and could not be guessed based on the file extension.')
 
 	if fmt == 'asdf':
-		f = asdf.open(filename)
-		field = Field.from_dict(f.tree['field'])
-		f.close()
-
-		return field
+		with asdf.open(filename) as f:
+			return Field.from_dict(f.tree['field'])
 	elif fmt == 'fits':
 		with fits.open(filename) as f:
 			af = _bintable_to_asdf(f['ASDF'])
@@ -346,11 +343,8 @@ def read_mode_basis(filename, fmt=None):
 			raise ValueError('Format not given and could not be guessed based on the file extension.')
 
 	if fmt == 'asdf':
-		f = asdf.open(filename)
-		mode_basis = ModeBasis.from_dict(f.tree['mode_basis'])
-		f.close()
-
-		return mode_basis
+		with asdf.open(filename) as f:
+			return ModeBasis.from_dict(f.tree['mode_basis'])
 	elif fmt == 'fits':
 		with fits.open(filename) as f:
 			af = _bintable_to_asdf(f['ASDF'])


### PR DESCRIPTION
asdf 3.0 removed the deprecated `AsdfInFits` (and `asdf.fits_embed`) used here to read/write fits files (see https://asdf.readthedocs.io/en/3.0.1/asdf/whats_new.html#whats-new-3-0-0 for descriptions of other changes).

This PR replaces uses of `asdf.fits_embed` with equivalent code. This was tested locally by modifying:
- test_grid_io
- test_field_io
- test_mode_basis_io
To save all test files (and not remove them after the test passed). Test files were generated with hcipy main and asdf 2.15.2 (we'll call these 'old' files) and with hcipy using this PR and asdf 3.0.1 ('new' files). hcipy main with asdf 2.15.2 could read both new and old files as could hcipy with this PR and asdf 3.0.1.

If there are static files that aren't captured by these tests it would be helpful to test those files with this PR to verify that the updated code can open all files generated with older versions of hcipy.