### PR TITLE
Fix number of core overrides.

### DIFF
--- a/hcipy/_math/cpu.py
+++ b/hcipy/_math/cpu.py
@@ -1,25 +1,50 @@
 import os
 import platform
 import multiprocessing
+import threadpoolctl
 
 def get_num_available_cores():
-    '''Get the number of cores available on the system.
+    '''Get the number of cores available to the current process.
 
-    The attempt at retrieving the number of cores that our process
-    is assigned may not be available on all operating systems. On
-    unsupported operating systems, the total number of cores is
-    returned instead.
+    Checks, in order of priority:
+    1. Actual BLAS thread count via threadpoolctl (if available and loaded)
+    2. BLAS/threading environment variables (OMP_NUM_THREADS, etc.)
+    3. HPC scheduler allocations (SLURM, SGE)
+    4. Process CPU affinity (Linux via sched_getaffinity, Windows via Win32 API)
+    5. Total logical CPU count as a last resort
 
     Returns
     -------
     int
         The number of available cores.
 
-    Raises
-    ------
-    RuntimeError
-        If we are unable to
     '''
+    # 1. Ground truth — what BLAS is actually using right now
+    pools = threadpoolctl.threadpool_info()
+    if pools:
+        return min(p["num_threads"] for p in pools)
+
+    # 2. Explicit BLAS/threading env var overrides
+    env_vars = [
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    ]
+
+    for env_var in env_vars:
+        val = os.environ.get(env_var)
+        if val is not None:
+            return int(val)
+
+    # 3. HPC scheduler allocations
+    for env_var in ("SLURM_CPUS_PER_TASK", "NSLOTS"):
+        val = os.environ.get(env_var)
+        if val is not None:
+            return int(val)
+
+    # 4. Process affinity — respects taskset, cgroups, containers, etc.
     if hasattr(os, 'sched_getaffinity'):
         return len(os.sched_getaffinity(0))
     elif platform.system() == 'Windows':
@@ -40,9 +65,7 @@ def get_num_available_cores():
         mask = DWORD_PTR()
 
         if GetProcessAffinityMask(GetCurrentProcess(), ctypes.byref(mask), ctypes.byref(DWORD_PTR())):
-            # Call successful. Return result.
             return bin(mask.value).count('1')
 
-    # Operating system is unsupported or the call to retrieve the
-    # core count has failed. Fall back to all cores.
+    # 5. Last resort
     return multiprocessing.cpu_count()

--- a/hcipy/_math/cpu.py
+++ b/hcipy/_math/cpu.py
@@ -35,8 +35,72 @@ def _cgroup_quota_cpus():
     return _cgroup_v2_quota() or _cgroup_v1_quota()
 
 
+def _blas_threadpool_count():
+    """Actual thread count BLAS is using right now, or None if no BLAS info is available.
+    """
+    pools = threadpoolctl.threadpool_info()
+    if not pools:
+        return None
+    return min(p["num_threads"] for p in pools)
+
+
+def _blas_env_override_count():
+    """BLAS/threading environment variable override, or None if none is set.
+    """
+    BLAS_THREAD_ENV_VARS = [
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    ]
+
+    for env_var in BLAS_THREAD_ENV_VARS:
+        val = os.environ.get(env_var)
+        if val is not None:
+            # Deal with comma-separated values.
+            return int(val.split(",")[0])
+    return None
+
+
+def _scheduler_env_override_count():
+    """HPC scheduler allocation from the environment, or None if none is set.
+    """
+    _SCHEDULER_ENV_VARS = [
+        "SLURM_CPUS_PER_TASK",
+        "NSLOTS",
+    ]
+
+    for env_var in _SCHEDULER_ENV_VARS:
+        val = os.environ.get(env_var)
+        if val is not None:
+            # Deal with comma-separated values.
+            return int(val.split(",")[0])
+    return None
+
+
+def _linux_affinity_count():
+    """Process CPU affinity, intersected with cgroup CPU quota, or None if unavailable.
+    """
+    if not hasattr(os, "sched_getaffinity"):
+        return None
+
+    affinity_count = len(os.sched_getaffinity(0))
+    quota = _cgroup_quota_cpus()
+
+    if quota is not None:
+        n = math.ceil(quota)
+        return max(1, min(affinity_count, n))
+
+    return affinity_count
+
+
 def _windows_affinity_count():
-    """Process CPU affinity count via Win32 GetProcessAffinityMask, or None on failure."""
+    """Process CPU affinity count via Win32 GetProcessAffinityMask, or None on failure.
+    """
+    if platform.system() != "Windows":
+        return None
+
     import ctypes
     import ctypes.wintypes
 
@@ -78,49 +142,19 @@ def get_num_available_cores():
     int
         The number of available cores, always >= 1.
     '''
