### PR TITLE
Grid coords should be Fields

### DIFF
--- a/hcipy/field/cartesian_grid.py
+++ b/hcipy/field/cartesian_grid.py
@@ -1,6 +1,8 @@
 import numpy as np
-from .grid import Grid
+
 from .coordinates import UnstructuredCoords
+from .field import Field
+from .grid import Grid
 
 from functools import reduce
 import operator
@@ -37,25 +39,25 @@ class CartesianGrid(Grid):
     def x(self):
         '''The x-coordinate (dimension 0).
         '''
-        return self.coords[0]
+        return Field(self.coords[0], self)
 
     @property
     def y(self):
         '''The y-coordinate (dimension 1).
         '''
-        return self.coords[1]
+        return Field(self.coords[1], self)
 
     @property
     def z(self):
         '''The z-coordinate (dimension 2).
         '''
-        return self.coords[2]
+        return Field(self.coords[2], self)
 
     @property
     def w(self):
         '''The w-coordinate (dimension 3).
         '''
-        return self.coords[3]
+        return Field(self.coords[3], self)
 
     def scale(self, scale):
         '''Scale the grid in-place.

--- a/hcipy/field/coordinates.py
+++ b/hcipy/field/coordinates.py
@@ -229,7 +229,7 @@ class UnstructuredCoords(Coords):
         boolean
             Whether the two objects are identical.
         '''
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         return np.array_equal(self.coords, other.coords)
@@ -361,7 +361,7 @@ class SeparatedCoords(Coords):
         boolean
             Whether the two objects are identical.
         '''
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         return np.array_equal(self.separated_coords, other.separated_coords)
@@ -519,7 +519,7 @@ class RegularCoords(Coords):
         boolean
             Whether the two objects are identical.
         '''
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         return np.array_equal(self.regular_coords, other.regular_coords)

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -408,4 +408,19 @@ class NewStyleField(Field, np.lib.mixins.NDArrayOperatorsMixin):
     var = np.var
 
 def is_field(obj):
+    '''Check if the object is an HCIPy Field.
+
+    This function should be preferred over of `isinstance(obj, hcipy.Field)` for
+    forward compatibility reasons.
+
+    Parameters
+    ----------
+    obj : Any
+        Any object to check.
+
+    Returns
+    -------
+    boolean
+        Whether `obj` is an HCIPy Field or not.
+    '''
     return isinstance(obj, Field)

--- a/hcipy/field/polar_grid.py
+++ b/hcipy/field/polar_grid.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from .field import Field
 from .grid import Grid
 from .coordinates import UnstructuredCoords
 
@@ -12,13 +13,13 @@ class PolarGrid(Grid):
     def r(self):
         '''The radial coordinate (dimension 0).
         '''
-        return self.coords[0]
+        return Field(self.coords[0], self)
 
     @property
     def theta(self):
         ''' The angular coordinate (dimension 1).
         '''
-        return self.coords[1]
+        return Field(self.coords[1], self)
 
     def scale(self, scale):
         '''Scale the grid in-place.


### PR DESCRIPTION
Before this PR: `CartesianGrid.x` was a Numpy array, not a Field. This requires the user to cast to a Field after evaluating basic functions like
```
Field(np.sin(grid.x), grid)
```

This PR fixes that problem. The new syntax would be
```
np.sin(grid.x)
```

I'm also fixing type equality tests which were done using `!=` rather than `is not`.