### PR TITLE
Add tests for grid utils and interpolators

### DIFF
--- a/hcipy/field/util.py
+++ b/hcipy/field/util.py
@@ -520,7 +520,7 @@ def make_uniform_vector_field(field, jones_vector):
     Field
         The expanded vector field
     '''
-    if field.is_scalar_field():
+    if field.is_scalar_field:
         return Field([ei * field for ei in jones_vector], field.grid)
 
 def make_uniform_vector_field_generator(field_generator, jones_vector):

--- a/hcipy/interpolation/linear.py
+++ b/hcipy/interpolation/linear.py
@@ -26,7 +26,7 @@ def make_linear_interpolator_separated(field, grid=None, fill_value=np.nan):
     else:
         field = Field(field, grid)
 
-    axes_reversed = np.array(grid.separated_coords)
+    axes_reversed = tuple(grid.separated_coords)
     interp = RegularGridInterpolator(axes_reversed, np.asarray(field.shaped), 'linear', False, fill_value)
 
     def interpolator(evaluated_grid):

--- a/hcipy/interpolation/linear.py
+++ b/hcipy/interpolation/linear.py
@@ -46,7 +46,8 @@ def make_linear_interpolator_unstructured(field, grid=None, fill_value=np.nan):
     grid : Grid or None
         The grid of the field. If it is given, the grid of `field` is replaced by this grid.
     fill_value : scalar
-        The value to use for points outside of the domain of the input field. Extrapolation is not supported.
+        The value to use for points outside of the domain of the input field. Linear extrapolation
+        is not supported.
 
     Returns
     -------
@@ -54,9 +55,6 @@ def make_linear_interpolator_unstructured(field, grid=None, fill_value=np.nan):
         The interpolator as a Field generator. The grid on which this field generator will be evaluated does
         not need to have any structure.
     '''
-    if fill_value is None:
-        raise ValueError('Extrapolation is not supported for a linear interpolator on an unstructured grid.')
-
     if grid is None:
         grid = field.grid
     else:
@@ -66,11 +64,15 @@ def make_linear_interpolator_unstructured(field, grid=None, fill_value=np.nan):
 
     def interpolator(evaluated_grid):
         res = interp(evaluated_grid.points)
+
+        if fill_value is not np.nan:
+            res[~np.isfinite(res)] = fill_value
+
         return Field(res, evaluated_grid)
 
     return interpolator
 