-    # 1. Ground truth — what BLAS is actually using right now
-    pools = threadpoolctl.threadpool_info()
-    if pools:
-        return min(p["num_threads"] for p in pools)
-
-    # 2. Explicit BLAS/threading env var overrides
-    env_vars = [
-        "OMP_NUM_THREADS",
-        "OPENBLAS_NUM_THREADS",
-        "MKL_NUM_THREADS",
-        "VECLIB_MAXIMUM_THREADS",
-        "NUMEXPR_NUM_THREADS",
+    funcs = [
+        _blas_threadpool_count,
+        _blas_env_override_count,
+        _scheduler_env_override_count,
+        _linux_affinity_count,
+        _windows_affinity_count,
     ]
 
-    for env_var in env_vars:
-        val = os.environ.get(env_var)
-        if val is not None:
-            # Deal with comma-separated values.
-            return int(val.split(",")[0])
+    for func in funcs:
+        count = func()
 
-    # 3. HPC scheduler allocations
-    for env_var in ("SLURM_CPUS_PER_TASK", "NSLOTS"):
-        val = os.environ.get(env_var)
-        if val is not None:
-            # Deal with comma-separated values.
-            return int(val.split(",")[0])
-
-    # 4a. Linux: process affinity, intersected with cgroup CPU quota
-    #     (a container can show a full affinity mask while throttled
-    #     to a fraction of a CPU by cpu.max / cfs_quota_us)
-    if hasattr(os, "sched_getaffinity"):
-        affinity_count = len(os.sched_getaffinity(0))
-        quota = _cgroup_quota_cpus()
-        if quota is not None:
-            n = math.ceil(quota)
-            return max(1, min(affinity_count, n))
-        return affinity_count
-
-    # 4b. Windows: Win32 affinity mask
-    if platform.system() == "Windows":
-        count = _windows_affinity_count()
         if count is not None:
             return count
 
-    # 5. Last resort
+    # Fallback.
     return multiprocessing.cpu_count()

--- a/hcipy/_math/cpu.py
+++ b/hcipy/_math/cpu.py
@@ -1,7 +1,66 @@
+import math
 import os
 import platform
 import multiprocessing
 import threadpoolctl
+
+
+def _cgroup_v2_quota():
+    """cgroup v2 unified quota (cpu.max), fractional CPUs or None if unlimited/unavailable."""
+    try:
+        with open("/sys/fs/cgroup/cpu.max") as f:
+            quota, period = f.read().split()
+        if quota == "max":
+            return None
+        return int(quota) / int(period)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _cgroup_v1_quota():
+    """cgroup v1 quota (cfs_quota_us / cfs_period_us), fractional CPUs or None."""
+    try:
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as f:
+            quota = int(f.read().strip())
+        if quota <= 0:  # -1 means unlimited
+            return None
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as f:
+            period = int(f.read().strip())
+        return quota / period
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _cgroup_quota_cpus():
+    return _cgroup_v2_quota() or _cgroup_v1_quota()
+
+
+def _windows_affinity_count():
+    """Process CPU affinity count via Win32 GetProcessAffinityMask, or None on failure."""
+    import ctypes
+    import ctypes.wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32")
+
+    DWORD_PTR = ctypes.wintypes.WPARAM
+    PDWORD_PTR = ctypes.POINTER(DWORD_PTR)
+
+    GetCurrentProcess = kernel32.GetCurrentProcess
+    GetCurrentProcess.restype = ctypes.wintypes.HANDLE
+
+    GetProcessAffinityMask = kernel32.GetProcessAffinityMask
+    GetProcessAffinityMask.argtypes = (ctypes.wintypes.HANDLE, PDWORD_PTR, PDWORD_PTR)
+
+    process_mask = DWORD_PTR()
+    system_mask = DWORD_PTR()  # named, not a throwaway temporary
+
+    ok = GetProcessAffinityMask(
+        GetCurrentProcess(), ctypes.byref(process_mask), ctypes.byref(system_mask)
+    )
+    if not ok or process_mask.value == 0:
+        return None
+    return bin(process_mask.value).count("1")
+
 
 def get_num_available_cores():
     '''Get the number of cores available to the current process.
@@ -10,14 +69,14 @@ def get_num_available_cores():
     1. Actual BLAS thread count via threadpoolctl (if available and loaded)
     2. BLAS/threading environment variables (OMP_NUM_THREADS, etc.)
     3. HPC scheduler allocations (SLURM, SGE)
-    4. Process CPU affinity (Linux via sched_getaffinity, Windows via Win32 API)
+    4. Process CPU affinity, intersected with cgroup CPU-bandwidth quota
+       where applicable (Linux); Win32 affinity mask (Windows)
     5. Total logical CPU count as a last resort
 
     Returns
     -------
     int
-        The number of available cores.
-
+        The number of available cores, always >= 1.
     '''
     # 1. Ground truth — what BLAS is actually using right now
     pools = threadpoolctl.threadpool_info()
@@ -36,36 +95,32 @@ def get_num_available_cores():
     for env_var in env_vars:
         val = os.environ.get(env_var)
         if val is not None:
-            return int(val)
+            # Deal with comma-separated values.
+            return int(val.split(",")[0])
 
     # 3. HPC scheduler allocations
     for env_var in ("SLURM_CPUS_PER_TASK", "NSLOTS"):
         val = os.environ.get(env_var)
         if val is not None:
-            return int(val)
+            # Deal with comma-separated values.
+            return int(val.split(",")[0])
 
-    # 4. Process affinity — respects taskset, cgroups, containers, etc.
-    if hasattr(os, 'sched_getaffinity'):
-        return len(os.sched_getaffinity(0))
-    elif platform.system() == 'Windows':
-        import ctypes
-        import ctypes.wintypes
+    # 4a. Linux: process affinity, intersected with cgroup CPU quota
+    #     (a container can show a full affinity mask while throttled
+    #     to a fraction of a CPU by cpu.max / cfs_quota_us)
+    if hasattr(os, "sched_getaffinity"):
+        affinity_count = len(os.sched_getaffinity(0))
+        quota = _cgroup_quota_cpus()
+        if quota is not None:
+            n = math.ceil(quota)
+            return max(1, min(affinity_count, n))
+        return affinity_count
 
-        kernel32 = ctypes.WinDLL('kernel32')
-
-        DWORD_PTR = ctypes.wintypes.WPARAM
-        PDWORD_PTR = ctypes.POINTER(DWORD_PTR)
-
-        GetCurrentProcess = kernel32.GetCurrentProcess
-        GetCurrentProcess.restype = ctypes.wintypes.HANDLE
-
-        GetProcessAffinityMask = kernel32.GetProcessAffinityMask
-        GetProcessAffinityMask.argtypes = (ctypes.wintypes.HANDLE, PDWORD_PTR, PDWORD_PTR)
-
-        mask = DWORD_PTR()
-
-        if GetProcessAffinityMask(GetCurrentProcess(), ctypes.byref(mask), ctypes.byref(DWORD_PTR())):
-            return bin(mask.value).count('1')
+    # 4b. Windows: Win32 affinity mask
+    if platform.system() == "Windows":
+        count = _windows_affinity_count()
+        if count is not None:
+            return count
 
     # 5. Last resort
     return multiprocessing.cpu_count()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "asdf",
     "packaging",
     "tqdm",
+    "threadpoolctl",
     "array_api_compat",
 ]
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -6,6 +6,7 @@ from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
 from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _row_pass, _col_pass
 from hcipy._math import cpu
