### PR TITLE
Fix documentation and community standards.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **reported by contacting the project team at conduct@hcipy.org.**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to HCIPy
+
+We welcome contributions of all kinds — bug reports, documentation improvements, new optical elements, and other enhancements.
+
+## Getting started
+
+- For a detailed walkthrough, see the [contributing guide](https://docs.hcipy.org/dev/development/contributing_guide.html).
+- Report bugs or request features by [opening an issue](https://github.com/ehpor/hcipy/issues/new/choose).
+
+## Code contributions
+
+1. **Discuss first.** Open an issue to let us know what you'd like to work on so your effort isn't wasted.
+2. **Create a feature branch** from `master`.
+3. **Commit logically.** Keep commits focused on a single logical change.
+4. **Push and open a pull request.** Link any relevant issues in the PR description.
+5. **Review.** A maintainer will review your changes.
+
+### Checklist for new code
+
+- Follow the [coding style](https://docs.hcipy.org/dev/development/project_setup.html#coding-style).
+- Add docstrings for all public classes and functions (numpydoc format).
+- Add tests for new functionality. Coverage should not decrease without good reason.
+- Ensure the full test suite passes: `pytest .`
+- Make sure the documentation still builds: `cd doc && make html`
+
+## Questions?
+
+Open a discussion or issue on [GitHub](https://github.com/ehpor/hcipy).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 HCIPy is an open-source object-oriented framework written in Python for performing end-to-end simulations of high-contrast imaging instruments for astronomy.
 
-The library defines wavefronts and optical elements for defining an optical system, and provides both Fraunhofer and Fresnel diffraction propgators. Polarization is supported using Jones calculus, with polarizers and waveplates included out of the box. It implements atmospheric turbulence using thin infinitely-long phase screens, and can model scintillation using Fresnel propagation between individual layers. Many wavefront sensors are implemented including a Shack-Hartmann and Pyramid wavefront sensor. Implemented coronagraphs include the vortex, Lyot and APP coronagraph.
+The library defines wavefronts and optical elements for defining an optical system, and provides both Fraunhofer and Fresnel diffraction propagators. Polarization is supported using Jones calculus, with polarizers and waveplates included out of the box. It implements atmospheric turbulence using thin infinitely-long phase screens, and can model scintillation using Fresnel propagation between individual layers. Many wavefront sensors are implemented including a Shack-Hartmann and Pyramid wavefront sensor. Implemented coronagraphs include the vortex, Lyot and APP coronagraph.
 
 By including simulation of both adaptive optics and coronagraphy into a single framework, HCIPy allows simulations including feedback from post-coronagraphic focal-plane wavefront sensors to the AO system.
 
@@ -19,7 +19,7 @@ The main website is hosted at <https://hcipy.org>. For documentation, see <https
 
 ## Team
 
-HCIPy was originally developed by a small team of astronomers at Leiden Observatory, but has since received external constributions from scientists and software developers around the world. For a current list, please visit our [website](https://hcipy.org/team.html).
+HCIPy was originally developed by a small team of astronomers at Leiden Observatory, but has since received external contributions from scientists and software developers around the world. For a current list, please visit our [website](https://hcipy.org/team.html).
 
 ## Citing
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,10 +33,18 @@
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.linkcode',
     'sphinx_automodapi.automodapi',
     'numpydoc',
     'nbsphinx']
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
+}
 
 numpydoc_show_class_members = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HCIPy'
-copyright = u'2017-2022, Emiel Por'
+copyright = u'2017-2026, Emiel Por'
 author = u'Emiel Por'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/development/project_setup.rst
+++ b/doc/development/project_setup.rst
@@ -12,12 +12,14 @@ This section explains the content of the repository:
 * **doc**. This folder contains the full documentation.
 * **tests**. This folder contains the unit tests, separated by submodule.
 * **examples**. This folder contains old examples. These examples should be rewritten into tutorials for the documentation. Do not add new examples here.
-* **pyproject.toml**. This file is necessary for pip installation.
-* **setup.py**. This file was used for pip installation, but is now deprecated. It is being kept for backwards compatibility.
+* **pyproject.toml**. The main project configuration file. Contains package metadata, dependencies, build system configuration, and tool settings (ruff).
+* **setup.py**. Minimal shim left for backwards compatibility with older pip versions. Delegates to setuptools_scm via pyproject.toml.
 * **README.md**. Main repository readme file.
 * **LICENSE**. A copy of the MIT license, which should be redistributed with any copy of HCIPy.
-* **.azure-pipelines.yml**. Configuration file for the continuous integration service.
-* **.flake8**. Configuration file for the Python linting.
+* **.github/workflows/**. Contains GitHub Actions workflows for continuous integration, linting, documentation building, and array API compliance testing.
+* **.github/conda_environments/**. Conda environment files used by CI workflows.
+* **.github/dependabot.yml**. Configuration for automated dependency updates via Dependabot.
+* **.flake8**. Configuration file for flake8 linting.
 * **.coveragerc**. Configuration file for test coverage.
 * **.gitignore**. List of files to ignore for the version control system.
 
@@ -30,11 +32,11 @@ Development for HCIPy takes place completely on `Github <https://github.com/ehpo
 
 We prefer git commits that are appropriately sized. That is, use a single commit for one logical change to the code base. Do not commit a whole feature consisting of many-hundreds of new lines of code in a single commit. Useful commits should show the line of development separated in logical parts.
 
-Git is also used to generate a version string, available as ``hcipy.__version__``. We use the `setuptools_scm <https://pypi.org/project/setuptools-scm/>`__. This means that for an editable installation of HCIPy, the version needs to be updated after you pull the repository.
+Git is also used to generate a version string, available as ``hcipy.__version__``. We use `setuptools_scm <https://pypi.org/project/setuptools-scm/>`__, which derives the version from git tags. For an editable installation, the version is updated automatically on each import; after pulling new tags you can re-install with:
 
 .. code-block:: shell
 
-    python setup.py egg_info
+    pip install -e .
 
 .. _coding-style:
 
@@ -54,7 +56,7 @@ We adhere mostly to `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__, the of
 Continuous integration and test suite
 -------------------------------------
 
-HCIPy currently supports Python 3.7+ on Linux, MacOS and Windows. To make sure that it keeps working as expected on all these configurations, we have set up automatic testing on each of these. We currently use `Azure <https://dev.azure.com/ehpor/hcipy/_build?definitionId=1>`__ to run our integrated testing suite. The configuration file for this service is **.azure-pipelines.yml**, which shows Azure how to install HCIPy and its dependencies, and on which operating systems and with which Python versions to test HCIPy. The testing itself is done via the `pytest <https://docs.pytest.org/en/latest/>`__ library.
+HCIPy currently supports Python 3.11+ on Linux, MacOS and Windows. To make sure that it keeps working as expected on all these configurations, we have set up automatic testing on each of these. We use `GitHub Actions <https://github.com/ehpor/hcipy/actions>`__ to run our integrated testing suite. The configuration files for this service are in **.github/workflows/**, which define how to install HCIPy and its dependencies, and on which operating systems and with which Python versions to test HCIPy. The testing itself is done via the `pytest <https://docs.pytest.org/en/latest/>`__ library.
 
 The test suite tests all major features of HCIPy. In the name of efficiency, HCIPy does not contain much so-called unit tests, but rather tests high-level behaviour, which implicitly tests low-level functions as well. For example, for the atmospheric model, we test whether then variance of the outcoming wavefront conforms to analytic formula, and whether the variance projection on a certain Zernike mode conforms to analytic formula, rather than testing the smallest possible unit of the atmospheric model. Tests are located in **tests/test_[submodule_name].py**, separated by submodule. All tests can be run with:
 
@@ -68,7 +70,7 @@ To reduce the time taken for the suite of tests, we have separated them into com
 
     pytest ./tests --runslow
 
-Test coverage is reported for all branches and pull requests on `Coveralls <https://coveralls.io/github/ehpor/hcipy>`__, based on the tests performed on Linux with Python 3.7 by Travis-CI.
+Test coverage is reported for all branches and pull requests on `codecov <https://codecov.io/gh/ehpor/hcipy>`__.
 
 Documentation
 -------------

--- a/doc/team.rst
+++ b/doc/team.rst
@@ -1,7 +1,7 @@
 The team
 ========
 
-HCIPy was originally developed by a small team of astronomers at Leiden University, but has since received external constributions from scientists and software developers around the world.
+HCIPy was originally developed by a small team of astronomers at Leiden University, but has since received external contributions from scientists and software developers around the world.
 
 Direct contributors to code
 ---------------------------


### PR DESCRIPTION
This PR fixes the project setup documentation which was severely outdated. It also adds a code of conduct ([Contributor Covenant](https://www.contributor-covenant.org/)) and short contributing guidelines, both to improve the Github Community Standards of this repo.

I added email conduct@hcipy.org and checked that emails are received on this email address.