### PR TITLE
Lyot coronagraph fix

### DIFF
--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -12,6 +12,10 @@ class LyotCoronagraph(OpticalElement):
 	.. [Soummer2007] Soummer et al. 2007, "Fast computation of Lyot-style
 		coronagraph propagation".
 
+	.. notes:: The LyotCoroonagraph tries to automatically get the grid from the focal_plane_mask.
+		However, a bug in AgnosticOpticalElements creates an invalid access which crashes the initialization.
+		The correct grid can be passed explicitely to circumvent this bug by using the focal_plane_mask_grid parameter.
+
 	Parameters
 	----------
 	input_grid : Grid
@@ -25,25 +29,25 @@ class LyotCoronagraph(OpticalElement):
 		this will be used instead. This allows for more realistic implementations of Lyot stops.
 	focal_length : scalar
 		The internal focal length of the Lyot system.
-	coronagraphic_focal_grid : Grid
+	focal_plane_mask_grid : Grid
 		The grid on which the focal plane mask is defined. If this is none,
 		the grid will be determined from the focal plane mask. The default value is None.
 	'''
-	def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1, coronagraphic_focal_grid=None):
+	def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1, focal_plane_mask_grid=None):
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
-			if coronagraphic_focal_grid is None:
+			if focal_plane_mask_grid is None:
 				grid = focal_plane_mask.apodization.grid
 			else:
-				grid = coronagraphic_focal_grid
+				grid = focal_plane_mask_grid
 
 			self.focal_plane_mask = focal_plane_mask
 		else:
 			# Focal plane mask is a field.
-			if coronagraphic_focal_grid is None:
+			if focal_plane_mask_grid is None:
 				grid = focal_plane_mask.grid
 			else:
-				grid = coronagraphic_focal_grid
+				grid = focal_plane_mask_grid
 
 			self.focal_plane_mask = Apodizer(focal_plane_mask)
 
@@ -116,6 +120,10 @@ class OccultedLyotCoronagraph(OpticalElement):
 
 	The area outside of this focal-plane mask is assumed to be fully absorbing.
 
+	.. notes:: The LyotCoroonagraph tries to automatically get the grid from the focal_plane_mask.
+		However, a bug in AgnosticOpticalElements creates an invalid access which crashes the initialization.
+		The correct grid can be passed explicitely to circumvent this bug by using the focal_plane_mask_grid parameter
+
 	Parameters
 	----------
 	input_grid : Grid
@@ -129,26 +137,26 @@ class OccultedLyotCoronagraph(OpticalElement):
 		this will be used instead. This allows for more realistic implementations of Lyot stops.
 	focal_length : scalar
 		The internal focal length of the Lyot system.
-	coronagraphic_focal_grid : Grid
+	focal_plane_mask_grid : Grid
 		The grid on which the focal plane mask is defined. If this is none,
 		the grid will be determined from the focal plane mask. The default value is None.
 	'''
-	def __init__(self, input_grid, focal_plane_mask, focal_length=1, coronagraphic_focal_grid=None):
+	def __init__(self, input_grid, focal_plane_mask, focal_length=1, focal_plane_mask_grid=None):
 
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
-			if coronagraphic_focal_grid is None:
+			if focal_plane_mask_grid is None:
 				grid = focal_plane_mask.apodization.grid
 			else:
-				grid = coronagraphic_focal_grid
+				grid = focal_plane_mask_grid
 
 			self.focal_plane_mask = focal_plane_mask
 		else:
 			# Focal plane mask is a field.
-			if coronagraphic_focal_grid is None:
+			if focal_plane_mask_grid is None:
 				grid = focal_plane_mask.grid
 			else:
-				grid = coronagraphic_focal_grid
+				grid = focal_plane_mask_grid
 
 			self.focal_plane_mask = Apodizer(focal_plane_mask)
 

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -33,7 +33,7 @@ class LyotCoronagraph(OpticalElement):
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
 			if coronagraphic_focal_grid is None:
-				grid = focal_plane_mask.apodization.grid 
+				grid = focal_plane_mask.apodization.grid
 			else:
 				grid = coronagraphic_focal_grid
 
@@ -41,7 +41,7 @@ class LyotCoronagraph(OpticalElement):
 		else:
 			# Focal plane mask is a field.
 			if coronagraphic_focal_grid is None:
-				grid = focal_plane_mask.grid 
+				grid = focal_plane_mask.grid
 			else:
 				grid = coronagraphic_focal_grid
 
@@ -138,7 +138,7 @@ class OccultedLyotCoronagraph(OpticalElement):
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
 			if coronagraphic_focal_grid is None:
-				grid = focal_plane_mask.apodization.grid 
+				grid = focal_plane_mask.apodization.grid
 			else:
 				grid = coronagraphic_focal_grid
 