+import io
 import math
 from scipy.ndimage import affine_transform
 
@@ -438,17 +439,65 @@ def test_row_col_pass_compiled():
 
     assert np.allclose(out_py, out_jit)
 
+
+_CGROUP_V2_PATH = "/sys/fs/cgroup/cpu.max"
+_CGROUP_V1_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+_CGROUP_V1_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+
+@pytest.fixture
+def cgroup_files(monkeypatch):
+    files = {}
+
+    def fake_open(path, *args, **kwargs):
+        try:
+            return io.StringIO(files[str(path)])
+        except KeyError:
+            raise FileNotFoundError(str(path))
+
+    monkeypatch.setattr(cpu, "open", fake_open, raising=False)
+    return files
+
+
 @pytest.mark.parametrize(
-    "func",
+    "content, expected",
     [
-        "_cgroup_v2_quota",
-        "_cgroup_v1_quota",
-        "_cgroup_quota_cpus",
+        ("50000 100000\n", 0.5),
+        ("400000 100000\n", 4.0),
+        ("max 100000\n", None),
+        ("not_a_number 100000\n", None),
+        ("100000\n", None),
     ],
 )
-def test_quota_functions_return_sensible_value(func):
-    value = getattr(cpu, func)()
-    assert value is None or value > 0
+def test_cgroup_v2_quota(cgroup_files, content, expected):
+    cgroup_files[_CGROUP_V2_PATH] = content
+    assert cpu._cgroup_v2_quota() == expected
+
+
+def test_cgroup_v2_quota_missing_file(cgroup_files):
+    assert cpu._cgroup_v2_quota() is None
+
+
+@pytest.mark.parametrize(
+    "quota, period, expected",
+    [
+        ("50000", "100000", 0.5),
+        ("800000", "100000", 8.0),
+        ("-1", "100000", None),
+        ("0", "100000", None),
+        ("not_a_number", "100000", None),
+        ("100000", "not_a_number", None),
+    ],
+)
+def test_cgroup_v1_quota(cgroup_files, quota, period, expected):
+    cgroup_files[_CGROUP_V1_QUOTA_PATH] = quota + "\n"
+    cgroup_files[_CGROUP_V1_PERIOD_PATH] = period + "\n"
+    assert cpu._cgroup_v1_quota() == expected
+
+
+def test_cgroup_v1_quota_missing_file(cgroup_files):
+    assert cpu._cgroup_v1_quota() is None
+
 
 @pytest.mark.parametrize(
     "func",
@@ -460,7 +509,7 @@ def test_quota_functions_return_sensible_value(func):
         "_windows_affinity_count",
     ],
 )
