### PR TITLE
Add RandomGenerator class that unifies randomness across backends.

### DIFF
--- a/.github/conda_environments/optional_dependencies.txt
+++ b/.github/conda_environments/optional_dependencies.txt
@@ -1,1 +1,3 @@
 mkl_fft
+jax
+pytorch

--- a/.github/conda_environments/testing_env.yml
+++ b/.github/conda_environments/testing_env.yml
@@ -4,3 +4,4 @@ dependencies:
   - scipy
   - ffmpeg
   - conda-forge::pyfftw
+  - pip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,7 @@ jobs:
       shell: bash -l {0}
     - name: Install our package
       run: |
-        pip install -e ".[dev]"
+        python -m pip install -e ".[dev]"
       shell: bash -l {0}
     - name: Print package versions
       run: |

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -1,7 +1,7 @@
 from array_api_compat import is_numpy_namespace, is_torch_namespace, is_jax_namespace, is_cupy_namespace
 import copy
 
-class RandomState:
+class RandomGenerator:
     '''A class that provides a consistent API for random number generation across different array API namespaces.
 
     Parameters
@@ -28,20 +28,21 @@ class RandomState:
                 self._rng.manual_seed(seed)
         elif is_jax_namespace(xp):
             from jax import random
+
             self._jax_random = random
             self._rng = random.PRNGKey(seed or 0)
         else:
             raise ValueError(f"Unsupported namespace: {xp}")
 
     def copy(self):
-        '''Return a new RandomState object that is an independent copy of the current state.
+        '''Return a new RandomGenerator object that is an independent copy of the current state.
 
         Returns
         -------
-        RandomState
-            A new RandomState object with the same internal state as the current object.
+        RandomGenerator
+            A new RandomGenerator object with the same internal state as the current object.
         '''
-        new_rng = RandomState.__new__(RandomState)
+        new_rng = RandomGenerator.__new__(RandomGenerator)
         new_rng.xp = self.xp
         new_rng._jax_random = self._jax_random
 

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -1,0 +1,141 @@
+from array_api_compat import is_numpy_namespace, is_torch_namespace, is_jax_namespace, is_cupy_namespace
+import copy
+
+class RandomState:
+    '''A class that provides a consistent API for random number generation across different array API namespaces.
+
+    Parameters
+    ----------
+    xp : object
+        The array API namespace (e.g., numpy, torch, jax) to use for random number generation.
+    seed : int, optional
+        The seed for the random number generator. If ``None``, a random seed will be used, by default None.
+
+    Raises
+    ------
+    ValueError
+        If an unsupported array API namespace is provided.
+    '''
+    def __init__(self, xp, seed=None):
+        self.xp = xp
+        self._jax_random = None
+
+        if is_numpy_namespace(xp) or is_cupy_namespace(xp):
+            self._rng = xp.random.default_rng(seed)
+        elif is_torch_namespace(xp):
+            self._rng = xp.Generator()
+            if seed is not None:
+                self._rng.manual_seed(seed)
+        elif is_jax_namespace(xp):
+            from jax import random
+            self._jax_random = random
+            self._rng = random.PRNGKey(seed or 0)
+        else:
+            raise ValueError(f"Unsupported namespace: {xp}")
+
+    def copy(self):
+        '''Return a new RandomState object that is an independent copy of the current state.
+
+        Returns
+        -------
+        RandomState
+            A new RandomState object with the same internal state as the current object.
+        '''
+        new_rng = RandomState.__new__(RandomState)
+        new_rng.xp = self.xp
+        new_rng._jax_random = self._jax_random
+
+        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
+            new_rng._rng = copy.deepcopy(self._rng)
+        elif is_torch_namespace(self.xp):
+            new_rng._rng = self.xp.Generator()
+            new_rng._rng.set_state(self.xp.get_rng_state())
+        elif is_jax_namespace(self.xp):
+            new_rng._rng = self._rng  # Immutable, safe to share reference
+
+        return new_rng
+
+    def normal(self, mean=0.0, std=1.0, *, size=None):
+        """Generate random samples from a normal (Gaussian) distribution.
+
+        Parameters
+        ----------
+        mean : float, optional
+            Mean ("center") of the distribution, by default 0.0.
+        std : float, optional
+            Standard deviation (spread or "width") of the distribution, by default 1.0.
+        size : int or tuple of ints, optional
+            Output shape. If ``None``, a single scalar value is returned, by default None.
+
+        Returns
+        -------
+        array
+            An array of specified shape filled with random samples from the
+            normal distribution.
+        """
+        if size is None:
+            size = ()
+
+        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
+            return self._rng.normal(mean, std, size)
+        elif is_torch_namespace(self.xp):
+            return self.xp.randn(*size, generator=self._rng) * std + mean
+        elif is_jax_namespace(self.xp):
+            self._rng, subkey = self._jax_random.split(self._rng)
+            return self._jax_random.normal(subkey, size) * std + mean
+
+    def poisson(self, lam=1.0, *, size=None):
+        """Generate random samples from a Poisson distribution.
+
+        Parameters
+        ----------
+        lam : float, optional
+            Rate parameter ("lambda") of the distribution, by default 1.0.
+        size : int or tuple of ints, optional
+            Output shape. If ``None``, a single scalar value is returned, by default None.
+
+        Returns
+        -------
+        array
+            An array of specified shape filled with random samples from the
+            Poisson distribution.
+        """
+        if size is None:
+            size = ()
+
+        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
+            return self._rng.poisson(lam, size)
+        elif is_torch_namespace(self.xp):
+            return self.xp.poisson(lam, size=size, generator=self._rng)
+        elif is_jax_namespace(self.xp):
+            self._rng, subkey = self._jax_random.split(self._rng)
+            return self._jax_random.poisson(subkey, lam, size)
+
+    def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
+        """Generate random samples from a Gamma distribution.
+
+        Parameters
+        ----------
+        scale : float, optional
+            The scale parameter (beta or theta, inverse of rate) of the distribution, by default 1.0.
+        shape_param : float, optional
+            The shape parameter (k or alpha) of the distribution, by default 1.0.
+        size : int or tuple of ints, optional
+            Output shape. If ``None``, a single scalar value is returned, by default None.
+
+        Returns
+        -------
+        array
+            An array of specified shape filled with random samples from the
+            Gamma distribution.
+        """
+        if size is None:
+            size = ()
+
+        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
+            return self._rng.gamma(shape_param, scale, size)
+        elif is_torch_namespace(self.xp):
+            return self.xp.gamma(shape_param, (1.0 / scale), size=size, generator=self._rng)
+        elif is_jax_namespace(self.xp):
+            self._rng, subkey = self._jax_random.split(self._rng)
+            return self._jax_random.gamma(subkey, shape_param, size) * scale

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -75,7 +75,7 @@ class RandomGenerator:
             normal distribution.
         """
         if size is None:
-            size = ()
+            size = (1,)
 
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.normal(mean, std, size)
@@ -102,11 +102,12 @@ class RandomGenerator:
             Poisson distribution.
         """
         if size is None:
-            size = ()
+            size = (1,)
 
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.poisson(lam, size)
         elif is_torch_namespace(self.xp):
+            lam = self.xp.ones(size=size) * lam
             return self.xp.poisson(lam, size=size, generator=self._rng)
         elif is_jax_namespace(self.xp):
             self._rng, subkey = self._jax_random.split(self._rng)
@@ -131,7 +132,7 @@ class RandomGenerator:
             Gamma distribution.
         """
         if size is None:
-            size = ()
+            size = (1,)
 
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.gamma(shape_param, scale, size)

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -136,6 +136,8 @@ class RandomGenerator:
         """
         if size is None:
             size = (1,)
+        elif not isinstance(size, tuple):
+            size = (size,)
 
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.normal(mean, std, size)
@@ -163,12 +165,14 @@ class RandomGenerator:
         """
         if size is None:
             size = (1,)
+        elif not isinstance(size, tuple):
+            size = (size,)
 
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.poisson(lam, size)
         elif is_torch_namespace(self.xp):
             lam = self.xp.ones(size=size) * lam
-            return self.xp.poisson(lam, size=size, generator=self._rng)
+            return self.xp.poisson(lam, generator=self._rng)
         elif is_jax_namespace(self.xp):
             self._rng, subkey = self._jax_random.split(self._rng)
             return self._jax_random.poisson(subkey, lam, size)
@@ -193,6 +197,8 @@ class RandomGenerator:
         """
         if size is None:
             size = (1,)
+        elif not isinstance(size, tuple):
+            size = (size,)
 
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.gamma(shape_param, scale, size)

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -110,7 +110,7 @@ class RandomGenerator:
             new_rng._rng = copy.deepcopy(self._rng)
         elif is_torch_namespace(self.xp):
             new_rng._rng = self.xp.Generator()
