### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/conda_environments/docs_env.yml
+++ b/.github/conda_environments/docs_env.yml
@@ -1,4 +1,6 @@
 name: ci-env
+channels:
+  - defaults
 dependencies:
   - numpy
   - scipy

--- a/.github/conda_environments/testing_env.yml
+++ b/.github/conda_environments/testing_env.yml
@@ -1,4 +1,6 @@
 name: ci-env
+channels:
+  - defaults
 dependencies:
   - numpy
   - scipy

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -33,7 +33,7 @@ jobs:
         activate-environment: ci-env
         python-version: "3.14"
         environment-file: ./.github/conda_environments/testing_env.yml
-        auto-activate-base: false
+        auto-activate: false
 
     - name: Install optional dependencies if available
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
         activate-environment: ci-env
         python-version: 3.14
         environment-file: .github/conda_environments/docs_env.yml
-        auto-activate-base: false
+        auto-activate: false
     - name: Install our package
       run: |
         pip install -e ".[doc]"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
         activate-environment: ci-env
         python-version: ${{ matrix.python_version }}
         environment-file: .github/conda_environments/testing_env.yml
-        auto-activate-base: false
+        auto-activate: false
     - name: Install optional dependencies if available
       run: |
         while read requirement; do


### PR DESCRIPTION
Fixes deprecations from conda-incubator/setup-miniconda:
* Change `auto-activate-base` to `auto-activate`.
* Add `defaults` channel to conda environment files.