### PR TITLE
Add `SegmentedHexikeSurface`

### DIFF
--- a/hcipy/optics/__init__.py
+++ b/hcipy/optics/__init__.py
@@ -53,6 +53,8 @@ __all__ = [
     'LinearPolarizingBeamSplitter',
     'CircularPolarizingBeamSplitter',
     'SegmentedDeformableMirror',
+    'SegmentedHexikeSurface',
+    'make_segment_hexike_surface_from_hex_aperture',
     'spherical_surface_sag',
     'parabolic_surface_sag',
     'conical_surface_sag',
@@ -87,6 +89,7 @@ from .micro_lens_array import *
 from .periodic_optical_element import *
 from .polarization import *
 from .segmented_mirror import *
+from .segmented_hexike import *
 from .surface_profiles import *
 from .thin_lens import *
 from .tip_tilt_mirror import *

--- a/hcipy/optics/segmented_hexike.py
+++ b/hcipy/optics/segmented_hexike.py
@@ -30,7 +30,11 @@ class SegmentedHexikeSurface(OpticalElement):
     '''
     def __init__(self, segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=np.pi / 2):
         self.input_grid = pupil_grid
-        self._num_segments = len(segments)
+        num_segments = len(segments)
+        if num_segments != segment_centers.size:
+            raise ValueError('segments and segment_centers must have the same length.')
+
+        self._num_segments = num_segments
         self._num_modes = num_modes
 
         segment_masks = [seg(pupil_grid) if callable(seg) else seg for seg in segments]

--- a/hcipy/optics/segmented_hexike.py
+++ b/hcipy/optics/segmented_hexike.py
@@ -39,8 +39,7 @@ class SegmentedHexikeSurface(OpticalElement):
         for mask, center in zip(segment_masks, segment_centers.points):
             local_grid = pupil_grid.shifted(-center)
             local_basis = make_hexike_basis(local_grid, num_modes, segment_circum_diameter, hexagon_angle=hexagon_angle)
-            local_matrix = np.nan_to_num(local_basis.transformation_matrix)
-            block = local_matrix * np.asarray(mask)[:, np.newaxis]
+            block = local_basis.transformation_matrix * np.asarray(mask)[:, np.newaxis]
             basis_blocks.append(block)
 
         if basis_blocks:

--- a/hcipy/optics/segmented_hexike.py
+++ b/hcipy/optics/segmented_hexike.py
@@ -1,0 +1,166 @@
+import numpy as np
+
+from ..field import Field, make_hexagonal_grid
+from ..mode_basis import ansi_to_zernike, make_hexike_basis, zernike_to_noll
+from .optical_element import OpticalElement
+from ..aperture import make_hexagonal_segmented_aperture
+
+
+class SegmentedHexikeSurface(OpticalElement):
+    '''An optical element applying per-segment hexike surface aberrations.
+
+    The coefficients represent surface height in meters. Phase is applied as
+    ``phase = 4 * pi * surface / wavelength`` (reflection: OPD = 2 * surface).
+
+    Parameters
+    ----------
+    segments : iterable of Field or callable
+        Segment masks, one per segment. Callables will be evaluated on `pupil_grid`.
+    segment_centers : Grid
+        Center positions for each segment, same ordering as `segments`.
+    segment_circum_diameter : scalar
+        Circumscribed diameter of each hexagonal segment.
+    pupil_grid : Grid
+        Grid on which the wavefront is defined.
+    num_modes : int
+        Number of hexike modes per segment (Noll ordered).
+    hexagon_angle : float
+        Rotation of each hexagon. Default pi/2 for flat-top orientation.
+    cache : dict or None
+        Optional cache passed to `make_hexike_basis` for reuse across segments.
+    '''
+    def __init__(self, segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=np.pi / 2, cache=None):
+        self.input_grid = pupil_grid
+        self._num_segments = len(segments)
+        self._num_modes = num_modes
+
+        basis_blocks = []
+
+        segment_masks = [seg(pupil_grid) if callable(seg) else seg for seg in segments]
+
+        for mask, center in zip(segment_masks, segment_centers.points):
+            local_grid = pupil_grid.shifted(-center)
+            local_basis = make_hexike_basis(local_grid, num_modes, segment_circum_diameter, hexagon_angle=hexagon_angle, cache=cache)
+            block = local_basis.transformation_matrix * np.asarray(mask)[:, np.newaxis]
+            basis_blocks.append(block)
+
+        if basis_blocks:
+            self._basis_matrix = np.concatenate(basis_blocks, axis=1)
+        else:
+            self._basis_matrix = np.zeros((pupil_grid.size, 0))
+
+        self._coefficients = np.zeros((self._num_segments, self._num_modes))
+
+    @property
+    def coefficients(self):
+        '''Surface height coefficients in meters, shape (num_segments, num_modes).'''
+        return self._coefficients
+
+    @coefficients.setter
+    def coefficients(self, value):
+        arr = np.asarray(value)
+        if arr.ndim == 1:
+            if arr.size != self._num_segments * self._num_modes:
+                raise ValueError('Coefficient array has wrong size.')
+            arr = arr.reshape(self._num_segments, self._num_modes)
+        elif arr.shape != (self._num_segments, self._num_modes):
+            raise ValueError('Coefficient array has wrong shape.')
+
+        self._coefficients = arr
+
+    def set_segment_coefficients(self, segment_id, coeffs_dict, indexing='noll'):
+        '''Set coefficients for a single segment.
+
+        Parameters
+        ----------
+        segment_id : int
+            Index of the segment.
+        coeffs_dict : dict
+            Mapping from mode index to surface height in meters.
+        indexing : {'noll', 'ansi'}
+            Indexing scheme for supplied mode indices.
+        '''
+        for mode_idx, height in coeffs_dict.items():
+            internal_idx = self._to_internal_mode_index(mode_idx, indexing)
+            self._coefficients[segment_id, internal_idx] = height
+
+    def set_coefficients_from_dict(self, coeffs_by_segment, indexing='noll'):
+        '''Convenience setter for dict-of-dicts coefficient input.'''
+        for seg_id, mode_dict in coeffs_by_segment.items():
+            self.set_segment_coefficients(seg_id, mode_dict, indexing=indexing)
+
+    def get_segment_coefficients(self, segment_id):
+        '''Get coefficients for a single segment.'''
+        return self._coefficients[segment_id].copy()
+
+    def flatten(self):
+        '''Reset all coefficients to zero.'''
+        self._coefficients[:] = 0
+
+    @property
+    def surface(self):
+        '''Current surface height in meters as a Field on `input_grid`.'''
+        surface = self._basis_matrix.dot(self._coefficients.ravel())
+        return Field(surface, self.input_grid)
+
+    @property
+    def opd(self):
+        '''Optical path difference (2 × surface for reflection).'''
+        return 2 * self.surface
+
+    def phase_for(self, wavelength):
+        '''Phase screen for a given wavelength.'''
+        return 4 * np.pi * self.surface / wavelength
+
+    def forward(self, wavefront):
+        if not np.any(self._coefficients):
+            return wavefront.copy()
+
+        phase = 4 * np.pi * self.surface / wavefront.wavelength
+
+        wf = wavefront.copy()
+        wf.electric_field *= np.exp(1j * phase)
+        return wf
+
+    def backward(self, wavefront):
+        if not np.any(self._coefficients):
+            return wavefront.copy()
+
+        phase = 4 * np.pi * self.surface / wavefront.wavelength
+
+        wf = wavefront.copy()
+        wf.electric_field *= np.exp(-1j * phase)
+        return wf
+
+    def _to_internal_mode_index(self, mode_index, indexing):
+        if indexing == 'noll':
+            internal_idx = mode_index - 1
+        elif indexing == 'ansi':
+            n, m = ansi_to_zernike(mode_index)
+            internal_idx = zernike_to_noll(n, m) - 1
+        else:
+            raise ValueError('Indexing must be "noll" or "ansi".')
+
+        if internal_idx < 0 or internal_idx >= self._num_modes:
+            raise ValueError('Mode index out of range for this surface.')
+        return internal_idx
+
+
+def make_segment_hexike_surface_from_hex_aperture(num_rings, segment_flat_to_flat, gap_size, pupil_grid, num_modes, hexagon_angle=np.pi / 2, cache=None, starting_ring=0):
+    '''Factory for SegmentedHexikeSurface on a hexagonal segmented aperture.'''
+    _, segment_generators = make_hexagonal_segmented_aperture(num_rings, segment_flat_to_flat, gap_size, starting_ring=starting_ring, return_segments=True)
+
+    segments = [seg(pupil_grid) for seg in segment_generators]
+
+    segment_pitch = segment_flat_to_flat + gap_size
+    segment_centers = make_hexagonal_grid(segment_pitch, num_rings, pointy_top=False)
+
+    if starting_ring != 0:
+        starting_segment = 3 * (starting_ring - 1) * starting_ring + 1
+        mask = segment_centers.zeros(dtype='bool')
+        mask[starting_segment:] = True
+        segment_centers = segment_centers.subset(mask)
+
+    segment_circum_diameter = segment_flat_to_flat * 2 / np.sqrt(3)
+
+    return SegmentedHexikeSurface(segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=hexagon_angle, cache=cache)

--- a/hcipy/optics/segmented_hexike.py
+++ b/hcipy/optics/segmented_hexike.py
@@ -26,10 +26,8 @@ class SegmentedHexikeSurface(OpticalElement):
         Number of hexike modes per segment (Noll ordered).
     hexagon_angle : float
         Rotation of each hexagon. Default pi/2 for flat-top orientation.
-    cache : dict or None
-        Optional cache passed to `make_hexike_basis` for reuse across segments.
     '''
-    def __init__(self, segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=np.pi / 2, cache=None):
+    def __init__(self, segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=np.pi / 2):
         self.input_grid = pupil_grid
         self._num_segments = len(segments)
         self._num_modes = num_modes
@@ -40,7 +38,7 @@ class SegmentedHexikeSurface(OpticalElement):
 
         for mask, center in zip(segment_masks, segment_centers.points):
             local_grid = pupil_grid.shifted(-center)
-            local_basis = make_hexike_basis(local_grid, num_modes, segment_circum_diameter, hexagon_angle=hexagon_angle, cache=cache)
+            local_basis = make_hexike_basis(local_grid, num_modes, segment_circum_diameter, hexagon_angle=hexagon_angle)
             local_matrix = np.nan_to_num(local_basis.transformation_matrix)
             block = local_matrix * np.asarray(mask)[:, np.newaxis]
             basis_blocks.append(block)
@@ -147,7 +145,7 @@ class SegmentedHexikeSurface(OpticalElement):
         return internal_idx
 
 
-def make_segment_hexike_surface_from_hex_aperture(num_rings, segment_flat_to_flat, gap_size, pupil_grid, num_modes, hexagon_angle=np.pi / 2, cache=None, starting_ring=0):
+def make_segment_hexike_surface_from_hex_aperture(num_rings, segment_flat_to_flat, gap_size, pupil_grid, num_modes, hexagon_angle=np.pi / 2, starting_ring=0):
     '''Factory for SegmentedHexikeSurface on a hexagonal segmented aperture.'''
     _, segment_generators = make_hexagonal_segmented_aperture(num_rings, segment_flat_to_flat, gap_size, starting_ring=starting_ring, return_segments=True)
 
@@ -164,4 +162,4 @@ def make_segment_hexike_surface_from_hex_aperture(num_rings, segment_flat_to_fla
 
     segment_circum_diameter = segment_flat_to_flat * 2 / np.sqrt(3)
 
-    return SegmentedHexikeSurface(segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=hexagon_angle, cache=cache)
+    return SegmentedHexikeSurface(segments, segment_centers, segment_circum_diameter, pupil_grid, num_modes, hexagon_angle=hexagon_angle)

--- a/hcipy/optics/segmented_hexike.py
+++ b/hcipy/optics/segmented_hexike.py
@@ -41,7 +41,8 @@ class SegmentedHexikeSurface(OpticalElement):
         for mask, center in zip(segment_masks, segment_centers.points):
             local_grid = pupil_grid.shifted(-center)
             local_basis = make_hexike_basis(local_grid, num_modes, segment_circum_diameter, hexagon_angle=hexagon_angle, cache=cache)
-            block = local_basis.transformation_matrix * np.asarray(mask)[:, np.newaxis]
+            local_matrix = np.nan_to_num(local_basis.transformation_matrix)
+            block = local_matrix * np.asarray(mask)[:, np.newaxis]
             basis_blocks.append(block)
 
         if basis_blocks:
@@ -113,7 +114,7 @@ class SegmentedHexikeSurface(OpticalElement):
         return 4 * np.pi * self.surface / wavelength
 
     def forward(self, wavefront):
-        if not np.any(self._coefficients):
+        if not np.any(self._coefficients != 0):
             return wavefront.copy()
 
         phase = 4 * np.pi * self.surface / wavefront.wavelength
@@ -123,7 +124,7 @@ class SegmentedHexikeSurface(OpticalElement):
         return wf
 
     def backward(self, wavefront):
-        if not np.any(self._coefficients):
+        if not np.any(self._coefficients != 0):
             return wavefront.copy()
 
         phase = 4 * np.pi * self.surface / wavefront.wavelength

--- a/tests/test_segmented_hexike.py
+++ b/tests/test_segmented_hexike.py
@@ -1,0 +1,134 @@
+import numpy as np
+
+from hcipy import *
+
+
+def test_single_segment_mode_matches_basis():
+    pupil_grid = make_pupil_grid(64)
+    segment_flat_to_flat = 1
+    num_modes = 4
+
+    surface = make_segment_hexike_surface_from_hex_aperture(
+        num_rings=0,
+        segment_flat_to_flat=segment_flat_to_flat,
+        gap_size=0,
+        pupil_grid=pupil_grid,
+        num_modes=num_modes
+    )
+
+    surface.set_segment_coefficients(0, {2: 1}, indexing='noll')
+
+    segment_circum_diameter = segment_flat_to_flat * 2 / np.sqrt(3)
+    expected_basis = make_hexike_basis(pupil_grid, num_modes, segment_circum_diameter, hexagon_angle=np.pi / 2)
+
+    assert np.allclose(surface.surface, expected_basis[1])
+
+
+def test_phase_scales_with_wavelength():
+    pupil_grid = make_pupil_grid(32)
+    surface = make_segment_hexike_surface_from_hex_aperture(
+        num_rings=0,
+        segment_flat_to_flat=1,
+        gap_size=0,
+        pupil_grid=pupil_grid,
+        num_modes=2
+    )
+
+    surface.set_segment_coefficients(0, {1: 10e-9}, indexing='noll')
+
+    wavelength = 500e-9
+    phase1 = surface.phase_for(wavelength)
+    phase2 = surface.phase_for(2 * wavelength)
+
+    assert np.allclose(phase2, 0.5 * phase1)
+
+
+def test_forward_backward_roundtrip():
+    pupil_grid = make_pupil_grid(32)
+    aperture = make_circular_aperture(1)(pupil_grid)
+    wavelength = 500e-9
+
+    surface = make_segment_hexike_surface_from_hex_aperture(
+        num_rings=0,
+        segment_flat_to_flat=1,
+        gap_size=0,
+        pupil_grid=pupil_grid,
+        num_modes=2
+    )
+    surface.set_segment_coefficients(0, {1: 20e-9}, indexing='noll')
+
+    wf = Wavefront(aperture, wavelength)
+    wf_fwd = surface.forward(wf)
+    wf_back = surface.backward(wf_fwd)
+
+    assert np.allclose(wf_back.electric_field, wf.electric_field)
+
+
+def test_zero_surface_is_noop():
+    pupil_grid = make_pupil_grid(16)
+    aperture = make_circular_aperture(1)(pupil_grid)
+    wavelength = 500e-9
+
+    surface = make_segment_hexike_surface_from_hex_aperture(
+        num_rings=0,
+        segment_flat_to_flat=1,
+        gap_size=0,
+        pupil_grid=pupil_grid,
+        num_modes=2
+    )
+
+    wf = Wavefront(aperture, wavelength)
+    wf_out = surface.forward(wf)
+
+    assert np.allclose(wf_out.electric_field, wf.electric_field)
+
+
+def test_coefficient_interfaces():
+    pupil_grid = make_pupil_grid(16)
+    num_modes = 3
+
+    surface = make_segment_hexike_surface_from_hex_aperture(
+        num_rings=1,
+        segment_flat_to_flat=1,
+        gap_size=0,
+        pupil_grid=pupil_grid,
+        num_modes=num_modes
+    )
+
+    num_segments = surface.coefficients.shape[0]
+
+    # Array setter (2D)
+    arr = np.arange(num_segments * num_modes).reshape(num_segments, num_modes) * 1e-9
+    surface.coefficients = arr
+    assert np.allclose(surface.coefficients, arr)
+
+    # Flat setter
+    surface.coefficients = arr.ravel()
+    assert np.allclose(surface.coefficients, arr)
+
+    # Dict setter
+    surface.flatten()
+    surface.set_segment_coefficients(0, {1: 1e-8, 3: 2e-8}, indexing='noll')
+    assert np.isclose(surface.coefficients[0, 0], 1e-8)
+    assert np.isclose(surface.coefficients[0, 2], 2e-8)
+
+    # Dict-of-dicts
+    surface.flatten()
+    surface.set_coefficients_from_dict({0: {2: 5e-9}}, indexing='noll')
+    assert np.isclose(surface.coefficients[0, 1], 5e-9)
+
+
+def test_starting_ring_subsets_segments():
+    pupil_grid = make_pupil_grid(16)
+
+    surface = make_segment_hexike_surface_from_hex_aperture(
+        num_rings=2,
+        segment_flat_to_flat=1,
+        gap_size=0,
+        pupil_grid=pupil_grid,
+        num_modes=1,
+        starting_ring=1
+    )
+
+    # num_rings=2 has 1 + 6 + 12 = 19 segments; starting_ring=1 drops the center.
+    assert surface.coefficients.shape[0] == 18

--- a/tests/test_segmented_hexike.py
+++ b/tests/test_segmented_hexike.py
@@ -25,7 +25,7 @@ def test_single_segment_mode_matches_basis():
 
 
 def test_segment_isolation():
-    pupil_grid = make_pupil_grid(64)
+    pupil_grid = make_pupil_grid(64, 4)
     segment_flat_to_flat = 1
 
     surface = make_segment_hexike_surface_from_hex_aperture(
@@ -110,7 +110,7 @@ def test_zero_surface_is_noop():
 
 
 def test_coefficient_interfaces():
-    pupil_grid = make_pupil_grid(16)
+    pupil_grid = make_pupil_grid(16, 4)
     num_modes = 3
 
     surface = make_segment_hexike_surface_from_hex_aperture(
@@ -145,7 +145,7 @@ def test_coefficient_interfaces():
 
 
 def test_starting_ring_subsets_segments():
-    pupil_grid = make_pupil_grid(16)
+    pupil_grid = make_pupil_grid(16, 6)
 
     surface = make_segment_hexike_surface_from_hex_aperture(
         num_rings=2,


### PR DESCRIPTION
Good evening, Emiel. This PR adds segment-level hexike integration in a way that addresses the design flaws we discussed in PR #272 (which never got merged) and your PR #283, which added the basis function. Below are a summary of the changes!

- I introduced a new standalone optic, `SegmentedHexikeSurface`, rather than modifying `SegmentedDeformableMirror`, addressing your "I'd create a separate class for the aberration" comment in the PR.
- For each segment, the hexike basis is computed on a grid shifted to that segment’s center using `make_hexike_basis()`, then each mode is masked to its segment. The full set is stored as a sparse `ModeBasis` and combined via `linear_combination`, which keeps RAM reasonable and is consistent with how you do the RAM saving in other methods like `hcipy/optics/deformable_mirror.py`.
- The surface is cached the same way as `DeformableMirror.surface`, so repeated propagations with unchanged coefficients don’t redo the basis dot product.
- I also added an optional convenience helper, `make_segment_hexike_surface_from_hex_aperture(...)`, in the spirit of HCIPy’s other `make_*` geometry helpers. It makes a standard hex-segmented aperture into a ready `SegmentedHexikeSurface`, and I’m totally fine dropping or renaming it if you think people should set their own segmented apertures (I set my own in my [HWO-SLAPS](https://github.com/nasa-jpl/hwo-slaps) codebase from my summer internship). If you don't use the helper, you just call the class. Example usage of that helper function is below!

```python
import numpy as np
from hcipy import *

# Define pupil/grid and wavelength.
pupil_grid = make_pupil_grid(256, diameter=7.2)
wavelength = 500e-9

# Build a segmented hexike surface
hexike_surface = make_segment_hexike_surface_from_hex_aperture(
    num_rings=2,
    segment_flat_to_flat=1.4,
    gap_size=0.01,
    pupil_grid=pupil_grid,
    num_modes=10,                 # per segment, Noll ordered
    hexagon_angle=np.pi/2,        # flat-top
)

# Set per-segment coefficients
hexike_surface.set_coefficients_from_dict({
    0: {1: 50e-9/2},   # segment 0, Noll mode 1 (piston)
    3: {4: 20e-9/2},   # segment 3, Noll mode 4, etc.
}, indexing='noll')
```

Happy to tweak naming or interfaces if you’d like anything closer to existing patterns. Let me know what you think!