-            new_rng._rng.set_state(self.xp.get_rng_state())
+            new_rng._rng.set_state(self._rng.get_state())
         elif is_jax_namespace(self.xp):
             new_rng._rng = self._rng  # Immutable, safe to share reference
 

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -7,6 +7,7 @@ def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
     '''Sample from Gamma(shape, scale) distribution using pytorch.
 
     Pytorch does not support a generator argument for gamma, so we need to implement it.
+    This implementation uses the Marsaglia-Tsang method.
 
     Parameters
     ----------
@@ -33,30 +34,35 @@ def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
 
     # For shape < 1, use the boost: if X ~ Gamma(a+1), then X*U^(1/a) ~ Gamma(a)
     boost = shape < 1
-    a = shape + 1.0 if boost else shape
+    a = shape + 1 if boost else shape
 
-    d = a - 1.0 / 3.0
-    c = 1.0 / math.sqrt(9.0 * d)
+    d = a - 1 / 3
+    c = 1 / math.sqrt(9.0 * d)
+
+    # Use batches, be conservative. Average acceptance rate is ~98% so a factor of 2x is appropriate.
+    batch_size = max(n * 2, 2**16)
 
     samples = []
-    while len(samples) < n:
-        batch = max(n - len(samples), 16)
-        x = torch.randn(batch, generator=generator)
-        v = (1.0 + c * x) ** 3
+    num_samples = 0
+    while num_samples < n:
+        x = torch.randn(batch_size, generator=generator)
+        v = (1 + c * x)**3
 
-        u = torch.rand(batch, generator=generator)
+        u = torch.rand(batch_size, generator=generator)
 
-        squeeze = u < 1.0 - 0.0331 * x ** 4
-        log_check = torch.log(u) < 0.5 * x ** 2 + d * (1.0 - v + torch.log(v.clamp(min=1e-10)))
+        squeeze = u < 1 - 0.0331 * x**4
+        log_check = torch.log(u) < 0.5 * x**2 + d * (1 - v + torch.log(v.clamp(min=1e-10)))
 
         accepted_mask = (v > 0) & (squeeze | log_check)
         samples.append((d * v)[accepted_mask])
+
+        num_samples += torch.sum(accepted_mask)
 
     samples = torch.cat(samples)[:n]
 
     if boost:
         u = torch.rand(n, generator=generator)
-        samples = samples * u ** (1.0 / shape)
+        samples = samples * u ** (1 / shape)
 
     return (samples * scale).reshape(size)
 

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -1,5 +1,65 @@
 from array_api_compat import is_numpy_namespace, is_torch_namespace, is_jax_namespace, is_cupy_namespace
 import copy
+import math
+
+
+def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
+    '''Sample from Gamma(shape, scale) distribution using pytorch.
+
+    Pytorch does not support a generator argument for gamma, so we need to implement it.
+
+    Parameters
+    ----------
+    scale : float
+        The scale parameter of the Gamma distribution.
+    shape : float
+        The shape parameters of the Gamma distribution.
+    size : tuple or None
+        The size of the output tensor.
+    generator : torch.Generator or None
+        The random number generator to use.
+
+    Returns
+    -------
+    torch.Tensor
+        The Gamma-distributed generated samples.
+    '''
+    import torch
+
+    if size is None:
+        size = (1,)
+
+    n = math.prod(size)
+
+    # For shape < 1, use the boost: if X ~ Gamma(a+1), then X*U^(1/a) ~ Gamma(a)
+    boost = shape < 1
+    a = shape + 1.0 if boost else shape
+
+    d = a - 1.0 / 3.0
+    c = 1.0 / math.sqrt(9.0 * d)
+
+    samples = []
+    while len(samples) < n:
+        batch = max(n - len(samples), 16)
+        x = torch.randn(batch, generator=generator)
+        v = (1.0 + c * x) ** 3
+
+        u = torch.rand(batch, generator=generator)
+
+        squeeze = u < 1.0 - 0.0331 * x ** 4
+        log_check = torch.log(u) < 0.5 * x ** 2 + d * (1.0 - v + torch.log(v.clamp(min=1e-10)))
+
+        accepted_mask = (v > 0) & (squeeze | log_check)
+        samples.append((d * v)[accepted_mask])
+
+    samples = torch.cat(samples)[:n]
+
+    if boost:
+        u = torch.rand(n, generator=generator)
+        samples = samples * u ** (1.0 / shape)
+
+    return (samples * scale).reshape(size)
+
 
 class RandomGenerator:
     '''A class that provides a consistent API for random number generation across different array API namespaces.
@@ -137,7 +197,7 @@ class RandomGenerator:
         if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
             return self._rng.gamma(shape_param, scale, size)
         elif is_torch_namespace(self.xp):
-            return self.xp.gamma(shape_param, (1.0 / scale), size=size, generator=self._rng)
+            return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
         elif is_jax_namespace(self.xp):
             self._rng, subkey = self._jax_random.split(self._rng)
             return self._jax_random.gamma(subkey, shape_param, size) * scale

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -3,6 +3,33 @@ import copy
 import math
 
 
