### PR TITLE
Fix utcnow() deprecation in Python 3.12.

### DIFF
--- a/hcipy/util/io.py
+++ b/hcipy/util/io.py
@@ -120,7 +120,7 @@ def _make_metadata(file_type):
 	tree = {
 		'meta': {
 			'author': 'HCIPy %s' % _version,
-			'date_utc': datetime.datetime.utcnow().isoformat(),
+			'date_utc': datetime.datetime.now(datetime.timezone.utc).isoformat(),
 			'file_type': file_type
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/ehpor/hcipy/issues/200