### PR TITLE
Add more distributions and functions on `RandomGenerator`.

### DIFF
--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -1,4 +1,4 @@
-from array_api_compat import is_numpy_namespace, is_torch_namespace, is_jax_namespace, is_cupy_namespace
+from array_api_compat import is_numpy_namespace, is_torch_namespace, is_jax_namespace, is_cupy_namespace, is_array_api_strict_namespace
 import copy
 import math
 
@@ -26,6 +26,8 @@ def make_random_generator(xp, seed=None):
         return RandomGeneratorTorch(seed)
     elif is_jax_namespace(xp):
         return RandomGeneratorJax(seed)
+    elif is_array_api_strict_namespace(xp):
+        return RandomGeneratorArrayApiStrict(seed)
     else:
         raise ValueError(f"Unsupported namespace: {xp}")
 
@@ -395,3 +397,28 @@ class RandomGeneratorJax(RandomGenerator):
         self._rng, subkey = self._jax_random.split(self._rng)
         return self._jax_random.choice(subkey, a, shape=size, replace=replace, p=p)
 
+
+class RandomGeneratorArrayApiStrict(RandomGeneratorNumpy):
+    def normal(self, mean=0.0, std=1.0, *, size=None):
+        res = super().normal(mean=mean, std=std, size=size)
+        return self._xp.asarray(res)
+
+    def poisson(self, lam=1.0, *, size=None):
+        res = super().poisson(lam=lam, size=size)
+        return self._xp.asarray(res)
+
+    def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
+        res = super().gamma(scale=scale, shape_param=shape_param, size=size)
+        return self._xp.asarray(res)
+
+    def uniform(self, low=0.0, high=1.0, *, size=None):
+        res = super().uniform(low=low, high=high, size=size)
+        return self._xp.asarray(res)
+
+    def exponential(self, scale=1.0, *, size=None):
+        res = super().exponential(scale=scale, size=size)
+        return self._xp.asarray(res)
+
+    def choice(self, a, *, size=None, replace=True, p=None):
+        res = super().choice(a, size=size, replace=replace, p=p)
+        return self._xp.asarray(res)

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -177,6 +177,68 @@ class RandomGenerator:
         """
         raise NotImplementedError()
 
+    def uniform(self, low=0.0, high=1.0, *, size=None):
+        """Generate random samples from a uniform distribution.
+
+        Parameters
+        ----------
+        low : float, optional
+            Lower bound of the distribution, by default 0.0.
+        high : float, optional
+            Upper bound of the distribution, by default 1.0.
+        size : int or tuple of ints, optional
+            Output shape. If ``None``, a single scalar value is returned, by default None.
+
+        Returns
+        -------
+        array
+            An array of specified shape filled with random samples from the
+            uniform distribution.
+        """
+        raise NotImplementedError()
+
+    def exponential(self, scale=1.0, *, size=None):
+        """Generate random samples from an exponential distribution.
+
+        Parameters
+        ----------
+        scale : float, optional
+            The scale parameter (inverse of rate), by default 1.0.
+        size : int or tuple of ints, optional
+            Output shape. If ``None``, a single scalar value is returned, by default None.
+
+        Returns
+        -------
+        array
+            An array of specified shape filled with random samples from the
+            exponential distribution.
+        """
+        raise NotImplementedError()
+
+    def choice(self, a, *, size=None, replace=True, p=None):
+        """Generate random samples from a given array.
+
+        Parameters
+        ----------
+        a : array-like or int
+            If an array, a random sample is generated from its elements.
+            If an int, the random sample is generated from ``range(a)``.
+        size : int or tuple of ints, optional
+            Output shape. If ``None``, a single scalar value is returned, by default None.
+        replace : bool, optional
+            Whether to sample with replacement, by default True.
+        p : array-like, optional
+            The probabilities of each element in ``a``. If not given, the
+            sample assumes a uniform distribution over all entries in ``a``.
+
+        Returns
+        -------
+        array
+            An array of specified shape filled with random samples from
+            the given array.
+        """
+        raise NotImplementedError()
+
 
 class RandomGeneratorNumpy(RandomGenerator):
     def __init__(self, seed=None):
@@ -202,6 +264,18 @@ class RandomGeneratorNumpy(RandomGenerator):
     def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
         size = _normalize_size(size)
         return self._rng.gamma(shape_param, scale, size)
+
+    def uniform(self, low=0.0, high=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._rng.uniform(low, high, size)
+
+    def exponential(self, scale=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._rng.exponential(scale, size)
+
+    def choice(self, a, *, size=None, replace=True, p=None):
+        size = _normalize_size(size)
+        return self._rng.choice(a, size, replace=replace, p=p)
 
 
 class RandomGeneratorCupy(RandomGeneratorNumpy):
@@ -241,6 +315,39 @@ class RandomGeneratorTorch(RandomGenerator):
         size = _normalize_size(size)
         return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
 
+    def uniform(self, low=0.0, high=1.0, *, size=None):
+        size = _normalize_size(size)
+        return self._xp.rand(*size, generator=self._rng) * (high - low) + low
+
+    def exponential(self, scale=1.0, *, size=None):
+        size = _normalize_size(size)
+        return -scale * self._xp.log(self._xp.rand(*size, generator=self._rng))
+
+    def choice(self, a, *, size=None, replace=True, p=None):
+        import math as _math
+
+        size = _normalize_size(size)
+        n = _math.prod(size)
+
+        if isinstance(a, int):
+            population = None
+            n_pop = a
+        else:
+            population = self._xp.asarray(a)
+            n_pop = len(population)
+
+        if p is None:
+            indices = self._xp.randint(0, n_pop, size, generator=self._rng)
+        else:
+            p_tensor = self._xp.asarray(p, dtype=self._xp.float64)
+            p_tensor = p_tensor / p_tensor.sum()
+            indices = self._xp.multinomial(p_tensor, n, replacement=replace, generator=self._rng)
+            indices = indices.reshape(size)
+
+        if population is None:
+            return indices
+        return population[indices]
+
 
 class RandomGeneratorJax(RandomGenerator):
     def __init__(self, seed=None):
@@ -272,3 +379,19 @@ class RandomGeneratorJax(RandomGenerator):
         size = _normalize_size(size)
         self._rng, subkey = self._jax_random.split(self._rng)
         return self._jax_random.gamma(subkey, shape_param, shape=size) * scale
+
+    def uniform(self, low=0.0, high=1.0, *, size=None):
+        size = _normalize_size(size)
+        self._rng, subkey = self._jax_random.split(self._rng)
+        return self._jax_random.uniform(subkey, shape=size, minval=low, maxval=high)
+
+    def exponential(self, scale=1.0, *, size=None):
+        size = _normalize_size(size)
+        self._rng, subkey = self._jax_random.split(self._rng)
+        return self._jax_random.exponential(subkey, shape=size) * scale
+
+    def choice(self, a, *, size=None, replace=True, p=None):
+        size = _normalize_size(size)
+        self._rng, subkey = self._jax_random.split(self._rng)
+        return self._jax_random.choice(subkey, a, shape=size, replace=replace, p=p)
+

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -399,26 +399,42 @@ class RandomGeneratorJax(RandomGenerator):
 
 
 class RandomGeneratorArrayApiStrict(RandomGeneratorNumpy):
+    def __init__(self, seed=None):
+        super().__init__(seed)
+
+        import array_api_strict
+        self._strict_xp = array_api_strict
+
+    def copy(self):
+        res = super().copy()
+        res._strict_xp = self._strict_xp
+
+        return res
+
     def normal(self, mean=0.0, std=1.0, *, size=None):
         res = super().normal(mean=mean, std=std, size=size)
-        return self._xp.asarray(res)
+        return self._strict_xp.asarray(res)
 
     def poisson(self, lam=1.0, *, size=None):
         res = super().poisson(lam=lam, size=size)
-        return self._xp.asarray(res)
+        return self._strict_xp.asarray(res)
 
     def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
         res = super().gamma(scale=scale, shape_param=shape_param, size=size)
-        return self._xp.asarray(res)
+        return self._strict_xp.asarray(res)
 
     def uniform(self, low=0.0, high=1.0, *, size=None):
         res = super().uniform(low=low, high=high, size=size)
-        return self._xp.asarray(res)
+        return self._strict_xp.asarray(res)
 
     def exponential(self, scale=1.0, *, size=None):
         res = super().exponential(scale=scale, size=size)
-        return self._xp.asarray(res)
+        return self._strict_xp.asarray(res)
 
     def choice(self, a, *, size=None, replace=True, p=None):
+        a = a if isinstance(a, int) else self._xp.from_dlpack(a)
+        p = p if p is None else self._xp.from_dlpack(p)
+
         res = super().choice(a, size=size, replace=replace, p=p)
-        return self._xp.asarray(res)
+
+        return self._strict_xp.asarray(res)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "dill",
     "flake8",
     "mypy",
+    "array_api_strict",
 ]
 doc = [
     "numpydoc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def get_backend(backend_name):
             pytest.skip(f'{backend_name} not available')
     elif backend_name == 'torch':
         try:
-            import torch
+            import array_api_compat.torch as torch
             return torch
         except ImportError:
             pytest.skip(f'{backend_name} not available')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,10 +39,16 @@ def get_backend(backend_name):
             return jnp
         except ImportError:
             pytest.skip(f'{backend_name} not available')
+    elif backend_name == 'array_api_strict':
+        try:
+            import array_api_strict
+            return array_api_strict
+        except ImportError:
+            pytest.skip(f'{backend_name} not available')
     else:
         pytest.skip(f'{backend_name} not available')
 
 
-@pytest.fixture(params=['numpy', 'cupy', 'jax', 'torch'])
+@pytest.fixture(params=['numpy', 'cupy', 'jax', 'torch', 'array_api_strict'])
 def xp(request):
     return get_backend(request.param)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -74,6 +74,7 @@ def test_random_generator_poisson(xp, lam):
     # Get samples from the Poisson distribution.
     rng = make_random_generator(xp, seed=42)
     samples = rng.poisson(lam=lam, size=(10000,))
+    samples = xp.astype(samples, xp.float32)
 
     # Basic statistical tests for poisson distribution
     assert np.isclose(float(xp.mean(samples)), lam, atol=0.1)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -91,48 +91,117 @@ def test_random_generator_gamma(xp, scale, shape):
     assert np.isclose(float(xp.std(samples)), math.sqrt(shape) * scale, atol=0.1)
 
 
-@pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
-def test_random_generator_reproducible(xp, distribution):
+@pytest.mark.parametrize('low, high', ((0.0, 1.0), (-2.0, 5.0)))
+def test_random_generator_uniform(xp, low, high):
+    # Get samples from the Uniform distribution.
+    rng = make_random_generator(xp, seed=42)
+    samples = rng.uniform(low, high, size=(10000,))
+
+    # Basic statistical tests for uniform distribution
+    mean = (low + high) / 2
+    std = (high - low) / math.sqrt(12)
+    assert np.isclose(float(xp.mean(samples)), mean, atol=0.05)
+    assert np.isclose(float(xp.std(samples)), std, atol=0.05)
+
+
+@pytest.mark.parametrize('scale', (1.0, 3.0))
+def test_random_generator_exponential(xp, scale):
+    # Get samples from the Exponential distribution.
+    rng = make_random_generator(xp, seed=42)
+    samples = rng.exponential(scale=scale, size=(10000,))
+
+    # Basic statistical tests for exponential distribution
+    assert np.isclose(float(xp.mean(samples)), scale, atol=0.1)
+    assert np.isclose(float(xp.std(samples)), scale, atol=0.1)
+
+
+@pytest.mark.parametrize('replace', (True, False))
+def test_random_generator_choice(xp, replace):
+    rng = make_random_generator(xp, seed=42)
+
+    n = 100 if replace else 3
+
+    # Sample from integer range
+    samples = rng.choice(10, size=(n,), replace=replace)
+    assert samples.shape == (n,)
+    assert all(0 <= s < 10 for s in samples)
+
+    # Sample from array
+    a = xp.asarray([5, 10, 15, 20])
+    samples = rng.choice(a, size=(n,), replace=replace)
+    assert samples.shape == (n,)
+    assert all(s in [5, 10, 15, 20] for s in np.asarray(samples))
+
+    # Sample with weights (always with replacement)
+    p = xp.asarray([0.1, 0.2, 0.3, 0.4])
+    samples = rng.choice(a, size=(100,), replace=True, p=p)
+    assert samples.shape == (100,)
+    assert all(s in [5, 10, 15, 20] for s in np.asarray(samples))
+
+
+@pytest.mark.parametrize('distribution, args', [
+    ('normal', (dict(),)),
+    ('gamma', (dict(),)),
+    ('poisson', (dict(),)),
+    ('uniform', (dict(),)),
+    ('exponential', (dict(),)),
+    ('choice', ({'a': 10, 'replace': True},)),
+])
+def test_random_generator_reproducible(xp, distribution, args):
     # Create two make_random_generator objects with same seed
     rng1 = make_random_generator(xp, seed=123)
     rng2 = make_random_generator(xp, seed=123)
 
     # Generate samples
-    samples1 = getattr(rng1, distribution)(size=(100,))
-    samples2 = getattr(rng2, distribution)(size=(100,))
+    samples1 = getattr(rng1, distribution)(size=(100,), **args[0])
+    samples2 = getattr(rng2, distribution)(size=(100,), **args[0])
 
     # Check that samples are identical
     assert np.allclose(samples1, samples2)
 
 
-@pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
-def test_random_generator_copy(xp, distribution):
+@pytest.mark.parametrize('distribution, args', [
+    ('normal', (dict(),)),
+    ('gamma', (dict(),)),
+    ('poisson', (dict(),)),
+    ('uniform', (dict(),)),
+    ('exponential', (dict(),)),
+    ('choice', ({'a': 10, 'replace': True},)),
+])
+def test_random_generator_copy(xp, distribution, args):
     # Create initial rngs
     rng1 = make_random_generator(xp, seed=42)
     rng2 = rng1.copy()
 
     # Generate some samples
-    samples1 = getattr(rng1, distribution)(size=(10,))
-    samples2 = getattr(rng2, distribution)(size=(10,))
+    samples1 = getattr(rng1, distribution)(size=(10,), **args[0])
+    samples2 = getattr(rng2, distribution)(size=(10,), **args[0])
 
     # Should be identical
     assert np.allclose(samples1, samples2)
 
 
-@pytest.mark.parametrize('distribution', ['normal', 'gamma', 'poisson'])
-def test_random_generator_different_sizes(xp, distribution):
+@pytest.mark.parametrize('distribution, args', [
+    ('normal', (dict(),)),
+    ('gamma', (dict(),)),
+    ('poisson', (dict(),)),
+    ('uniform', (dict(),)),
+    ('exponential', (dict(),)),
+    ('choice', ({'a': 10, 'replace': True},)),
+])
+def test_random_generator_different_sizes(xp, distribution, args):
     rng = make_random_generator(xp, seed=42)
 
     generation_func = getattr(rng, distribution)
 
     # Test 1D array
-    arr_1d = generation_func(size=5)
+    arr_1d = generation_func(size=5, **args[0])
     assert arr_1d.shape == (5,)
 
     # Test 2D array
-    arr_2d = generation_func(size=(3, 4))
+    arr_2d = generation_func(size=(3, 4), **args[0])
     assert arr_2d.shape == (3, 4)
 
     # Test 3D array
-    arr_3d = generation_func(size=(2, 3, 4))
+    arr_3d = generation_func(size=(2, 3, 4), **args[0])
     assert arr_3d.shape == (2, 3, 4)


### PR DESCRIPTION
This PR adds the `uniform()`, `exponential()` and `choice()` functions that are available for Numpy into the `RandomGenerator` classes. It also adds `array_api_strict` as a backend, allowing for testing with that backend. Tests have been added for all functions.

This now should be all random functions that are used internally in HCIPy.