### PR TITLE
Improve the `ModalAdaptiveOpticsLayer` class

### DIFF
--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -39,7 +39,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         self.controlled_modes = controlled_modes
         self.corrected_coeffs = []
         self.lag = round(lag)
-        self._framerate = framerate
+        self.framerate = framerate
 
         # Initialize reconstruction.
         self._reconstruct_wavefront()

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -52,7 +52,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         if self.framerate is None:
             self._last_reconstruction_frame = 0
         else:
-            self._last_reconstruction_frame = int(self.layer.t * self.framerate)
+            self._last_reconstruction_frame = int(self.layer.t * framerate)
 
     def phase_for(self, wavelength):
         """Calculates the phase screen for a given wavelength with AO correction.

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -29,14 +29,14 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         the layer will be reconstructed every call to `evolve_until()`.
     """
     def __init__(self, layer, controlled_modes, lag, framerate=None):
-        super().__init__(self, layer.input_grid, layer.Cn_squared, layer.L0, layer.velocity, layer.height)
-
         self.layer = layer
-        self.controlled_modes = controlled_modes
+
+        super().__init__(layer.input_grid, layer.Cn_squared, layer.L0, layer.velocity, layer.height)
 
         self.transformation_matrix = controlled_modes.transformation_matrix
         self.transformation_matrix_inverse = inverse_tikhonov(self.transformation_matrix, 1e-7)
 
+        self.controlled_modes = controlled_modes
         self.corrected_coeffs = []
         self.lag = round(lag)
         self.framerate = framerate
@@ -86,7 +86,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         """
         if self.framerate is None:
             self.layer.evolve_until(t)
-            self.reconstruct_wavefront()
+            self._reconstruct_wavefront()
 
             return
 
@@ -95,7 +95,6 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         # Evolve and reconstruct in steps, performing reconstruction along the way.
         while self.layer.t < t:
             next_reconstruction_t = (self._last_reconstruction_frame + 1) * dt
-
             next_t = min(next_reconstruction_t, t)
 
             self.layer.evolve_until(next_t)

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -2,34 +2,133 @@ from .atmospheric_model import AtmosphericLayer
 from ..util import inverse_tikhonov
 
 class ModalAdaptiveOpticsLayer(AtmosphericLayer):
-    def __init__(self, layer, controlled_modes, lag):
+    """An atmospheric layer that simulates modal adaptive optics correction.
+
+    This layer wraps an existing atmospheric layer and applies a correction
+    based on a set of controlled modes, simulating the effect of an adaptive
+    optics system with a certain framerate and lag.
+
+    Note
+    ----
+    This class provides a rudimentary way to simulate AO-system-like residuals
+    in an infinite signal-to-noise ratio (SNR) regime. It is not intended as a
+    first-principles simulation of an AO system, but rather as a perfect
+    representation of an AO system's ability to correct modes.
+
+    Parameters
+    ----------
+    layer : AtmosphericLayer
+        The underlying atmospheric layer to be corrected.
+    controlled_modes : ModeBasis
+        The mode basis used for adaptive optics correction.
+    lag : int
+        The number of frames of lag in the adaptive optics system. This has
+        to be an integer; if it's not, it will be rounded to the nearest integer.
+    framerate : scalar or None
+        The framerate of the adaptive optics system in 1/time. If this is None,
+        the layer will be reconstructed every call to `evolve_until()`.
+    """
+    def __init__(self, layer, controlled_modes, lag, framerate=None):
+        super().__init__(self, layer.input_grid, layer.Cn_squared, layer.L0, layer.velocity, layer.height)
+
         self.layer = layer
         self.controlled_modes = controlled_modes
-
-        AtmosphericLayer.__init__(self, layer.input_grid, layer.Cn_squared, layer.L0, layer.velocity, layer.height)
 
         self.transformation_matrix = controlled_modes.transformation_matrix
         self.transformation_matrix_inverse = inverse_tikhonov(self.transformation_matrix, 1e-7)
 
         self.corrected_coeffs = []
-        self.lag = lag
+        self.lag = round(lag)
+        self.framerate = framerate
+
+    @property
+    def framerate(self):
+        return self._framerate
+
+    @framerate.setter
+    def framerate(self, framerate):
+        self._framerate = framerate
+
+        if self.framerate is None:
+            self._last_reconstruction_frame = 0
+        else:
+            self._last_reconstruction_frame = int(self.layer.t * self.framerate)
 
     def phase_for(self, wavelength):
+        """Calculates the phase screen for a given wavelength with AO correction.
+
+        Parameters
+        ----------
+        wavelength : scalar
+            The wavelength for which to calculate the phase screen.
+
+        Returns
+        -------
+        Field
+            The phase screen with adaptive optics correction applied.
+        """
         ps = self.layer.phase_for(wavelength)
         ps -= self.transformation_matrix.dot(self.corrected_coeffs[0] / wavelength)
 
         return ps
 
     def evolve_until(self, t):
-        self.layer.evolve_until(t)
+        """Evolves the atmospheric layer until a certain time `t`.
 
