### PR TITLE
Fix removed `copy_arrays` parameter in asdf 4.0.0.

### DIFF
--- a/hcipy/util/io.py
+++ b/hcipy/util/io.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 import pickle
+import packaging
 
 import numpy as np
 import asdf
@@ -14,6 +15,9 @@ try:
     from .._version import version as _version
 except ImportError:
     _version = ''
+
+
+use_asdf_memmap = packaging.version.parse(asdf.__version__) >= packaging.version.parse('3.1.0')
 
 
 def _asdf_to_bintable(af, *args, **kwargs):
@@ -160,7 +164,8 @@ def read_grid(filename, fmt=None):
             af = _bintable_to_asdf(f['ASDF'])
             return Grid.from_dict(af.tree['grid'])
     elif fmt == 'asdf':
-        with asdf.open(filename, copy_arrays=True) as f:
+        params = {'memmap': False} if use_asdf_memmap else {'copy_arrays': True}
+        with asdf.open(filename, **params) as f:
             return Grid.from_dict(f.tree['grid'])
     elif fmt == 'pickle':
         with open(filename, 'rb') as f:
@@ -238,7 +243,8 @@ def read_field(filename, fmt=None):
             raise ValueError('Format not given and could not be guessed based on the file extension.')
 
     if fmt == 'asdf':
-        with asdf.open(filename, copy_arrays=True) as f:
+        params = {'memmap': False} if use_asdf_memmap else {'copy_arrays': True}
+        with asdf.open(filename, **params) as f:
             return Field.from_dict(f.tree['field'])
     elif fmt == 'fits':
         with fits.open(filename, memmap=False) as f:
@@ -343,7 +349,8 @@ def read_mode_basis(filename, fmt=None):
             raise ValueError('Format not given and could not be guessed based on the file extension.')
 
     if fmt == 'asdf':
-        with asdf.open(filename, copy_arrays=True) as f:
+        params = {'memmap': False} if use_asdf_memmap else {'copy_arrays': True}
+        with asdf.open(filename, **params) as f:
             return ModeBasis.from_dict(f.tree['mode_basis'])
     elif fmt == 'fits':
         with fits.open(filename, memmap=False) as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -31,9 +30,8 @@ dependencies = [
     "imageio",
     "xxhash",
     "numexpr",
-    "asdf<=2.10 ; python_version<='3.7'",
-    "asdf ; python_version>'3.7'",
-    "importlib_metadata ; python_version<'3.7'",
+    "asdf",
+    "importlib_metadata",
     "importlib_resources>=1.4 ; python_version<'3.9'"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Astronomy"
 ]
 


### PR DESCRIPTION
The `copy_arrays` was deprecated in asdf 3.1.0 (8 months ago) and is now removed (asdf 4.0.0). This PR changes usage for asdf to use the correct parameter depending on asdf version.

Another option is to force asdf>=3.1.0 to be installed, but given the short time since 3.1.0 was released, I'm doing a version check for now.

This PR also removes the Python 3.7 label that should've been removed in #236.