### PR TITLE
Nan fix

### DIFF
--- a/doc/team.rst
+++ b/doc/team.rst
@@ -20,6 +20,7 @@ Direct contributors to code
 * David Kleingeld (`@dskleingeld <https://github.com/dskleingeld>`__), Leiden Observatory
 * Gilles Orban de Xivry (`@GillesOrban <https://github.com/GillesOrban>`__), Université de Liège
 * Brett Graham (`@braingram <https://github.com/braingram>`__), Space Telescope Science Institute
+* Rachel Morgan (`@rmnasa <https://github.com/rmnasa>`__), NASA Ames Research Center
 
 Testing and QA
 --------------

--- a/hcipy/optics/surface_profiles.py
+++ b/hcipy/optics/surface_profiles.py
@@ -60,7 +60,7 @@ def conical_surface_sag(radius_of_curvature, conic_constant=0):
         curvature = 1 / radius_of_curvature
         alpha = (1 + conic_constant) * curvature**2 * r**2
         sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
-        sag[np.isnan(sag)] = np.nanmin(sag)  # propagator will throw an error if there are nan's in this definition, this replaces nans with smallest value of sag
+        sag[np.isnan(sag)] = 0 # propagator will throw an error if there are nan's in this definition, this replaces nans with 0
         return Field(sag, grid)
 
     return func