+        This method evolves the underlying atmospheric layer in discrete steps
+        determined by the `framerate`, and calls `reconstruct_wavefront` at
+        each of these steps.
+
+        Parameters
+        ----------
+        t : scalar
+            The time until which to evolve the layer.
+        """
+        if self.framerate is None:
+            self.layer.evolve_until(t)
+            self.reconstruct_wavefront()
+
+            return
+
+        dt = 1 / self.framerate
+
+        # Evolve and reconstruct in steps, performing reconstruction along the way.
+        while self.layer.t < t:
+            next_reconstruction_t = (self._last_reconstruction_frame + 1) * dt
+
+            next_t = min(next_reconstruction_t, t)
+
+            self.layer.evolve_until(next_t)
+
+            if next_reconstruction_t <= t:
+                self._reconstruct_wavefront()
+
+        self._t = t
+
+    def _reconstruct_wavefront(self):
+        """Reconstructs the wavefront and updates the corrected coefficients.
+
+        This method simulates the wavefront sensing and control part of an
+        adaptive optics system. It reconstructs the wavefront from the current
+        atmospheric layer and updates the internal buffer of corrected coefficients
+        considering the system's lag.
+        """
         coeffs = self.transformation_matrix_inverse.dot(self.layer.phase_for(1))
         if len(self.corrected_coeffs) > self.lag:
             self.corrected_coeffs.pop(0)
         self.corrected_coeffs.append(coeffs)
 
+        self._last_reconstruction_frame += 1
+
     @property
     def Cn_squared(self):  # noqa: N802
+        """The atmospheric refractive index structure constant (Cn^2) of the layer.
+
+        Returns
+        -------
+        scalar
+            The Cn^2 value.
+        """
         return self.layer.Cn_squared
 
     @Cn_squared.setter
@@ -38,6 +137,13 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
 
     @property
     def outer_scale(self):
+        """The outer scale of turbulence (L0) of the layer.
+
+        Returns
+        -------
+        scalar
+            The L0 value.
+        """
         return self.layer.L0
 
     @outer_scale.setter
@@ -45,5 +151,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         self.layer.L0 = L0
 
     def reset(self):
+        """Resets the corrected coefficients and the underlying atmospheric layer.
+        """
         self.corrected_coeffs = []
         self.layer.reset()

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -39,7 +39,10 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         self.controlled_modes = controlled_modes
         self.corrected_coeffs = []
         self.lag = round(lag)
-        self.framerate = framerate
+        self._framerate = framerate
+
+        # Initialize reconstruction.
+        self._reconstruct_wavefront()
 
     @property
     def framerate(self):
@@ -49,9 +52,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
     def framerate(self, framerate):
         self._framerate = framerate
 
-        if self.framerate is None:
-            self._last_reconstruction_frame = 0
-        else:
+        if self.framerate is not None:
             self._last_reconstruction_frame = int(self.layer.t * framerate)
 
     def phase_for(self, wavelength):
@@ -117,7 +118,8 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
             self.corrected_coeffs.pop(0)
         self.corrected_coeffs.append(coeffs)
 
-        self._last_reconstruction_frame += 1
+        if self.framerate is not None:
+            self._last_reconstruction_frame = int(self.layer.t * self.framerate)
 
     @property
     def Cn_squared(self):  # noqa: N802
@@ -154,3 +156,5 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         """
         self.corrected_coeffs = []
         self.layer.reset()
+
+        self._reconstruct_wavefront()

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -1,5 +1,6 @@
 from .atmospheric_model import AtmosphericLayer
 from ..util import inverse_tikhonov