-def test_count_functions_return_sensible_value(func):
+def test_cpu_count_functions(func):
     value = getattr(cpu, func)()
     assert value is None or value >= 1
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -5,6 +5,7 @@ from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
 from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _row_pass, _col_pass
+from hcipy._math import cpu
 import math
 from scipy.ndimage import affine_transform
 
@@ -436,3 +437,32 @@ def test_row_col_pass_compiled():
     _col_pass(img, kernel, r, out_jit)
 
     assert np.allclose(out_py, out_jit)
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        "_cgroup_v2_quota",
+        "_cgroup_v1_quota",
+        "_cgroup_quota_cpus",
+    ],
+)
+def test_quota_functions_return_sensible_value(func):
+    value = getattr(cpu, func)()
+    assert value is None or value > 0
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        "_blas_threadpool_count",
+        "_blas_env_override_count",
+        "_scheduler_env_override_count",
+        "_linux_affinity_count",
+        "_windows_affinity_count",
+    ],
+)
+def test_count_functions_return_sensible_value(func):
+    value = getattr(cpu, func)()
+    assert value is None or value >= 1
+
+def test_get_num_available_cores():
+    assert cpu.get_num_available_cores() >= 1


### PR DESCRIPTION
We should use BLAS number of core overrides (environment variables), HPC scheduler number of cores (environment variables), the number of cores BLAS decided to use (threadpoolctl) before resorting to maxing out the core count.

This PR adds `threadpoolctl` as a new dependency. This is a widely-used package, eg. a dependency of scikit-learn.

Fixes #229.