+def make_random_generator(xp, seed=None):
+    '''Create a RandomGenerator instance for the given array API namespace.
+
+    Parameters
+    ----------
+    xp : object
+        The array API namespace (e.g., numpy, torch, jax, cupy).
+    seed : int, optional
+        The seed for the random number generator, by default None.
+
+    Returns
+    -------
+    RandomGenerator
+        An instance of the appropriate RandomGenerator subclass for the given namespace.
+    '''
+    if is_numpy_namespace(xp):
+        return RandomGeneratorNumpy(seed)
+    elif is_cupy_namespace(xp):
+        return RandomGeneratorCupy(seed)
+    elif is_torch_namespace(xp):
+        return RandomGeneratorTorch(seed)
+    elif is_jax_namespace(xp):
+        return RandomGeneratorJax(seed)
+    else:
+        raise ValueError(f"Unsupported namespace: {xp}")
+
+
 def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
     '''Sample from Gamma(shape, scale) distribution using pytorch.
 
@@ -67,38 +94,17 @@ def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
     return (samples * scale).reshape(size)
 
 
+def _normalize_size(size):
+    if size is None:
+        return (1,)
+    elif not isinstance(size, tuple):
+        return (size,)
+    return size
+
+
 class RandomGenerator:
-    '''A class that provides a consistent API for random number generation across different array API namespaces.
-
-    Parameters
-    ----------
-    xp : object
-        The array API namespace (e.g., numpy, torch, jax) to use for random number generation.
-    seed : int, optional
-        The seed for the random number generator. If ``None``, a random seed will be used, by default None.
-
-    Raises
-    ------
-    ValueError
-        If an unsupported array API namespace is provided.
-    '''
-    def __init__(self, xp, seed=None):
-        self.xp = xp
-        self._jax_random = None
-
-        if is_numpy_namespace(xp) or is_cupy_namespace(xp):
-            self._rng = xp.random.default_rng(seed)
-        elif is_torch_namespace(xp):
-            self._rng = xp.Generator()
-            if seed is not None:
-                self._rng.manual_seed(seed)
-        elif is_jax_namespace(xp):
-            from jax import random
-
-            self._jax_random = random
-            self._rng = random.PRNGKey(seed or 0)
-        else:
-            raise ValueError(f"Unsupported namespace: {xp}")
+    def __init__(self, xp):
+        self._xp = xp
 
     def copy(self):
         '''Return a new RandomGenerator object that is an independent copy of the current state.
