### PR TITLE
Do not ignore overwrite parameter in `write_fits()`.

### DIFF
--- a/hcipy/util/io.py
+++ b/hcipy/util/io.py
@@ -81,7 +81,7 @@ def write_fits(data, filename, shape=None, overwrite=True):
     if hdu is None:
         hdu = fits.PrimaryHDU(data)
 
-    hdu.writeto(filename, overwrite=True)
+    hdu.writeto(filename, overwrite=overwrite)
 
 def _guess_file_format(filename):
     '''Guess the file format from the filename.


### PR DESCRIPTION
The `overwrite` was hardcoded as `True` and the function parameter was completely ignored.