### PR TITLE
Add fourier convolution and correlation functions.

### DIFF
--- a/hcipy/fourier/__init__.py
+++ b/hcipy/fourier/__init__.py
@@ -7,6 +7,8 @@ __all__ = [
     'is_fft_grid',
     'FastFourierTransform',
     'FourierFilter',
+    'make_fourier_convolution',
+    'make_fourier_correlation',
     'FourierShift',
     'FourierShear',
     'FourierRotation',

--- a/hcipy/fourier/fourier_operations.py
+++ b/hcipy/fourier/fourier_operations.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 from .fast_fourier_transform import FastFourierTransform, make_fft_grid, _numexpr_grid_shift
-from ..field import Field, field_dot, field_conjugate_transpose, CartesianGrid, RegularCoords
+from .fourier_transform import make_fourier_transform
+from ..field import Field, field_dot, field_conjugate_transpose, CartesianGrid, RegularCoords, make_uniform_grid
 from .._math import fft as _fft_module
-
 
 class FourierFilter(object):
     '''A filter in the Fourier domain.
@@ -149,6 +149,108 @@ class FourierFilter(object):
             res = f[c].reshape(s)
 
         return Field(res, self.input_grid)
+
+def _make_fourier_kernel_filter(input_grid, kernel, q=1, conjugate=False):
+    '''Internal helper that returns a :class:`FourierFilter` for convolution or correlation.
+
+    Parameters
+    ----------
+    input_grid : Grid
+        The grid that is expected for the input field.
+    kernel : Field or callable
+        The spatial kernel. If a callable, it is evaluated on a grid with the
+        same delta as ``input_grid`` and ``dims = tuple(d * q for d in input_grid.dims)``.
+        If a :class:`Field`, its grid's ``delta`` must match ``input_grid.delta``;
+        its coordinate system is used directly to compute the transfer function.
+    q : scalar
+        The amount of zeropadding to perform in the real domain.
+    conjugate : boolean
+        If True, the resulting transfer function is conjugated, producing a
+        correlation. If False (the default), the operation is a convolution.
+
+    Returns
+    -------
+    FourierFilter
+        A :class:`FourierFilter` that applies the convolution or correlation.
+    '''
+    fft = FastFourierTransform(input_grid, q)
+
+    if callable(kernel):
+        # Build a grid for the callable that has the same delta as input_grid
+        # and dims scaled by q.
+        kernel_dims = tuple(d * q for d in input_grid.dims)
+        kernel_extent = tuple(d * delta for d, delta in zip(kernel_dims, input_grid.delta))
+        kernel_grid = make_uniform_grid(kernel_dims, kernel_extent, has_center=False)
+
+        kernel_field = kernel(kernel_grid)
+    else:
+        if not np.allclose(kernel.grid.delta, input_grid.delta):
+            raise ValueError('The kernel grid delta must match the input grid delta.')
+        kernel_field = kernel
+
+    kernel_fft = make_fourier_transform(kernel_field.grid, fft.output_grid)
+    transfer_function = kernel_fft.forward(kernel_field)
+
+    if conjugate:
+        transfer_function = np.conj(transfer_function)
+
+    return FourierFilter(input_grid, transfer_function, q)
+
+def make_fourier_convolution(input_grid, kernel, q=1):
+    '''Create a :class:`FourierFilter` that performs convolution with a spatial kernel.
+
+    Parameters
+    ----------
+    input_grid : Grid
+        The grid that is expected for the input field.
+    kernel : Field or Field generator
+        The spatial convolution kernel. If a callable, it is evaluated on the
+        internal  spatial grid and must return a :class:`Field`. If a
+        :class:`Field`, its grid's ``delta`` must equal ``input_grid.delta``.
+    q : scalar
+        The amount of zeropadding to perform in the real domain. A value of 1
+        means no zeropadding.
+
+    Returns
+    -------
+    FourierFilter
+        An operator that performs the convolution.
+
+    Raises
+    ------
+    ValueError
+        When a Field is given as the kernel, and its pixel size is not the same
+        as the pixel size of the input grid.
+    '''
+    return _make_fourier_kernel_filter(input_grid, kernel, q, conjugate=False)
+
+def make_fourier_correlation(input_grid, kernel, q=1):
+    '''Create a :class:`FourierFilter` that performs correlation with a spatial kernel.
+
+    Parameters
+    ----------
+    input_grid : Grid
+        The grid that is expected for the input field.
+    kernel : Field or callable
+        The spatial correlation kernel. If a callable, it is evaluated on the
+        internal padded spatial grid and must return a :class:`Field`. If a
+        :class:`Field`, its grid's ``delta`` must equal ``input_grid.delta``.
+    q : scalar
+        The amount of zeropadding to perform in the real domain. A value of 1
+        means no zeropadding.
+
+    Returns
+    -------
+    FourierFilter
+        An operator that performs the correlation.
+
+    Raises
+    ------
+    ValueError
+        When a Field is given as the kernel, and its pixel size is not the same
+        as the pixel size of the input grid.
+    '''
+    return _make_fourier_kernel_filter(input_grid, kernel, q, conjugate=True)
 
 class FourierShift:
     '''An image shifting operator implemented in the Fourier domain.

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -4,6 +4,7 @@ import pytest
 from packaging import version
 import scipy.signal
 import os
+from hcipy._math.random import make_random_generator
 
 def make_all_fourier_transforms(input_grid, q, fov, shift):
     fft1 = FastFourierTransform(input_grid, q=q, fov=fov, shift=shift, emulate_fftshifts=True)
@@ -306,6 +307,84 @@ def test_fourier_filter():
 
                     assert np.allclose(f_out_fft, f_out_ff)
                     assert np.allclose(f_in_fft, f_in_ff)
+
+def _reference_convolution_or_correlation(f_in, kernel, q, conjugate):
+    fft = FastFourierTransform(f_in.grid, q)
+
+    kernel_fft = make_fourier_transform(kernel.grid, fft.output_grid)
+    transfer_function = kernel_fft.forward(kernel)
+
+    if conjugate:
+        transfer_function = np.conj(transfer_function)
+
+    ft = fft.forward(f_in)
+    ft *= transfer_function
+    res = fft.backward(ft)
+
+    return res
+
+def _gaussian(grid, sigma=0.15):
+    r = grid.as_('polar').r
+    data = np.exp(-r**2 / (2 * sigma**2))
+
+    return Field(data, grid)
+
+@pytest.mark.parametrize('n', [16, 17, [16, 17]])
+@pytest.mark.parametrize('q', [1, 2, 3])
+def test_fourier_convolution(n, q):
+    input_grid = make_pupil_grid(n, 1)
+
+    kernel_grid = make_pupil_grid(tuple(d * q for d in input_grid.dims), q)
+    assert input_grid.delta[0] == kernel_grid.delta[0]
+
+    kernel = _gaussian(kernel_grid)
+    op_direct = make_fourier_convolution(input_grid, kernel, q)
+    op_callable = make_fourier_convolution(input_grid, _gaussian, q)
+
+    rng = make_random_generator(np, seed=0)
+    f_in = Field(rng.normal(size=input_grid.size) + 1j * rng.normal(size=input_grid.size), input_grid)
+
+    ref = _reference_convolution_or_correlation(f_in, kernel, q, conjugate=False)
+
+    assert np.allclose(ref, op_direct.forward(f_in))
+    assert np.allclose(ref, op_callable.forward(f_in))
+
+@pytest.mark.parametrize('n', [16, 17, [16, 17]])
+@pytest.mark.parametrize('q', [1, 2, 3])
+def test_fourier_correlation(n, q):
+    input_grid = make_pupil_grid(n, 1)
+
+    kernel_grid = make_pupil_grid(tuple(d * q for d in input_grid.dims), q)
+    assert input_grid.delta[0] == kernel_grid.delta[0]
+
+    kernel = _gaussian(kernel_grid)
+    op_direct = make_fourier_correlation(input_grid, kernel, q)
+    op_callable = make_fourier_correlation(input_grid, _gaussian, q)
+
+    rng = make_random_generator(np, seed=0)
+    f_in = Field(rng.normal(size=input_grid.size) + 1j * rng.normal(size=input_grid.size), input_grid)
+
+    ref = _reference_convolution_or_correlation(f_in, kernel, q, conjugate=True)
+
+    assert np.allclose(ref, op_direct.forward(f_in))
+    assert np.allclose(ref, op_callable.forward(f_in))
+
+def test_fourier_convolution_correlation_errors():
+    input_grid = make_pupil_grid(8)
+
+    # A Field kernel with mismatched delta should raise.
+    bad_grid = input_grid.scaled(1.1)
+    bad_kernel = bad_grid.ones(dtype='complex')
+
+    with pytest.raises(ValueError):
+        make_fourier_convolution(input_grid, bad_kernel, q=1)
+
+    # A Field kernel that does not fit in the padded grid should raise.
+    huge_grid = make_pupil_grid(16)
+    huge_kernel = huge_grid.ones()
+
+    with pytest.raises(ValueError):
+        make_fourier_convolution(input_grid, huge_kernel, q=1)
 
 def check_czt_vs_scipy(x, m, w, a, dtype):
     # Check that the CZT gives the same answer as the scipy implementation.


### PR DESCRIPTION
## Summary

Adds `make_fourier_convolution()` and `make_fourier_correlation()`, which construct a `FourierFilter` pre-computed from a spatial kernel (provided as a Field or a Field generator). Also adds a private `_make_fourier_kernel_filter()` helper to share the common logic. Includes tests against a reference implementation for various grid sizes and zeropadding factors, plus error-case tests for delta mismatches and oversized kernels.

## Usage

```python
import numpy as np
import matplotlib.pyplot as plt
from hcipy import *

grid = make_pupil_grid(128, 1)
noise = Field(np.random.normal(0, 1, grid.size), grid)

def gaussian_kernel(grid, sigma=0.02):
    r = grid.as_('polar').r
    return Field(np.exp(-r**2 / (2 * sigma**2)), grid)

conv = make_fourier_convolution(grid, gaussian_kernel, q=2)
smoothed = conv.forward(noise)

plt.figure(figsize=(10, 4))
plt.subplot(121)
imshow_field(noise, cmap='RdBu')
plt.title('Gaussian noise')

plt.subplot(122)
imshow_field(smoothed.real, cmap='RdBu')
plt.title('Noise convolved with Gaussian')

plt.tight_layout()
plt.show()
```

<img width="1500" height="600" alt="convolution_demo" src="https://github.com/user-attachments/assets/619b4130-8dc8-4545-bb3c-4a984d22290f" />