@@ -108,17 +114,8 @@ class RandomGenerator:
         RandomGenerator
             A new RandomGenerator object with the same internal state as the current object.
         '''
-        new_rng = RandomGenerator.__new__(RandomGenerator)
-        new_rng.xp = self.xp
-        new_rng._jax_random = self._jax_random
-
-        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
-            new_rng._rng = copy.deepcopy(self._rng)
-        elif is_torch_namespace(self.xp):
-            new_rng._rng = self.xp.Generator()
-            new_rng._rng.set_state(self._rng.get_state())
-        elif is_jax_namespace(self.xp):
-            new_rng._rng = self._rng  # Immutable, safe to share reference
+        new_rng = self.__new__(type(self))
+        new_rng._xp = self._xp
 
         return new_rng
 
@@ -140,18 +137,7 @@ class RandomGenerator:
             An array of specified shape filled with random samples from the
             normal distribution.
         """
-        if size is None:
-            size = (1,)
-        elif not isinstance(size, tuple):
-            size = (size,)
-
-        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
-            return self._rng.normal(mean, std, size)
-        elif is_torch_namespace(self.xp):
-            return self.xp.randn(*size, generator=self._rng) * std + mean
-        elif is_jax_namespace(self.xp):
-            self._rng, subkey = self._jax_random.split(self._rng)
-            return self._jax_random.normal(subkey, size) * std + mean
+        raise NotImplementedError()
 
     def poisson(self, lam=1.0, *, size=None):
         """Generate random samples from a Poisson distribution.
@@ -169,19 +155,7 @@ class RandomGenerator:
             An array of specified shape filled with random samples from the
             Poisson distribution.
         """
-        if size is None:
-            size = (1,)
-        elif not isinstance(size, tuple):
-            size = (size,)
-
-        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
-            return self._rng.poisson(lam, size)
-        elif is_torch_namespace(self.xp):
-            lam = self.xp.ones(size=size) * lam
-            return self.xp.poisson(lam, generator=self._rng)
-        elif is_jax_namespace(self.xp):
-            self._rng, subkey = self._jax_random.split(self._rng)
-            return self._jax_random.poisson(subkey, lam, size)
+        raise NotImplementedError()
 
     def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
         """Generate random samples from a Gamma distribution.
@@ -201,15 +175,100 @@ class RandomGenerator:
             An array of specified shape filled with random samples from the
             Gamma distribution.
         """
-        if size is None:
-            size = (1,)
-        elif not isinstance(size, tuple):
-            size = (size,)
+        raise NotImplementedError()
 
-        if is_numpy_namespace(self.xp) or is_cupy_namespace(self.xp):
-            return self._rng.gamma(shape_param, scale, size)
-        elif is_torch_namespace(self.xp):
-            return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
-        elif is_jax_namespace(self.xp):
-            self._rng, subkey = self._jax_random.split(self._rng)
-            return self._jax_random.gamma(subkey, shape_param, size) * scale
+
+class RandomGeneratorNumpy(RandomGenerator):
+    def __init__(self, seed=None):
+        import numpy
+        super().__init__(numpy)
+
+        self._rng = self._xp.random.default_rng(seed)
+
+    def copy(self):
+        res = super().copy()
+        res._rng = copy.deepcopy(self._rng)
+
+        return res
+
+    def normal(self, mean=0.0, std=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._rng.normal(mean, std, size)
+
+    def poisson(self, lam=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._rng.poisson(lam, size)
+
+    def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._rng.gamma(shape_param, scale, size)
+
+
+class RandomGeneratorCupy(RandomGeneratorNumpy):
+    def __init__(self, seed=None):
+        import cupy
+        super().__init__(cupy)
+
+        self._rng = self._xp.random.default_rng(seed)
+
+
+class RandomGeneratorTorch(RandomGenerator):
+    def __init__(self, seed=None):
+        import torch
+        super().__init__(torch)
+
+        self._rng = self._xp.Generator()
+        if seed is not None:
+            self._rng.manual_seed(seed)
+
+    def copy(self):
+        res = super().copy()
+        res._rng = self._xp.Generator()
+        res._rng.set_state(self._rng.get_state())
+
+        return res
+
+    def normal(self, mean=0.0, std=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._xp.randn(*size, generator=self._rng) * std + mean
+
+    def poisson(self, lam=1.0, *, size=None):
+        size = _normalize_size(size)
+        lam_tensor = self._xp.ones(size=size) * lam
+        return self._xp.poisson(lam_tensor, generator=self._rng)
+
+    def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
+        size = _normalize_size(size)
+        return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
+
+
+class RandomGeneratorJax(RandomGenerator):
+    def __init__(self, seed=None):
+        from jax import random
+        import jax.numpy
+        super().__init__(jax.numpy)
+        self._jax_random = random
+
+        self._rng = random.PRNGKey(seed or 0)
+
+    def copy(self):
+        res = super().copy()
+        res._jax_random = self._jax_random
+        res._rng = self._rng
+
+        return res
+
+    def normal(self, mean=0.0, std=1.0, *, size=None):
+        size = _normalize_size(size)
+        self._rng, subkey = self._jax_random.split(self._rng)
+        return self._jax_random.normal(subkey, size) * std + mean
+
+    def poisson(self, lam=1.0, *, size=None):
+        size = _normalize_size(size)
+        self._rng, subkey = self._jax_random.split(self._rng)
+        return self._jax_random.poisson(subkey, lam, shape=size)
+
+    def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
+        size = _normalize_size(size)
+        self._rng, subkey = self._jax_random.split(self._rng)
+        return self._jax_random.gamma(subkey, shape_param, shape=size) * scale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,7 @@ hcipy_tune_fourier = "hcipy.fourier.tuning:_cli"
 
 [tool.ruff]
 target-version = "py310"
+line-length = 150
+
+[tool.ruff.format]
+quote-style = "preserve"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "asdf",
     "importlib_metadata",
     "importlib_resources>=1.4 ; python_version<'3.9'",
-    "tqdm"
+    "tqdm",
+    "array_api_compat",
 ]
 
 [project.optional-dependencies]
@@ -79,3 +80,6 @@ write_to = "hcipy/_version.py"
 
 [project.scripts]
 hcipy_tune_fourier = "hcipy.fourier.tuning:_cli"
+
+[tool.ruff]
+target-version = "py310"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,33 @@ def disable_user_config():
     hcipy.Configuration().reset(enable_user_overrides=False)
     yield
     hcipy.Configuration().reset()
+
+def get_backend(backend_name):
+    if backend_name == 'numpy':
+        import numpy as np
+        return np
+    elif backend_name == 'cupy':
+        try:
+            import cupy as cp
+            return cp
+        except ImportError:
+            pytest.skip(f'{backend_name} not available')
+    elif backend_name == 'torch':
+        try:
+            import torch
+            return torch
+        except ImportError:
+            pytest.skip(f'{backend_name} not available')
+    elif backend_name == 'jax':
+        try:
+            import jax
+            return jax
+        except ImportError:
+            pytest.skip(f'{backend_name} not available')
+    else:
+        pytest.skip(f'{backend_name} not available')
+
+
+@pytest.fixture(params=['numpy', 'cupy', 'jax', 'torch'])
+def xp(request):
+    return get_backend(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,8 @@ def get_backend(backend_name):
             pytest.skip(f'{backend_name} not available')
     elif backend_name == 'jax':
         try:
-            import jax
-            return jax
+            import jax.numpy as jnp
+            return jnp
         except ImportError:
             pytest.skip(f'{backend_name} not available')
     else:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,7 +1,7 @@
 import pytest
 import hcipy
 import numpy as np
-from hcipy._math.random import RandomState
+from hcipy._math.random import RandomGenerator
 
 
 def _parameters():
@@ -58,9 +58,9 @@ def test_fft_acceleration(func, method, dtype_in, dtype_out):
         assert y_method.dtype == dtype_out
 
 
-def test_random_state_distribution(xp):
+def test_random_generator_distribution(xp):
     # Get samples from the Standard Normal distribution.
-    rng = RandomState(xp, seed=42)
+    rng = RandomGenerator(xp, seed=42)
     samples = rng.normal(size=(10000,))
 
     # Basic statistical tests for normal distribution
@@ -68,28 +68,28 @@ def test_random_state_distribution(xp):
     assert np.isclose(float(xp.std(samples)), 1.0, atol=0.05)
 
 
-def test_random_state_poisson(xp):
+def test_random_generator_poisson(xp):
     # Get samples from the Poisson distribution.
-    rng = RandomState(xp, seed=42)
+    rng = RandomGenerator(xp, seed=42)
     samples = rng.poisson(lam=2.0, size=(10000,))
 
     # Basic statistical tests for poisson distribution
     assert np.isclose(float(xp.mean(samples)), 2.0, atol=0.1)
 
 
-def test_random_state_gamma(xp):
+def test_random_generator_gamma(xp):
     # Get samples from the Gamma distribution.
-    rng = RandomState(xp, seed=42)
+    rng = RandomGenerator(xp, seed=42)
     samples = rng.gamma(scale=2.0, shape_param=2.0, size=(10000,))
 
     # Basic statistical tests (mean should be shape * scale = 2 * 2 = 4)
     assert np.isclose(float(xp.mean(samples)), 4.0, atol=0.5)
 
 
-def test_random_state_reproducible(xp):
-    # Create two RandomState objects with same seed
-    rng1 = RandomState(xp, seed=123)
-    rng2 = RandomState(xp, seed=123)
+def test_random_generator_reproducible(xp):
+    # Create two RandomGenerator objects with same seed
+    rng1 = RandomGenerator(xp, seed=123)
+    rng2 = RandomGenerator(xp, seed=123)
 
     # Generate samples
     samples1 = rng1.normal(size=(100,))
@@ -98,14 +98,13 @@ def test_random_state_reproducible(xp):
     assert np.allclose(samples1, samples2)
 
 
-def test_random_state_copy(xp):
+def test_random_generator_copy(xp):
     # Create initial rngs
-    rng1 = RandomState(xp, seed=42)
+    rng1 = RandomGenerator(xp, seed=42)
     rng2 = rng1.copy()
 
     # Generate some samples
     samples1 = rng1.normal(size=(10,))
-
 
     # Generate samples from copied rng
     samples2 = rng2.normal(size=(10,))
@@ -114,8 +113,8 @@ def test_random_state_copy(xp):
     assert np.allclose(samples1, samples2)
 
 
-def test_random_state_different_sizes(xp):
-    rng = RandomState(xp, seed=42)
+def test_random_generator_different_sizes(xp):
+    rng = RandomGenerator(xp, seed=42)
 
     # Test scalar output
     arr_0d = rng.normal()

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -122,10 +122,6 @@ def test_random_generator_different_sizes(xp, distribution):
 
     generation_func = getattr(rng, distribution)
 
-    # Test scalar output
-    arr_0d = generation_func()
-    assert arr_0d.shape == tuple()
-
     # Test 1D array
     arr_1d = generation_func(size=5)
     assert arr_1d.shape == (5,)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -80,7 +80,7 @@ def test_random_generator_poisson(xp, lam):
     assert np.isclose(float(xp.std(samples)), math.sqrt(lam), atol=0.1)
 
 
-@pytest.mark.parametrize('scale, shape', ((2.0, 2.0), (1.0, 3.0)))
+@pytest.mark.parametrize('scale, shape', ((2.0, 2.0), (1.0, 3.0), (1.0, 0.5)))
 def test_random_generator_gamma(xp, scale, shape):
     # Get samples from the Gamma distribution.
     rng = RandomGenerator(xp, seed=42)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -57,77 +57,83 @@ def test_fft_acceleration(func, method, dtype_in, dtype_out):
         assert np.allclose(y_numpy, y_method, rtol=rtol, atol=rtol)
         assert y_method.dtype == dtype_out
 
-
-def test_random_generator_distribution(xp):
+@pytest.mark.parametrize('mean, std', ((0.0, 1.0), (3.0, 2.0)))
+def test_random_generator_distribution(xp, mean, std):
     # Get samples from the Standard Normal distribution.
     rng = RandomGenerator(xp, seed=42)
-    samples = rng.normal(size=(10000,))
+    samples = rng.normal(mean, std, size=(10000,))
 
     # Basic statistical tests for normal distribution
-    assert np.isclose(float(xp.mean(samples)), 0.0, atol=0.05)
-    assert np.isclose(float(xp.std(samples)), 1.0, atol=0.05)
+    assert np.isclose(float(xp.mean(samples)), mean, atol=0.05)
+    assert np.isclose(float(xp.std(samples)), std, atol=0.05)
 
 
-def test_random_generator_poisson(xp):
+@pytest.mark.parametrize('lam', (1.0, 3.0))
+def test_random_generator_poisson(xp, lam):
     # Get samples from the Poisson distribution.
     rng = RandomGenerator(xp, seed=42)
-    samples = rng.poisson(lam=2.0, size=(10000,))
+    samples = rng.poisson(lam=lam, size=(10000,))
 
     # Basic statistical tests for poisson distribution
-    assert np.isclose(float(xp.mean(samples)), 2.0, atol=0.1)
+    assert np.isclose(float(xp.mean(samples)), lam, atol=0.1)
 
 
-def test_random_generator_gamma(xp):
+@pytest.mark.parametrize('scale, shape', ((2.0, 2.0), (1.0, 3.0)))
+def test_random_generator_gamma(xp, scale, shape):
     # Get samples from the Gamma distribution.
     rng = RandomGenerator(xp, seed=42)
-    samples = rng.gamma(scale=2.0, shape_param=2.0, size=(10000,))
+    samples = rng.gamma(scale=scale, shape_param=shape, size=(10000,))
 
-    # Basic statistical tests (mean should be shape * scale = 2 * 2 = 4)
-    assert np.isclose(float(xp.mean(samples)), 4.0, atol=0.5)
+    # Basic statistical tests (mean should be shape * scale)
+    assert np.isclose(float(xp.mean(samples)), shape * scale, atol=0.5)
 
 
-def test_random_generator_reproducible(xp):
+@pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
+def test_random_generator_reproducible(xp, distribution):
     # Create two RandomGenerator objects with same seed
     rng1 = RandomGenerator(xp, seed=123)
     rng2 = RandomGenerator(xp, seed=123)
 
     # Generate samples
-    samples1 = rng1.normal(size=(100,))
-    samples2 = rng2.normal(size=(100,))
+    samples1 = getattr(rng1, distribution)(size=(100,))
+    samples2 = getattr(rng2, distribution)(size=(100,))
 
+    # Check that samples are identical
     assert np.allclose(samples1, samples2)
 
 
-def test_random_generator_copy(xp):
+@pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
+def test_random_generator_copy(xp, distribution):
     # Create initial rngs
     rng1 = RandomGenerator(xp, seed=42)
     rng2 = rng1.copy()
 
     # Generate some samples
-    samples1 = rng1.normal(size=(10,))
-
-    # Generate samples from copied rng
-    samples2 = rng2.normal(size=(10,))
+    samples1 = getattr(rng1, distribution)(size=(10,))
+    samples2 = getattr(rng2, distribution)(size=(10,))
 
     # Should be identical
     assert np.allclose(samples1, samples2)
 
 
-def test_random_generator_different_sizes(xp):
+@pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
+def test_random_generator_different_sizes(xp, distribution):
     rng = RandomGenerator(xp, seed=42)
 
+    generation_func = getattr(rng, distribution)
+
     # Test scalar output
-    arr_0d = rng.normal()
+    arr_0d = generation_func()
     assert arr_0d.shape == tuple()
 
     # Test 1D array
-    arr_1d = rng.normal(size=5)
+    arr_1d = generation_func(size=5)
     assert arr_1d.shape == (5,)
 
     # Test 2D array
-    arr_2d = rng.normal(size=(3, 4))
+    arr_2d = generation_func(size=(3, 4))
     assert arr_2d.shape == (3, 4)
 
     # Test 3D array
-    arr_3d = rng.normal(size=(2, 3, 4))
+    arr_3d = generation_func(size=(2, 3, 4))
     assert arr_3d.shape == (2, 3, 4)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -2,6 +2,7 @@ import pytest
 import hcipy
 import numpy as np
 from hcipy._math.random import RandomGenerator
+import math
 
 
 def _parameters():
@@ -76,6 +77,7 @@ def test_random_generator_poisson(xp, lam):
 
     # Basic statistical tests for poisson distribution
     assert np.isclose(float(xp.mean(samples)), lam, atol=0.1)
+    assert np.isclose(float(xp.std(samples)), math.sqrt(lam), atol=0.1)
 
 
 @pytest.mark.parametrize('scale, shape', ((2.0, 2.0), (1.0, 3.0)))
@@ -85,7 +87,8 @@ def test_random_generator_gamma(xp, scale, shape):
     samples = rng.gamma(scale=scale, shape_param=shape, size=(10000,))
 
     # Basic statistical tests (mean should be shape * scale)
-    assert np.isclose(float(xp.mean(samples)), shape * scale, atol=0.5)
+    assert np.isclose(float(xp.mean(samples)), shape * scale, atol=0.1)
+    assert np.isclose(float(xp.std(samples)), math.sqrt(shape) * scale, atol=0.1)
 
 
 @pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,7 +1,7 @@
 import pytest
 import hcipy
 import numpy as np
-from hcipy._math.random import RandomGenerator
+from hcipy._math.random import make_random_generator
 import math
 
 
@@ -61,7 +61,7 @@ def test_fft_acceleration(func, method, dtype_in, dtype_out):
 @pytest.mark.parametrize('mean, std', ((0.0, 1.0), (3.0, 2.0)))
 def test_random_generator_distribution(xp, mean, std):
     # Get samples from the Standard Normal distribution.
-    rng = RandomGenerator(xp, seed=42)
+    rng = make_random_generator(xp, seed=42)
     samples = rng.normal(mean, std, size=(10000,))
 
     # Basic statistical tests for normal distribution
@@ -72,7 +72,7 @@ def test_random_generator_distribution(xp, mean, std):
 @pytest.mark.parametrize('lam', (1.0, 3.0))
 def test_random_generator_poisson(xp, lam):
     # Get samples from the Poisson distribution.
-    rng = RandomGenerator(xp, seed=42)
+    rng = make_random_generator(xp, seed=42)
     samples = rng.poisson(lam=lam, size=(10000,))
 
     # Basic statistical tests for poisson distribution
@@ -83,7 +83,7 @@ def test_random_generator_poisson(xp, lam):
 @pytest.mark.parametrize('scale, shape', ((2.0, 2.0), (1.0, 3.0), (1.0, 0.5)))
 def test_random_generator_gamma(xp, scale, shape):
     # Get samples from the Gamma distribution.
-    rng = RandomGenerator(xp, seed=42)
+    rng = make_random_generator(xp, seed=42)
     samples = rng.gamma(scale=scale, shape_param=shape, size=(10000,))
 
     # Basic statistical tests (mean should be shape * scale)
@@ -93,9 +93,9 @@ def test_random_generator_gamma(xp, scale, shape):
 
 @pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
 def test_random_generator_reproducible(xp, distribution):
-    # Create two RandomGenerator objects with same seed
-    rng1 = RandomGenerator(xp, seed=123)
-    rng2 = RandomGenerator(xp, seed=123)
+    # Create two make_random_generator objects with same seed
+    rng1 = make_random_generator(xp, seed=123)
+    rng2 = make_random_generator(xp, seed=123)
 
     # Generate samples
     samples1 = getattr(rng1, distribution)(size=(100,))
@@ -108,7 +108,7 @@ def test_random_generator_reproducible(xp, distribution):
 @pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
 def test_random_generator_copy(xp, distribution):
     # Create initial rngs
-    rng1 = RandomGenerator(xp, seed=42)
+    rng1 = make_random_generator(xp, seed=42)
     rng2 = rng1.copy()
 
     # Generate some samples
@@ -121,7 +121,7 @@ def test_random_generator_copy(xp, distribution):
 
 @pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
 def test_random_generator_different_sizes(xp, distribution):
-    rng = RandomGenerator(xp, seed=42)
+    rng = make_random_generator(xp, seed=42)
 
     generation_func = getattr(rng, distribution)
 


### PR DESCRIPTION
Related to #299 but independent.

This PR adds a `RandomGenerator` class. The `RandomGenerator` class provides a unified and consistent API for generating random numbers across various array API namespaces such as NumPy, CuPy, PyTorch, and JAX. Its primary purpose is to abstract away the specific implementations and nuances of random number generation in these different libraries, allowing users to write generic code that works regardless of the underlying array backend. It initializes an appropriate random number generator based on the provided namespace and an optional seed.

The class exposes common methods for sampling from statistical distributions, including `normal()` (Gaussian), `poisson()`, and `gamma()`. It internally manages the state of the random number generator, handling differences such as explicit PRNG key splitting for JAX's functional paradigm or state management for PyTorch. Additionally, it includes a `copy()` method to create an independent duplicate of the current random state.

I'm also sneaking in a Ruff config change to ignore python 3.8 warnings (which is a Python version that is no longer supported). It was annoying me, sorry.

Also, since most backends are not tested by CI, the coverage will go down despite my best efforts to add comprehensive tests. Tests will be performed if the library is installed.