@@ -146,7 +146,7 @@ class OccultedLyotCoronagraph(OpticalElement):
 		else:
 			# Focal plane mask is a field.
 			if coronagraphic_focal_grid is None:
-				grid = focal_plane_mask.grid 
+				grid = focal_plane_mask.grid
 			else:
 				grid = coronagraphic_focal_grid
 

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -133,7 +133,7 @@ class OccultedLyotCoronagraph(OpticalElement):
 		The grid on which the focal plane mask is defined. If this is none,
 		the grid will be determined from the focal plane mask. The default value is None.
 	'''
-	def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1, coronagraphic_focal_grid=None):
+	def __init__(self, input_grid, focal_plane_mask, focal_length=1, coronagraphic_focal_grid=None):
 
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -41,7 +41,7 @@ class LyotCoronagraph(OpticalElement):
 		else:
 			# Focal plane mask is a field.
 			if coronagraphic_focal_grid is None:
-				grid = focal_plane_mask.apodization.grid 
+				grid = focal_plane_mask.grid 
 			else:
 				grid = coronagraphic_focal_grid
 
@@ -146,7 +146,7 @@ class OccultedLyotCoronagraph(OpticalElement):
 		else:
 			# Focal plane mask is a field.
 			if coronagraphic_focal_grid is None:
-				grid = focal_plane_mask.apodization.grid 
+				grid = focal_plane_mask.grid 
 			else:
 				grid = coronagraphic_focal_grid
 

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -29,7 +29,7 @@ class LyotCoronagraph(OpticalElement):
 		The grid on which the focal plane mask is defined. If this is none,
 		the grid will be determined from the focal plane mask. The default value is None.
 	'''
-	def __init__(self, input_grid, focal_plane_mask, focal_length=1, coronagraphic_focal_grid=None):
+	def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1, coronagraphic_focal_grid=None):
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
 			if coronagraphic_focal_grid is None:

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -25,15 +25,26 @@ class LyotCoronagraph(OpticalElement):
 		this will be used instead. This allows for more realistic implementations of Lyot stops.
 	focal_length : scalar
 		The internal focal length of the Lyot system.
+	coronagraphic_focal_grid : Grid
+		The grid on which the focal plane mask is defined. If this is none,
+		the grid will be determined from the focal plane mask. The default value is None.
 	'''
-	def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1):
+	def __init__(self, input_grid, focal_plane_mask, focal_length=1, coronagraphic_focal_grid=None):
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
-			grid = focal_plane_mask.input_grid
+			if coronagraphic_focal_grid is None:
+				grid = focal_plane_mask.apodization.grid 
+			else:
+				grid = coronagraphic_focal_grid
+
 			self.focal_plane_mask = focal_plane_mask
 		else:
 			# Focal plane mask is a field.
-			grid = focal_plane_mask.grid
+			if coronagraphic_focal_grid is None:
+				grid = focal_plane_mask.apodization.grid 
+			else:
+				grid = coronagraphic_focal_grid
+
 			self.focal_plane_mask = Apodizer(focal_plane_mask)
 
 		if lyot_stop is not None and not hasattr(lyot_stop, 'input_grid'):
@@ -118,15 +129,27 @@ class OccultedLyotCoronagraph(OpticalElement):
 		this will be used instead. This allows for more realistic implementations of Lyot stops.
 	focal_length : scalar
 		The internal focal length of the Lyot system.
+	coronagraphic_focal_grid : Grid
+		The grid on which the focal plane mask is defined. If this is none,
+		the grid will be determined from the focal plane mask. The default value is None.
 	'''
-	def __init__(self, input_grid, focal_plane_mask, focal_length=1):
+	def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1, coronagraphic_focal_grid=None):
+
 		if hasattr(focal_plane_mask, 'input_grid'):
 			# Focal plane mask is an optical element.
-			grid = focal_plane_mask.input_grid
+			if coronagraphic_focal_grid is None:
+				grid = focal_plane_mask.apodization.grid 
+			else:
+				grid = coronagraphic_focal_grid
+
 			self.focal_plane_mask = focal_plane_mask
 		else:
 			# Focal plane mask is a field.
-			grid = focal_plane_mask.grid
+			if coronagraphic_focal_grid is None:
+				grid = focal_plane_mask.apodization.grid 
+			else:
+				grid = coronagraphic_focal_grid
+
 			self.focal_plane_mask = Apodizer(focal_plane_mask)
 
 		self.prop = FraunhoferPropagator(input_grid, grid, focal_length=focal_length)


### PR DESCRIPTION
This pull request fixes the bug in #177. I added an explicit parameter to pass the coronagraphic focal grid to the lyot coronagraph. And I have also changed how the grid is determined when an optical element is passed into the function. The function now works with any derivative of the Apodizer class, which should capture 95% of all cases. The other cases will still work if they pass the focal grid explicitely.