@@ -104,7 +104,7 @@ def even_aspheric_surface_sag(radius_of_curvature, conic_constant=0, aspheric_co
         curvature = 1 / radius_of_curvature
         alpha = (1 + conic_constant) * curvature**2 * r**2
         sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
-        sag[np.isnan(sag)] = np.nanmin(sag)  # propagator will throw an error if there are nan's in this definition, this replaces nans with smallest value of sag
+        sag[np.isnan(sag)] = 0 # propagator will throw an error if there are nan's in this definition, this replaces nans with 0
         # Add aspheric coefficients
         # Only use the even modes and start at 4, because 0 is piston and 2 is the conic surface
         for ai, coef in enumerate(aspheric_coefficients):

--- a/hcipy/optics/surface_profiles.py
+++ b/hcipy/optics/surface_profiles.py
@@ -1,5 +1,6 @@
 import numpy as np
 from ..field import Field
+import warnings
 
 def _fill_nans(arr, fill_value):
     '''Fill in NaNs with a fill value.
@@ -104,7 +105,13 @@ def conical_surface_sag(radius_of_curvature, conic_constant=0, fill_value=None):
 
         curvature = 1 / radius_of_curvature
         alpha = (1 + conic_constant) * curvature**2 * r**2
-        sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
+
+        with warnings.catch_warnings():
+            # Suppress warnings about NaNs being produced if we're filling them in later.
+            if fill_value is not None:
+                warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value encountered in sqrt")
+
+            sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
 
         sag = _fill_nans(sag, fill_value)
 
@@ -155,7 +162,12 @@ def even_aspheric_surface_sag(radius_of_curvature, conic_constant=0, aspheric_co
         # Start with a conic surface
         curvature = 1 / radius_of_curvature
         alpha = (1 + conic_constant) * curvature**2 * r**2
-        sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
+
+        with warnings.catch_warnings():
+            if fill_value is not None:
+                warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value encountered in sqrt")
+
+            sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
 
         # Add aspheric coefficients
         # Only use the even modes and start at 4, because 0 is piston and 2 is the conic surface

--- a/hcipy/optics/surface_profiles.py
+++ b/hcipy/optics/surface_profiles.py
@@ -60,7 +60,7 @@ def conical_surface_sag(radius_of_curvature, conic_constant=0):
         curvature = 1 / radius_of_curvature
         alpha = (1 + conic_constant) * curvature**2 * r**2
         sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
-
+        sag[np.isnan(sag)] = np.nanmin(sag)  # propagator will throw an error if there are nan's in this definition, this replaces nans with smallest value of sag
         return Field(sag, grid)
 
     return func
@@ -104,7 +104,7 @@ def even_aspheric_surface_sag(radius_of_curvature, conic_constant=0, aspheric_co
         curvature = 1 / radius_of_curvature
         alpha = (1 + conic_constant) * curvature**2 * r**2
         sag = r**2 / (radius_of_curvature * (1 + np.sqrt(1 - alpha)))
-
+        sag[np.isnan(sag)] = np.nanmin(sag)  # propagator will throw an error if there are nan's in this definition, this replaces nans with smallest value of sag
         # Add aspheric coefficients
         # Only use the even modes and start at 4, because 0 is piston and 2 is the conic surface
         for ai, coef in enumerate(aspheric_coefficients):

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 from hcipy import *
 import pytest
 import os
+import warnings
 
 def test_agnostic_apodizer():
     aperture_achromatic = make_circular_aperture(1)
@@ -892,8 +893,12 @@ def test_surface_profile_fill_value():
     radius_of_curvature = 1
     grid_large = make_pupil_grid(128, 2)
 
-    spherical_sag_nan = spherical_surface_sag(radius_of_curvature)(grid_large)
-    assert np.any(np.isnan(spherical_sag_nan))
+    with warnings.catch_warnings():
+        # Suppress the warning about NaNs being produced.
+        warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value encountered in sqrt")
+
+        spherical_sag_nan = spherical_surface_sag(radius_of_curvature)(grid_large)
+        assert np.any(np.isnan(spherical_sag_nan))
 
     fill_value = -123
     spherical_sag_filled = spherical_surface_sag(radius_of_curvature, fill_value=fill_value)(grid_large)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -862,3 +862,48 @@ def test_power_law_errors():
     screen = make_high_pass_power_law_error(pupil_grid, 0.1, 2 * pupil_diameter, cutoff_freq, exponent=-2.5, aperture=aperture)
     fk = abs(fft.forward(screen))**2
     assert np.ptp(fk[fourier_mask > 0]) < 1e-6
+
+radius_of_curvature = 1
+conic_constant = -0.5
+aspheric_coefficients = [1e-3, 1e-5]
+
+sags = [
+    pytest.param(spherical_surface_sag(radius_of_curvature), id='spherical'),
+    pytest.param(parabolic_surface_sag(radius_of_curvature), id='parabolic'),
+    pytest.param(conical_surface_sag(radius_of_curvature, conic_constant), id='conical'),
+    pytest.param(even_aspheric_surface_sag(radius_of_curvature, conic_constant, aspheric_coefficients), id='even_aspheric'),
+]
+
+@pytest.mark.parametrize('sag', sags)
+def test_surface_profile_rotational_symmetry(sag):
+    angle = 1
+
+    grid = make_pupil_grid(128, 1)
+    rotated_grid = grid.rotated(angle)
+
+    field_original = sag(grid)
+    field_rotated = sag(rotated_grid)
+
+    assert is_field(field_original)
+    assert is_field(field_rotated)
+    assert np.allclose(field_original, field_rotated, equal_nan=True)
+
+def test_surface_profile_fill_value():
+    radius_of_curvature = 1
+    grid_large = make_pupil_grid(128, 2)
+
+    spherical_sag_nan = spherical_surface_sag(radius_of_curvature)(grid_large)
+    assert np.any(np.isnan(spherical_sag_nan))
+
+    fill_value = -123
+    spherical_sag_filled = spherical_surface_sag(radius_of_curvature, fill_value=fill_value)(grid_large)
+    assert not np.any(np.isnan(spherical_sag_filled))
+    assert np.any(spherical_sag_filled == fill_value)
+
+    spherical_sag_max = spherical_surface_sag(radius_of_curvature, fill_value='max')(grid_large)
+    assert not np.any(np.isnan(spherical_sag_max))
+    assert np.allclose(np.nanmax(spherical_sag_nan), np.max(spherical_sag_max))
+
+    spherical_sag_min = spherical_surface_sag(radius_of_curvature, fill_value='min')(grid_large)
+    assert not np.any(np.isnan(spherical_sag_min))
+    assert np.allclose(np.nanmin(spherical_sag_nan), np.min(spherical_sag_min))


### PR DESCRIPTION
Hi! I found that the propagators would throw an error if there were any NaNs in an optic sag profile, so added this line to set it to zero outside of the optic diameter. I was simulating a microlens array which is how this came up (the microlens diameter was smaller than the full simulation pupil size so there were nan's in the corners).