-def make_linear_interpolator(field, grid=None, fill_value=None):
+def make_linear_interpolator(field, grid=None, fill_value=np.nan):
     '''Make a linear interpolator for a Field on any type of grid.
 
     Parameters

--- a/hcipy/interpolation/nearest.py
+++ b/hcipy/interpolation/nearest.py
@@ -60,7 +60,8 @@ def make_nearest_interpolator_unstructured(field, grid=None):
     interp = NearestNDInterpolator(grid.points, field)
 
     def interpolator(evaluated_grid):
-        res = interp(grid.points)
+        res = interp(evaluated_grid.points)
+
         return Field(res, evaluated_grid)
 
     return interpolator

--- a/hcipy/interpolation/nearest.py
+++ b/hcipy/interpolation/nearest.py
@@ -23,12 +23,15 @@ def make_nearest_interpolator_separated(field, grid=None):
     else:
         field = Field(field, grid)
 
-    axes_reversed = tuple(grid.separated_coords)
-    interp = RegularGridInterpolator(axes_reversed, field.shaped, 'nearest', False)
+    # RegularGridInterpolator expects data to be in ij indexing rather than xy. We
+    # need to reverse the axes of the data and the coordinates.
+    data = np.moveaxis(field.shaped, range(-1, -grid.ndim - 1, -1), range(-grid.ndim, 0, 1))
+
+    interp = RegularGridInterpolator(grid.separated_coords, data, 'nearest', False)
 
     def interpolator(evaluated_grid):
-        evaluated_coords = np.flip(np.array(evaluated_grid.coords), 0)
-        res = interp(evaluated_coords.T)
+        res = interp(evaluated_grid.points)
+
         return Field(res.ravel(), evaluated_grid)
 
     return interpolator

--- a/hcipy/interpolation/nearest.py
+++ b/hcipy/interpolation/nearest.py
@@ -23,7 +23,7 @@ def make_nearest_interpolator_separated(field, grid=None):
     else:
         field = Field(field, grid)
 
-    axes_reversed = np.array(grid.separated_coords)
+    axes_reversed = tuple(grid.separated_coords)
     interp = RegularGridInterpolator(axes_reversed, field.shaped, 'nearest', False)
 
     def interpolator(evaluated_grid):

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -15,7 +15,7 @@ def make_unstructured_field():
     return hcipy.Field(field, grid)
 
 def make_separated_grid():
-    return hcipy.make_uniform_grid([2, 2], [0.5, 0.5])
+    return hcipy.make_uniform_grid([2, 2], [0.8, 0.8])
 
 def make_unstructured_grid():
     grid = make_separated_grid()
@@ -37,7 +37,7 @@ def test_linear_interpolator(field_in, grid_out):
     interpolator = hcipy.make_linear_interpolator(field_in)
     field_out = interpolator(grid_out)
 
-    expected_values = np.array([2.5, 4.5, 10.5, 12.5])
+    expected_values = np.array([3.5, 5.1, 9.9, 11.5])
     assert np.allclose(field_out, expected_values)
 
 @pytest.mark.parametrize('grid_out', grids)
@@ -46,5 +46,5 @@ def test_nearest_interpolator(field_in, grid_out):
     interpolator = hcipy.make_nearest_interpolator(field_in)
     field_out = interpolator(grid_out)
 
-    expected_values = np.array([0, 2, 8, 10])
+    expected_values = np.array([5, 6, 9, 10])
     assert np.allclose(field_out, expected_values)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+import hcipy
+
+def make_separated_field():
+    grid = hcipy.make_uniform_grid([4, 4], [1, 1])
+    values = np.arange(grid.size)
+
+    return hcipy.Field(values, grid)
+
+def make_unstructured_field():
+    field = make_separated_field()
+    grid = hcipy.CartesianGrid(hcipy.UnstructuredCoords((field.grid.x, field.grid.y)))
+
+    return hcipy.Field(field, grid)
+
+def make_separated_grid():
+    return hcipy.make_uniform_grid([2, 2], [0.5, 0.5])
+
+def make_unstructured_grid():
+    grid = make_separated_grid()
+    return hcipy.CartesianGrid(hcipy.UnstructuredCoords((grid.x, grid.y)))
+
+fields = [
+    pytest.param(make_separated_field(), id='separated_in'),
+    pytest.param(make_unstructured_field(), id='unstructured_in'),
+]
+
+grids = [
+    pytest.param(make_separated_grid(), id='separated_out'),
+    pytest.param(make_unstructured_grid(), id='unstructured_out'),
+]
+
+@pytest.mark.parametrize('grid_out', grids)
+@pytest.mark.parametrize('field_in', fields)
+def test_linear_interpolator(field_in, grid_out):
+    interpolator = hcipy.make_linear_interpolator(field_in)
+    field_out = interpolator(grid_out)
+
+    expected_values = np.array([2.5, 4.5, 10.5, 12.5])
+    assert np.allclose(field_out, expected_values)
+
+@pytest.mark.parametrize('grid_out', grids)
+@pytest.mark.parametrize('field_in', fields)
+def test_nearest_interpolator(field_in, grid_out):
+    interpolator = hcipy.make_nearest_interpolator(field_in)
+    field_out = interpolator(grid_out)
+
+    expected_values = np.array([0, 2, 8, 10])
+    assert np.allclose(field_out, expected_values)


### PR DESCRIPTION
This PR adds tests for grid utils and for interpolation. This PR also fixes two bugs:

* A function call to `Field.is_scalar_field` that should have been a property accessor in `make_uniform_vector_field()`.
* The use of the original grid rather than the grid on which the Field generator was evaluated in `make_nearest_interpolator_unstructured()`.