### PR TITLE
Preserve asdf.fits_embed import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "xxhash",
     "numexpr",
     "asdf<=2.10 ; python_version<='3.7'",
-    "asdf ; python_version>'3.7'",
+    "asdf<3.0 ; python_version>'3.7'",
     "importlib_metadata ; python_version<'3.7'",
     "importlib_resources>=1.4 ; python_version<'3.9'"
 ]


### PR DESCRIPTION
Fresh installs of HCIPy won't import due to a `ModuleNotFoundError`:

```
File [~/Sys/miniconda3/lib/python3.11/site-packages/hcipy/__init__.py:5]
      [1] # flake8: noqa
      [2]
      [3] # Import all submodules.
      [4] from . import aperture
----> [5] from . import atmosphere
      [6] from . import config
      [7] from . import coronagraphy

File [~/Sys/miniconda3/lib/python3.11/site-packages/hcipy/atmosphere/__init__.py:18]
      [1] __all__ = [
      [2] 	'MultiLayerAtmosphere',
      [3] 	'AtmosphericLayer',
   (...)
     [15] 	'make_las_campanas_atmospheric_layers'
     [16] ]
---> [18] from .atmospheric_model import *
     [19] from .finite_atmospheric_layer import *
...
----> [6] import asdf.fits_embed
      [7] from astropy import wcs
      [8] from astropy.io import fits

ModuleNotFoundError: No module named 'asdf.fits_embed'
```

ASDF has deprecated the fits_embed module in v3.0: https://asdf.readthedocs.io/en/3.0.1/asdf/deprecations.html#asdf-in-fits-deprecation



This commit pins the ASDF version to < 3.0 to keep HCIPy installable. In the longer term, it would probably be advisable to migrate to [stdatamodels](https://stdatamodels.readthedocs.io/en/latest/asdf_in_fits.html) (the recommended replacement for `asdf.fits_embed`)