### PR TITLE
Make unit tests smaller and use tmpdir for file output.

### DIFF
--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -62,28 +62,27 @@ def check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, d
         assert np.allclose(patterns_match, patterns_match[0, 0])
 
 @pytest.mark.parametrize('dtype', ['complex128', 'complex64'])
-def test_fourier_energy_conservation_1d(dtype):
+@pytest.mark.parametrize('shift_input', [0, 0.1])
+@pytest.mark.parametrize('scale', [1, 2])
+@pytest.mark.parametrize('shift_output', [0, 0.1])
+@pytest.mark.parametrize('q', [1, 1.23, 3, 4])
+@pytest.mark.parametrize('fov', [1, 0.5, 0.8])
+@pytest.mark.parametrize('dims', [64, 65])
+def test_fourier_energy_conservation_1d(dtype, shift_input, scale, shift_output, q, fov, dims):
     np.random.seed(0)
 
-    for shift_input in [0, 0.1]:
-        for scale in [1, 2]:
-            for shift_output in [0, 0.1]:
-                for q in [1, 1.23, 3, 4]:
-                    for fov in [1, 0.5, 0.8]:
-                        for dims in [64, 65]:
-                            check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims)
+    check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims)
 
 @pytest.mark.parametrize('dtype', ['complex128', 'complex64'])
-def test_fourier_energy_conservation_2d(dtype):
+@pytest.mark.parametrize('shift_input', [[0, 0], [0.1]])
+@pytest.mark.parametrize('scale', [1, 2])
+@pytest.mark.parametrize('shift_output', [[0, 0], [0.1]])
+@pytest.mark.parametrize('q', [1, 1.23, 3, 4])
+@pytest.mark.parametrize('fov', [1, 0.5, 0.8])
+@pytest.mark.parametrize('dims', [[8, 8], [8, 16], [9, 9], [9, 18]])
+def test_fourier_energy_conservation_2d(dtype, shift_input, scale, shift_output, q, fov, dims):
     np.random.seed(0)
-
-    for shift_input in [[0, 0], [0.1]]:
-        for scale in [1, 2]:
-            for shift_output in [[0, 0], [0.1]]:
-                for q in [1, 1.23, 3, 4]:
-                    for fov in [1, 0.5, 0.8]:
-                        for dims in [[8, 8], [8, 16], [9, 9], [9, 18]]:
-                            check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims)
+    check_energy_conservation(dtype, shift_input, scale, shift_output, q, fov, dims)
 
 def check_symmetry(dtype, scale, shift_output, q, fov, dims):
     tol = 1e-12 if dtype == 'complex128' else 1e-6

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -43,34 +43,34 @@ def check_animation(mw, style):
     pytest.raises(RuntimeError, mw.add_frame)
 
 @pytest.mark.parametrize('style', ['mpl', 'fig', 'img'])
-def test_frame_writer(style):
-    mw = FrameWriter('test_frames/')
+def test_frame_writer(style, tmpdir):
+    dirname = os.path.join(tmpdir, 'test_frames/')
+    mw = FrameWriter(dirname)
 
     check_animation(mw, style=style)
 
-    assert os.path.isdir('test_frames')
-    shutil.rmtree('test_frames')
+    assert os.path.isdir(dirname)
 
 @pytest.mark.parametrize('style', ['mpl', 'fig', 'img'])
-def test_gif_writer(style):
-    mw = GifWriter('test.gif')
+def test_gif_writer(style, tmpdir):
+    fname = os.path.join(tmpdir, 'test.gif')
+    mw = GifWriter(fname)
 
     check_animation(mw, style=style)
 
-    assert os.path.isfile('test.gif')
-    os.remove('test.gif')
+    assert os.path.isfile(fname)
 
 @pytest.mark.parametrize('style', ['mpl', 'fig', 'img'])
 @pytest.mark.skipif(not is_ffmpeg_installed(), reason='FFMpeg is not installed.')