+import warnings
 
 class ModalAdaptiveOpticsLayer(AtmosphericLayer):
     """An atmospheric layer that simulates modal adaptive optics correction.
@@ -24,6 +25,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
     lag : int
         The number of frames of lag in the adaptive optics system. This has
         to be an integer; if it's not, it will be rounded to the nearest integer.
+        A warning will also be emitted in this case.
     framerate : scalar or None
         The framerate of the adaptive optics system in 1/time. If this is None,
         the layer will be reconstructed every call to `evolve_until()`.
@@ -33,12 +35,16 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
 
         super().__init__(layer.input_grid, layer.Cn_squared, layer.L0, layer.velocity, layer.height)
 
+        if lag != round(lag):
+            warnings.warn("The lag will be rounded to an integer. Pass an integer to remove this warning.", warnings.UserWarning, stacklevel=2)
+            lag = round(lag)
+
         self.transformation_matrix = controlled_modes.transformation_matrix
         self.transformation_matrix_inverse = inverse_tikhonov(self.transformation_matrix, 1e-7)
 
         self.controlled_modes = controlled_modes
         self.corrected_coeffs = []
-        self.lag = round(lag)
+        self.lag = lag
         self.framerate = framerate
 
         # Initialize reconstruction.

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -46,6 +46,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         self.corrected_coeffs = []
         self.lag = lag
         self.framerate = framerate
+        self._t = layer.t
 
         # Initialize reconstruction.
         self._reconstruct_wavefront()

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -184,7 +184,7 @@ def make_modal_ao_layer(framerate):
 def test_modal_ao_evolve_until_none_framerate():
     layer, ao_layer = make_modal_ao_layer(framerate=None)
 
-    with patch.object(ao_layer, '_reconstruct_wavefront', wraps=ao_layer._reconstruct_wavefront) as mock_reconstruct,\
+    with patch.object(ao_layer, '_reconstruct_wavefront', wraps=ao_layer._reconstruct_wavefront) as mock_reconstruct,  \
             patch.object(layer, 'evolve_until', wraps=layer.evolve_until) as mock_evolve:
         ao_layer.evolve_until(10)
 
@@ -197,7 +197,7 @@ def test_modal_ao_evolve_until_none_framerate():
 def test_modal_ao_evolve_until_fixed_framerate():
     layer, ao_layer = make_modal_ao_layer(framerate=1)
 
-    with patch.object(ao_layer, '_reconstruct_wavefront', wraps=ao_layer._reconstruct_wavefront) as mock_reconstruct,\
+    with patch.object(ao_layer, '_reconstruct_wavefront', wraps=ao_layer._reconstruct_wavefront) as mock_reconstruct, \
             patch.object(layer, 'evolve_until', wraps=layer.evolve_until) as mock_evolve:
         ao_layer.evolve_until(2.5)
 
@@ -206,6 +206,7 @@ def test_modal_ao_evolve_until_fixed_framerate():
 
         # Should reconstruct wavefront twice (at t=1 and t=2)
         assert mock_reconstruct.call_count == 2
+
 
 def test_multi_layer_atmosphere():
     r0 = 0.1

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -5,6 +5,7 @@ import mpmath
 import scipy
 
 import pytest
+from unittest.mock import patch
 
 def zernike_variance_von_karman(n, m, R, k0, Cn_squared, wavelength):
     '''Calculate the variance of the Zernike mode (`n`,`m`), using a von Karman turbulence spectrum.
@@ -172,6 +173,39 @@ def test_atmospheric_layer_reset(layer_cls):
     assert np.allclose(phase_4, phase_5)
     assert not np.allclose(phase_5, phase_6)
     assert np.allclose(phase_6, phase_7)
+
+def make_modal_ao_layer(framerate):
+    grid = make_uniform_grid([16, 16], 1)
+    layer = InfiniteAtmosphericLayer(grid, 1, 1, 0, 0)
+    ao_layer = ModalAdaptiveOpticsLayer(layer, make_zernike_basis(1, 1, grid), lag=1, framerate=framerate)
+
+    return layer, ao_layer
+
+def test_modal_ao_evolve_until_none_framerate():
+    layer, ao_layer = make_modal_ao_layer(framerate=None)
+
+    with patch.object(ao_layer, '_reconstruct_wavefront', wraps=ao_layer._reconstruct_wavefront) as mock_reconstruct,\
+            patch.object(layer, 'evolve_until', wraps=layer.evolve_until) as mock_evolve:
+        ao_layer.evolve_until(10)
+
+        # Should evolve the underlying layer to the final time
+        assert mock_evolve.call_args == ((10,),)
+
+        # Should reconstruct wavefront once
+        assert mock_reconstruct.call_count == 1
+
+def test_modal_ao_evolve_until_fixed_framerate():
+    layer, ao_layer = make_modal_ao_layer(framerate=1)
+
+    with patch.object(ao_layer, '_reconstruct_wavefront', wraps=ao_layer._reconstruct_wavefront) as mock_reconstruct,\
+            patch.object(layer, 'evolve_until', wraps=layer.evolve_until) as mock_evolve:
+        ao_layer.evolve_until(2.5)
+
+        # Should evolve the underlying layer to 1, 2, 2.5
+        assert mock_evolve.call_args_list == [((1,),), ((2,),), ((2.5,),)]
+
+        # Should reconstruct wavefront twice (at t=1 and t=2)
+        assert mock_reconstruct.call_count == 2
 
 def test_multi_layer_atmosphere():
     r0 = 0.1


### PR DESCRIPTION
## Description

Fixes https://github.com/ehpor/hcipy/issues/259.

Various improvements to the `ModalAdaptiveOpticsLayer` class. This includes
1. Adding docstrings.
2. Reconstructing the wavefront at regular intervals rather than on every `evolve_until()` call. This simplifies usage.
3. Add tests to confirm that this behavior is implemented correctly.

## Todo

- [x] Check if the changes are backwards compatible.