-def test_ffmpeg_writer(style):
-    mw = FFMpegWriter('test.mp4')
+def test_ffmpeg_writer(style, tmpdir):
+    fname = os.path.join(tmpdir, 'test.mp4')
+    mw = FFMpegWriter(fname)
 
     check_animation(mw, style=style)
 
     assert mw._repr_html_()
 
-    assert os.path.isfile('test.mp4')
-    os.remove('test.mp4')
+    assert os.path.isfile(fname)
 
 def test_imshow_field():
     grid = make_pupil_grid(256)

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -61,7 +61,25 @@ def test_fraunhofer_propagation_rectangular():
                         # This should never happen.
                         assert False
 
-def single_propagation_test(propagator, number_of_pixels, wavelength, a, b, relative_distance, error_threshold):
+@pytest.mark.parametrize('propagator', [FresnelPropagator, AngularSpectrumPropagator])
+@pytest.mark.parametrize('number_of_pixels', [
+    pytest.param(512),
+    pytest.param(1024, marks=pytest.mark.slow)
+])
+@pytest.mark.parametrize('wavelength', [
+    pytest.param(500e-9),
+    pytest.param(700e-9, marks=pytest.mark.slow)
+])
+@pytest.mark.parametrize('a, b', [
+    pytest.param(0.001, 0.001),
+    pytest.param(0.0015, 0.001, marks=pytest.mark.slow)
+])
+@pytest.mark.parametrize('relative_distance,error_threshold', [
+    pytest.param(0.2, 0.02),
+    pytest.param(1, 0.01, marks=pytest.mark.slow),
+    pytest.param(5, 0.01)
+])
+def test_nearfield_propagation_rectangular(propagator, number_of_pixels, wavelength, a, b, relative_distance, error_threshold):
     wavenumber = 2 * np.pi / wavelength
 
     pupil_grid = make_pupil_grid(number_of_pixels, [16 * a, 16 * b])
@@ -118,33 +136,3 @@ def single_propagation_test(propagator, number_of_pixels, wavelength, a, b, rela
 
     absolute_error_backward = np.abs(img_backward - reference_image).max()
     assert absolute_error_backward < error_threshold
-
-def test_fresnel_propagation_rectangular_quick():
-    for num_pix in [512]:
-        for wavelength in [500e-9]:
-            for a, b in [[0.001, 0.001]]:
-                for relative_distance, error_threshold in zip([0.2, 5], [0.02, 0.01]):
-                    single_propagation_test(FresnelPropagator, num_pix, wavelength, a, b, relative_distance, error_threshold)
-
-def test_asp_propagation_rectangular_quick():
-    for num_pix in [512]:
-        for wavelength in [500e-9]:
-            for a, b in [[0.001, 0.001]]:
-                for relative_distance, error_threshold in zip([0.2, 5], [0.02, 0.01]):
-                    single_propagation_test(AngularSpectrumPropagator, num_pix, wavelength, a, b, relative_distance, error_threshold)
-
-@pytest.mark.slow
-def test_fresnel_propagation_rectangular():
-    for num_pix in [512, 1024]:
-        for wavelength in [500e-9, 700e-9]:
-            for a, b in [[0.001, 0.001], [0.0015, 0.001]]:
-                for relative_distance, error_threshold in zip([0.2, 1, 5], [0.02, 0.01, 0.01]):
-                    single_propagation_test(FresnelPropagator, num_pix, wavelength, a, b, relative_distance, error_threshold)
-
-@pytest.mark.slow
-def test_asp_propagation_rectangular():
-    for num_pix in [512, 1024]:
-        for wavelength in [500e-9, 700e-9]:
-            for a, b in [[0.001, 0.001], [0.0015, 0.001]]:
-                for relative_distance, error_threshold in zip([0.2, 1, 5], [0.02, 0.01, 0.01]):
-                    single_propagation_test(AngularSpectrumPropagator, num_pix, wavelength, a, b, relative_distance, error_threshold)


### PR DESCRIPTION
Smaller tests make parallel execution of tests faster. Also, it enables better output when the tests fail.

Using tmpdir for file output also enables running tests in parallel.