### PR TITLE
Refactor apodizer classes.

### DIFF
--- a/doc/tutorial_notebooks/ElectricFieldConjugation/ElectricFieldConjugation.ipynb
+++ b/doc/tutorial_notebooks/ElectricFieldConjugation/ElectricFieldConjugation.ipynb
@@ -307,7 +307,7 @@
    "source": [
     "aberration_distance = 100e-3 # m\n",
     "\n",
-    "aberration_at_distance = SurfaceAberrationAtDistance(aberration, aberration_distance)\n",
+    "aberration_at_distance = SurfaceAberrationAtDistance(pupil_grid, aberration, aberration_distance)\n",
     "\n",
     "aberrated_pupil = aberration_at_distance(Wavefront(aperture, wavelength))\n",
     "\n",

--- a/hcipy/optics/aberration.py
+++ b/hcipy/optics/aberration.py
@@ -131,13 +131,15 @@ class SurfaceAberrationAtDistance(OpticalElement):
 
     Parameters
     ----------
+    input_grid : Grid
+        The grid on which the surface aberration operates.
     surface_aberration : OpticalElement
         The optical element describing the surface aberration.
     distance : scalar
         The distance from the current plane.
     '''
-    def __init__(self, surface_aberration, distance):
-        self.fresnel = FresnelPropagator(surface_aberration.input_grid, distance)
+    def __init__(self, input_grid, surface_aberration, distance):
+        self.fresnel = FresnelPropagator(input_grid, distance)
         self.surface_aberration = surface_aberration
 
     def forward(self, wavefront):

--- a/hcipy/optics/apodization.py
+++ b/hcipy/optics/apodization.py
@@ -1,7 +1,9 @@
 import numpy as np
-from .optical_element import OpticalElement, AgnosticOpticalElement, make_agnostic_forward, make_agnostic_backward
+from .optical_element import OpticalElement
+from .wavefront import Wavefront
+import warnings
 
-class Apodizer(AgnosticOpticalElement):
+class Apodizer(OpticalElement):
     '''A thin apodizer.
 
     This apodizer can apodize both in phase and amplitude.
@@ -12,71 +14,54 @@ class Apodizer(AgnosticOpticalElement):
         The apodization that we want to apply to any input wavefront.
     '''
     def __init__(self, apodization):
-        self._apodization = apodization
+        self.apodization = apodization
 
-        AgnosticOpticalElement.__init__(self, True, True)
+    def _get_apodization(self, wavelength):
+        if callable(self.apodization):
+            return self.apodization(wavelength)
+        else:
+            return self.apodization
 
-    def make_instance(self, instance_data, input_grid, output_grid, wavelength):
-        instance_data.apodization = self.evaluate_parameter(self.apodization, input_grid, output_grid, wavelength)
+    def forward(self, wavefront):
+        a = self._get_apodization(wavefront.wavelength)
+        new_field = wavefront.electric_field * a
 
-    @property
-    def apodization(self):
-        return self._apodization
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
-    @apodization.setter
-    def apodization(self, apodization):
-        self._apodization = apodization
+    def backward(self, wavefront):
+        a = self._get_apodization(wavefront.wavelength)
+        new_field = wavefront.electric_field * np.conj(a)
 
-        self.clear_cache()
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
-    def get_input_grid(self, output_grid, wavelength):
-        return output_grid
-
-    def get_output_grid(self, input_grid, wavelength):
-        return input_grid
-
-    @make_agnostic_forward
-    def forward(self, instance_data, wavefront):
-        wf = wavefront.copy()
-        wf.electric_field *= instance_data.apodization
-
-        return wf
-
-    @make_agnostic_backward
-    def backward(self, instance_data, wavefront):
-        wf = wavefront.copy()
-        wf.electric_field *= instance_data.apodization.conj()
-
-        return wf
-
-class PhaseApodizer(Apodizer):
+class PhaseApodizer(OpticalElement):
     '''A phase-only thin apodizer.
 
     Parameters
     ----------
-    phase : Field or scalar or function
+    phase : Field or scalar
         The phase apodization.
     '''
     def __init__(self, phase):
         self._phase = phase
 
-        Apodizer.__init__(self, self.apodization)
-
-    @property
-    def apodization(self):
-        return self.construct_function(lambda p: np.exp(1j * p), self.phase)
-
     @property
     def phase(self):
         return self._phase
 
-    @phase.setter
-    def phase(self, phase):
-        self._phase = phase
+    def forward(self, wavefront):
+        a = np.exp(1j * self.phase)
+        new_field = wavefront.electric_field * a
 
-        self.clear_cache()
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
-class SurfaceApodizer(Apodizer):
+    def backward(self, wavefront):
+        a_conj = np.exp(-1j * self.phase)
+        new_field = wavefront.electric_field * a_conj
+
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
+
+class SurfaceApodizer(OpticalElement):
     '''A transmissive sagged surface optic.
 
     The surface is simulated as a thin plate. Propagation effects due to the
@@ -85,109 +70,141 @@ class SurfaceApodizer(Apodizer):
 
     Parameters
     ----------
-    surface_sag : Field or scalar or function
+    surface_sag : Field
         The sag in the surface.
-    refractive_index : scalar or function
+    refractive_index : scalar or function of wavelength
         The refractive index of the material of the plate.
     '''
     def __init__(self, surface_sag, refractive_index):
-        self._surface_sag = surface_sag
-        self._refractive_index = refractive_index
+        self.surface_sag = surface_sag
+        self.refractive_index = refractive_index
 
-        Apodizer.__init__(self, self.apodization)
+    def _get_refractive_index(self, wavelength):
+        if callable(self.refractive_index):
+            return self.refractive_index(wavelength)
+        else:
+            return self.refractive_index
 
-    @property
-    def opd(self):
-        return self.construct_function(lambda n, surf: (n - 1) * surf, self.refractive_index, self.surface_sag)
+    def forward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+        a = np.exp(1j * (n - 1) * self.surface_sag * wavefront.wavenumber)
 
-    optical_path_difference = opd
+        new_field = wavefront.electric_field * a
 
-    @property
-    def phase(self):
-        return self.construct_function(lambda opd, wavelength: opd * 2 * np.pi / wavelength, self.opd)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
-    @property
-    def apodization(self):
-        return self.construct_function(lambda p: np.exp(1j * p), self.phase)
+    def backward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+        a_conj = np.exp(-1j * (n - 1) * self.surface_sag * wavefront.wavenumber)
 
-    @property
-    def refractive_index(self):
-        return self._refractive_index
+        new_field = wavefront.electric_field * a_conj
 
-    @refractive_index.setter
-    def refractive_index(self, refractive_index):
-        self._refractive_index = refractive_index
-
-        self.clear_cache()
-
-    @property
-    def surface_sag(self):
-        return self._surface_sag
-
-    @surface_sag.setter
-    def surface_sag(self, surface_sag):
-        self._surface_sag = surface_sag
-
-        self.clear_cache()
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
 class ComplexSurfaceApodizer(OpticalElement):
+    '''A surface apodizer with amplitude coating.
+
+    Parameters
+    ----------
+    amplitude : Field or scalar or function of wavelength
+        The amplitude apodization.
+    surface : Field or scalar
+        The sag in the surface.
+    refractive_index : scalar or function of wavelength
+        The refractive index of the material of the plate.
+    '''
     def __init__(self, amplitude, surface, refractive_index):
         self.amplitude = amplitude
         self.surface = surface
         self.refractive_index = refractive_index
 
-    def phase_for(self, wavelength):
-        '''Get the phase screen in radians at a certain wavelength.
+    def _get_refractive_index(self, wavelength):
+        if callable(self.refractive_index):
+            return self.refractive_index(wavelength)
+        else:
+            return self.refractive_index
 
-        Parameters
-        ----------
-        wavelength : scalar
-            The wavelength at which to calculate the phase screen.
-        '''
-        wavenumber = 2 * np.pi / wavelength
-
-        opd = (self.refractive_index - 1) * self.surface
-
-        return opd * wavenumber
+    def _get_amplitude(self, wavelength):
+        if callable(self.amplitude):
+            return self.amplitude(wavelength)
+        else:
+            return self.amplitude
 
     def forward(self, wavefront):
-        opd = (self.refractive_index(wavefront.wavelength) - 1) * self.surface
+        amp = self._get_amplitude(wavefront.wavelength)
+        n = self._get_refractive_index(wavefront.wavelength)
 
-        wf = wavefront.copy()
-        wf.electric_field *= self.amplitude * np.exp(1j * opd * wf.wavenumber)
+        a = amp * np.exp(1j * (n - 1) * self.surface * wavefront.wavenumber)
+        new_field = wavefront.electric_field * a
 
-        return wf
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
     def backward(self, wavefront):
-        opd = (self.refractive_index(wavefront.wavelength) - 1) * self.surface
+        amp_conj = np.conj(self._get_amplitude(wavefront.wavelength))
+        n = self._get_refractive_index(wavefront.wavelength)
 
-        wf = wavefront.copy()
-        wf.electric_field *= self.amplitude * np.exp(-1j * opd * wf.wavenumber)
+        a_conj = amp_conj * np.exp(-1j * (n - 1) * self.surface * wavefront.wavenumber)
+        new_field = wavefront.electric_field * a_conj
 
-        return wf
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
 class MultiplexedComplexSurfaceApodizer(OpticalElement):
-    def __init__(self, amplitude, surface, refractive_index):
-        self.amplitude = amplitude
-        self.surface = surface
+    '''A non-physical apodizer that consists of multiple :class:`ComplexSurfaceApodizer`
+    apodizers on top of each other.
+
+    Parameters
+    ----------
+    amplitudes : list of {Field or scalars or functions of wavelength}
+        The amplitude apodizations of each of the masks.
+    surfaces : list of Fields
+        The surface sags of each of the masks.
+    refractive_index : scalar or function of wavelength
+        The refractive index of the material of the plate.
+    '''
+    def __init__(self, amplitudes, surfaces, refractive_index, amplitude=None, surface=None):
+        if amplitude is not None:
+            warnings.warn("The `amplitude` parameter has been deprecated and will be removed in a future version. Use `amplitudes` instead.", DeprecationWarning, stacklevel=2)
+            amplitudes = amplitude
+
+        if surface is not None:
+            warnings.warn("The `surface` parameter has been deprecated and will be removed in a future version. Use `surfaces` instead.", DeprecationWarning, stacklevel=2)
+            surfaces = surface
+
+        self.amplitudes = amplitudes
+        self.surfaces = surfaces
         self.refractive_index = refractive_index
 
-    def forward(self, wavefront):
-        apodizer_mask = 0
-        for amplitude, surface in zip(self.amplitude, self.surface):
-            opd = (self.refractive_index(wavefront.wavelength) - 1) * surface
-            apodizer_mask += amplitude * np.exp(1j * opd * wavefront.wavenumber)
+    def _get_refractive_index(self, wavelength):
+        if callable(self.refractive_index):
+            return self.refractive_index(wavelength)
+        else:
+            return self.refractive_index
 
-        wf = wavefront.copy()
-        wf.electric_field *= apodizer_mask
-        return wf
+    @staticmethod
+    def _get_amplitude(amplitude, wavelength):
+        if callable(amplitude):
+            return amplitude(wavelength)
+        else:
+            return amplitude
+
+    def forward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+
+        apodizer_mask = 0
+        for amplitude, surface in zip(self.amplitudes, self.surfaces):
+            amp = self._get_amplitude(amplitude, wavefront.wavelength)
+            apodizer_mask += amp * np.exp(1j * (n - 1) * surface * wavefront.wavenumber)
+
+        new_field = wavefront.electric_field * apodizer_mask
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
     def backward(self, wavefront):
-        apodizer_mask = 0
-        for amplitude, surface in zip(self.amplitude, self.surface):
-            opd = (self.refractive_index(wavefront.wavelength) - 1) * surface
-            apodizer_mask += amplitude * np.exp(1j * opd * wavefront.wavenumber)
+        n = self._get_refractive_index(wavefront.wavelength)
 
-        wf = wavefront.copy()
-        wf.electric_field /= apodizer_mask
-        return wf
+        apodizer_mask_conj = 0
+        for amplitude, surface in zip(self.amplitudes, self.surfaces):
+            amp_conj = np.conj(self._get_amplitude(amplitude, wavefront.wavelength))
+            apodizer_mask_conj += amp_conj * np.exp(-1j * (n - 1) * surface * wavefront.wavenumber)
+
+        new_field = wavefront.electric_field * apodizer_mask_conj
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)

--- a/hcipy/optics/dispersion_optics.py
+++ b/hcipy/optics/dispersion_optics.py
@@ -1,10 +1,12 @@
-from .apodization import SurfaceApodizer, PhaseApodizer
+from ..dev import deprecated
+from .optical_element import OpticalElement
+from .wavefront import Wavefront
 import numpy as np
 from ..field import Field
 from scipy.special import jv
 
 def grating_equation(wavelength, order, period, angle_of_incidence):
-    ''' Calculates the angle of the diffracted beam.
+    '''Calculate the angle of the diffracted beam.
 
     Parameters
     ----------
@@ -25,7 +27,7 @@ def grating_equation(wavelength, order, period, angle_of_incidence):
     return np.arcsin(order * wavelength / period + np.sin(angle_of_incidence))
 
 def diffraction_efficiency_sinusoidal_grating(wavelength, groove_depth, order, period, angle_of_incidence):
-    ''' Calculates the diffraction efficiency from a sinusoidal phase grating.
+    '''Calculate the diffraction efficiency from a sinusoidal phase grating.
 
     Parameters
     ----------
@@ -47,10 +49,11 @@ def diffraction_efficiency_sinusoidal_grating(wavelength, groove_depth, order, p
     '''
     diffracted_angle = grating_equation(wavelength, order, period, angle_of_incidence)
     phase_difference = np.pi * groove_depth / wavelength * (np.cos(angle_of_incidence) + np.cos(diffracted_angle))
+
     return jv(order, phase_difference)**2
 
 def snells_law(incidence_angle, relative_refractive_index):
-    ''' Applies Snell's law.
+    '''Apply Snell's law.
 
     Parameters
     ----------
@@ -72,8 +75,28 @@ def snells_law(incidence_angle, relative_refractive_index):
         else:
             raise ValueError("Total internal reflection is occuring.")
 
-class TiltElement(SurfaceApodizer):
-    ''' An element that applies a tilt.
+def _tilt_sag(orientation, angle):
+    '''Calculate the sag profile for a tilt element.
+
+    Parameters
+    ----------
+    orientation : scalar
+        The orientation of the tilt in radians.
+    angle : scalar
+        The tilt angle in radians.
+
+    Returns
+    -------
+    Field generator
+        A function that takes a grid and returns the surface sag as a Field.
+    '''
+    def res(grid):
+        return Field(grid.rotated(orientation).y * np.tan(angle), grid)
+
+    return res
+
+class TiltElement(OpticalElement):
+    '''An element that applies a tilt.
 
     Parameters
     ----------
@@ -81,46 +104,32 @@ class TiltElement(SurfaceApodizer):
         The tilt angle in radians.
     orientation : scalar
         The orientation of the tilt in radians. The default orientation is aligned along the y-axis.
-    refractive_index : scalar or function
+    refractive_index : scalar or function of wavelength
         The refractive index of the material. The default is 2.0 which makes it achromatic and exact.
     '''
     def __init__(self, angle, orientation=0, refractive_index=2.0):
-        self._angle = angle
-        self._orientation = orientation
-        super().__init__(self.tilt_sag, refractive_index)
+        self.angle = angle
+        self.orientation = orientation
+        self.refractive_index = refractive_index
 
-    @property
-    def angle(self):
-        return self._angle
+    def _get_refractive_index(self, wavelength):
+        if callable(self.refractive_index):
+            return self.refractive_index(wavelength)
+        return self.refractive_index
 
-    @angle.setter
-    def angle(self, new_angle):
-        self._angle = new_angle
-        self.surface_sag = self.tilt_sag
+    def forward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+        sag = _tilt_sag(self.orientation, self.angle)(wavefront.electric_field.grid)
 
-    @property
-    def orientation(self):
-        return self._orientation
+        new_field = wavefront.electric_field * np.exp(1j * (n - 1) * sag * wavefront.wavenumber)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
-    @orientation.setter
-    def orientation(self, new_orientation):
-        self._orientation = new_orientation
-        self.surface_sag = self.tilt_sag
+    def backward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+        sag = _tilt_sag(self.orientation, self.angle)(wavefront.electric_field.grid)
 
-    def tilt_sag(self, grid):
-        ''' Calculate the sag profile for the tilt element.
-
-        Parameters
-        ----------
-        grid : Grid
-            The grid on which the surface sag is calculated.
-
-        Returns
-        -------
-        Field
-            The surface sag.
-        '''
-        return Field(grid.rotated(self._orientation).y * np.tan(self._angle), grid)
+        new_field = wavefront.electric_field * np.exp(-1j * (n - 1) * sag * wavefront.wavenumber)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
 class ThinPrism(TiltElement):
     '''A thin prism that operates in the paraxial regime.
@@ -129,16 +138,16 @@ class ThinPrism(TiltElement):
     ----------
     angle : scalar
         The wedge angle of the prism in radians.
-    orientation : scalar
-        The orientation of the prism in radians. The default orientation is aligned along the x-axis.
     refractive_index : scalar or function of wavelength
         The refractive index of the prism.
+    orientation : scalar
+        The orientation of the prism in radians. The default orientation is aligned along the x-axis.
     '''
     def __init__(self, angle, refractive_index, orientation=0):
         super().__init__(angle, orientation, refractive_index)
 
     def minimal_deviation_angle(self, wavelength):
-        ''' Find the angle of minimal deviation for a paraxial prism.
+        '''Find the angle of minimal deviation for a paraxial prism.
 
         Parameters
         ----------
@@ -150,11 +159,11 @@ class ThinPrism(TiltElement):
         scalar
             The angle of minimal deviation in radians.
         '''
-        n = self._refractive_index(wavelength)
-        return (n - 1) * self._prism_angle
+        n = self._get_refractive_index(wavelength)
+        return (n - 1) * self.angle
 
     def trace(self, wavelength):
-        ''' Trace a paraxial ray through the prism.
+        '''Trace a paraxial ray through the prism.
 
         Parameters
         ----------
@@ -166,14 +175,15 @@ class ThinPrism(TiltElement):
         scalar
             The angle of deviation for the traced ray in radians.
         '''
-        return (self._refractive_index(wavelength) - 1) * self.angle
+        n = self._get_refractive_index(wavelength)
+        return (n - 1) * self.angle
 
-class Prism(SurfaceApodizer):
+class Prism(OpticalElement):
     '''A prism that deviates the beam.
 
     Parameters
     ----------
-    angle_of_incidence : sacalar
+    angle_of_incidence : scalar
         The angle of incidence of the wavefront in radians.
     prism_angle : scalar
         The angle of the prism in radians.
@@ -183,33 +193,32 @@ class Prism(SurfaceApodizer):
         The orientation of the prism in radians. The default orientation is aligned along the y-axis.
     '''
     def __init__(self, angle_of_incidence, prism_angle, refractive_index, orientation=0):
-        self._prism_angle = prism_angle
-        self._angle_of_incidence = angle_of_incidence
-        self._refractive_index = refractive_index
-        self._orientation = orientation
+        self.angle_of_incidence = angle_of_incidence
+        self.prism_angle = prism_angle
+        self.orientation = orientation
+        self.refractive_index = refractive_index
 
-        super().__init__(self.prism_sag, self._refractive_index)
+    def _get_refractive_index(self, wavelength):
+        if callable(self.refractive_index):
+            return self.refractive_index(wavelength)
+        return self.refractive_index
 
-    @property
-    def orientation(self):
-        return self._orientation
+    def forward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+        sag = self.prism_sag(wavefront.electric_field.grid, wavefront.wavelength)
 
-    @orientation.setter
-    def orientation(self, new_orientation):
-        self._orientation = new_orientation
-        self.surface_sag = self.prism_sag
+        new_field = wavefront.electric_field * np.exp(1j * (n - 1) * sag * wavefront.wavenumber)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
-    @property
-    def prism_angle(self):
-        return self._prism_angle
+    def backward(self, wavefront):
+        n = self._get_refractive_index(wavefront.wavelength)
+        sag = self.prism_sag(wavefront.electric_field.grid, wavefront.wavelength)
 
-    @prism_angle.setter
-    def prism_angle(self, new_prism_angle):
-        self._prism_angle = new_prism_angle
-        self.surface_sag = self.prism_sag
+        new_field = wavefront.electric_field * np.exp(-1j * (n - 1) * sag * wavefront.wavenumber)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
 
     def minimal_deviation_angle(self, wavelength):
-        ''' Find the angle of minimal deviation for a prism.
+        '''Find the angle of minimal deviation for a prism.
 
         Parameters
         ----------
@@ -221,11 +230,11 @@ class Prism(SurfaceApodizer):
         scalar
             The angle of minimal deviation in radians.
         '''
-        n = self._refractive_index(wavelength)
-        return 2 * np.arcsin(n * np.sin(self._prism_angle / 2)) - self._prism_angle
+        n = self._get_refractive_index(wavelength)
+        return 2 * np.arcsin(n * np.sin(self.prism_angle / 2)) - self.prism_angle
 
     def trace(self, wavelength):
-        ''' Trace a ray through the prism.
+        '''Trace a ray through the prism.
 
         Parameters
         ----------
@@ -237,18 +246,11 @@ class Prism(SurfaceApodizer):
         scalar
             The angle of deviation for the traced ray in radians.
         '''
-        n = self._refractive_index(wavelength)
-        transmitted_angle_surface_1 = snells_law(self._angle_of_incidence, 1 / n)
-
-        incident_angle_surface_2 = self._prism_angle - transmitted_angle_surface_1
-        transmitted_angle = snells_law(incident_angle_surface_2, n)
-
-        angle_of_deviation = self._angle_of_incidence + transmitted_angle - self._prism_angle
-
-        return angle_of_deviation
+        n = self._get_refractive_index(wavelength)
+        return self._deviation(n)
 
     def prism_sag(self, grid, wavelength):
-        ''' Calculate the sag profile for the prism.
+        '''Calculate the sag profile for the prism.
 
         Parameters
         ----------
@@ -262,10 +264,21 @@ class Prism(SurfaceApodizer):
         Field
             The surface sag.
         '''
-        theta = self.trace(wavelength)
-        return Field(grid.rotated(self._orientation).y * np.tan(theta) / (self._refractive_index(wavelength) - 1), grid)
+        n = self._get_refractive_index(wavelength)
+        theta = self._deviation(n)
+        sag = _tilt_sag(self.orientation, theta)(grid)
+        return Field(sag / (n - 1), grid)
 
-class PhaseGrating(PhaseApodizer):
+    def _deviation(self, n):
+        '''Calculate the deviation angle for a given refractive index.
+        '''
+        transmitted_angle_surface_1 = snells_law(self.angle_of_incidence, 1 / n)
+        incident_angle_surface_2 = self.prism_angle - transmitted_angle_surface_1
+        transmitted_angle = snells_law(incident_angle_surface_2, n)
+
+        return self.angle_of_incidence + transmitted_angle - self.prism_angle
+
+class PhaseGrating(OpticalElement):
     '''A grating that applies an achromatic phase pattern.
 
     Parameters
@@ -280,9 +293,9 @@ class PhaseGrating(PhaseApodizer):
         The orientation of the grating in radians. The default orientation is aligned along the y-axis.
     '''
     def __init__(self, grating_period, grating_amplitude, grating_profile=None, orientation=0):
-        self._grating_period = grating_period
-        self._orientation = orientation
-        self._grating_amplitude = grating_amplitude
+        self.grating_period = grating_period
+        self.grating_amplitude = grating_amplitude
+        self.orientation = orientation
 
         if grating_profile is None:
             def sinusoidal_grating_profile(grid):
@@ -290,36 +303,39 @@ class PhaseGrating(PhaseApodizer):
 
             grating_profile = sinusoidal_grating_profile
 
-        self._grating_profile = grating_profile
-
-        super().__init__(self.grating_pattern)
+        self.grating_profile = grating_profile
 
     def grating_pattern(self, grid):
-        return self._grating_amplitude * Field(self._grating_profile(grid.rotated(self._orientation).scaled(1 / self._grating_period)), grid)
+        return self.grating_amplitude * Field(self.grating_profile(grid.rotated(self.orientation).scaled(1 / self.grating_period)), grid)
 
     @property
-    def orientation(self):
-        return self._orientation
-
-    @orientation.setter
-    def orientation(self, new_orientation):
-        self._orientation = new_orientation
-        self.phase = self.grating_pattern
-
-    @property
+    @deprecated('Use grating_period instead.')
     def period(self):
-        return self._grating_period
+        return self.grating_period
 
     @period.setter
-    def period(self, new_period):
-        self._grating_period = new_period
-        self.phase = self.grating_pattern
+    @deprecated('Use grating_period instead.')
+    def period(self, period):
+        self.grating_period = period
 
     @property
+    @deprecated('Use grating_amplitude instead.')
     def amplitude(self):
-        return self._amplitude
+        return self.grating_amplitude
 
     @amplitude.setter
-    def amplitude(self, new_amplitude):
-        self._amplitude = new_amplitude
-        self.phase = self.grating_pattern
+    @deprecated('Use grating_amplitude instead.')
+    def amplitude(self, val):
+        self.grating_amplitude = val
+
+    def forward(self, wavefront):
+        phase = self.grating_pattern(wavefront.electric_field.grid)
+        new_field = wavefront.electric_field * np.exp(1j * phase)
+
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
+
+    def backward(self, wavefront):
+        phase = self.grating_pattern(wavefront.electric_field.grid)
+        new_field = wavefront.electric_field * np.exp(-1j * phase)
+
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)

--- a/hcipy/optics/thin_lens.py
+++ b/hcipy/optics/thin_lens.py
@@ -1,41 +1,50 @@
 from .surface_profiles import parabolic_surface_sag
-from .apodization import SurfaceApodizer
+from .optical_element import OpticalElement
+from .wavefront import Wavefront
+import numpy as np
 
-class ThinLens(SurfaceApodizer):
+class ThinLens(OpticalElement):
     '''A parabolic thin lens.
 
     Parameters
     ----------
     focal_length : scalar
-        The focal length of the thin lens at the refernce wavelength.
+        The focal length of the thin lens at the reference wavelength.
     refractive_index : scalar or function of wavelength
         The refractive index of the lens material.
     reference_wavelength : scalar
         The wavelength for which the focal length is defined.
-
     '''
     def __init__(self, focal_length, refractive_index, reference_wavelength):
-        self._focal_length = focal_length
-        self._refractive_index = refractive_index
-        self._reference_wavelength = reference_wavelength
+        self.reference_wavelength = reference_wavelength
+        self.refractive_index = refractive_index
+        self.focal_length = focal_length
 
-        n0 = refractive_index(reference_wavelength)
-        radius_of_curvature = focal_length * (n0 - 1)
-        sag = parabolic_surface_sag(-radius_of_curvature)
-        super().__init__(sag, refractive_index)
+    def _get_refractive_index(self, wavelength):
+        if callable(self.refractive_index):
+            return self.refractive_index(wavelength)
+        else:
+            return self.refractive_index
 
     @property
-    def focal_length(self):
-        '''The focal length of the lens.
-        '''
-        return self._focal_length
+    def surface_sag(self):
+        return parabolic_surface_sag(-self.radius_of_curvature)
 
-    @focal_length.setter
-    def focal_length(self, focal_length):
-        self._focal_length = focal_length
+    @property
+    def radius_of_curvature(self):
+        n0 = self._get_refractive_index(self.reference_wavelength)
+        return self.focal_length * (n0 - 1)
 
-        n0 = self._refractive_index(self._reference_wavelength)
-        radius_of_curvature = focal_length * (n0 - 1)
-        sag = parabolic_surface_sag(-radius_of_curvature)
+    def forward(self, wavefront):
+        surface_sag = self.surface_sag(wavefront.electric_field.grid)
+        n = self._get_refractive_index(wavefront.wavelength)
 
-        self.surface_sag = sag
+        new_field = wavefront.electric_field * np.exp(1j * (n - 1) * surface_sag * wavefront.wavenumber)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)
+
+    def backward(self, wavefront):
+        surface_sag = self.surface_sag(wavefront.electric_field.grid)
+        n = self._get_refractive_index(wavefront.wavelength)
+
+        new_field = wavefront.electric_field * np.exp(-1j * (n - 1) * surface_sag * wavefront.wavenumber)
+        return Wavefront(new_field, wavefront.wavelength, wavefront.input_stokes_vector)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1082,3 +1082,177 @@ def test_dynamic_optical_system_callback_adds_callback_during_evolution():
     system.add_callback(2.0, first)
     system.evolve_until(5.0)
     assert events == ['first', 'second']
+
+def test_apodizer_roundtrip():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    apod = Apodizer(np.exp(1j * Field(grid.ones(), grid)))
+
+    wf2 = apod.backward(apod.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_apodizer_callable():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    apod = Apodizer(lambda wl: np.exp(1j * (wl / 1e-6)))
+
+    wf2 = apod.backward(apod.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_phase_apodizer_roundtrip():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    phase = zernike(2, 0)(grid)
+    apod = PhaseApodizer(phase)
+
+    wf2 = apod.backward(apod.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_surface_apodizer_scalar_n():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    sag = Field(0.1 * grid.ones(), grid)
+    sa = SurfaceApodizer(sag, 1.5)
+
+    wf2 = sa.backward(sa.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_surface_apodizer_callable_n():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    sag = Field(0.1 * grid.ones(), grid)
+    sa = SurfaceApodizer(sag, lambda wl: 1.5 + (wl - 1e-6) * 1e4)
+
+    wf2 = sa.backward(sa.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_complex_surface_apodizer_roundtrip():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    csa = ComplexSurfaceApodizer(np.exp(1j * Field(grid.ones(), grid)), Field(0.1 * grid.ones(), grid), 1.5)
+
+    wf2 = csa.backward(csa.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_complex_surface_apodizer_callable():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    csa = ComplexSurfaceApodizer(lambda wl: np.exp(1j * (wl / 1e-6)), Field(0.1 * grid.ones(), grid), lambda wl: 1.5 + (wl - 1e-6) * 1e4)
+
+    wf2 = csa.backward(csa.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_multiplexed_complex_surface_apodizer_roundtrip():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    amp = np.exp(1j * Field(0.5 * np.ones(grid.size), grid))
+    surf = Field(0.1 * grid.ones(), grid)
+    mcsa = MultiplexedComplexSurfaceApodizer([amp], [surf], 1.5)
+
+    wf2 = mcsa.backward(mcsa.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_multiplexed_complex_surface_apodizer_multi():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    amps = [np.exp(1j * Field(0.5 * np.ones(grid.size), grid)), np.exp(1j * Field(0.3 * np.ones(grid.size), grid))]
+    surfs = [Field(0.1 * grid.ones(), grid), Field(0.2 * grid.ones(), grid)]
+    mcsa = MultiplexedComplexSurfaceApodizer(amps, surfs, 1.5)
+
+    wf_out = mcsa.forward(wf)
+    wf_back = mcsa.backward(wf_out)
+
+    assert np.all(np.isfinite(wf_back.electric_field))
+
+def test_multiplexed_complex_surface_apodizer_callable():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    amps = [lambda wl: np.exp(1j * 0.5 * (wl / 1e-6)), lambda wl: np.exp(1j * 0.3 * (wl / 1e-6))]
+    surfs = [Field(0.1 * grid.ones(), grid), Field(0.2 * grid.ones(), grid)]
+    mcsa = MultiplexedComplexSurfaceApodizer(amps, surfs, lambda wl: 1.5 + (wl - 1e-6) * 1e4)
+
+    wf_out = mcsa.forward(wf)
+    wf_back = mcsa.backward(wf_out)
+
+    assert np.all(np.isfinite(wf_back.electric_field))
+
+def test_multiplexed_complex_surface_apodizer_deprecated_params():
+    grid = make_pupil_grid(64)
+    amps = [Field(0.5 * np.ones(grid.size), grid)]
+    surfs = [Field(0.1 * grid.ones(), grid)]
+
+    with pytest.warns(DeprecationWarning):
+        mcsa = MultiplexedComplexSurfaceApodizer(None, None, 1.5, amplitude=amps, surface=surfs)
+
+    assert len(mcsa.amplitudes) == 1
+
+def test_tilt_element_roundtrip():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    tilt = TiltElement(0.05)
+
+    wf2 = tilt.backward(tilt.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_tilt_element_callable_n():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    tilt = TiltElement(0.05, refractive_index=lambda wl: 1.5 + (wl - 1e-6) * 1e4)
+
+    wf2 = tilt.backward(tilt.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_thin_prism_forward_backward():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    tp = ThinPrism(np.deg2rad(3), 1.5)
+
+    wf2 = tp.backward(tp.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_prism_roundtrip():
+    grid = make_pupil_grid(64)
+    wf = Wavefront(grid.ones(), 1e-6)
+    p = Prism(0, np.deg2rad(3), 1.5)
+
+    wf2 = p.backward(p.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_prism_prism_sag():
+    grid = make_pupil_grid(64)
+    p = Prism(0, np.deg2rad(3), 1.5)
+
+    sag = p.prism_sag(grid, 1e-6)
+
+    assert isinstance(sag, Field)
+    assert sag.grid is grid
+
+def test_phase_grating_roundtrip():
+    grid = make_pupil_grid(128, 1)
+    wf = Wavefront(grid.ones(), 1e-6)
+    g = PhaseGrating(1 / 20, np.pi / 2)
+
+    wf2 = g.backward(g.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_thin_lens_backward():
+    grid = make_pupil_grid(256, 1)
+    wf = Wavefront(grid.ones(), 1e-6)
+    lens = ThinLens(300e-1, 1.5, 1e-6)
+
+    wf2 = lens.backward(lens.forward(wf))
+
+    assert np.allclose(wf.electric_field, wf2.electric_field)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1256,3 +1256,14 @@ def test_thin_lens_backward():
     wf2 = lens.backward(lens.forward(wf))
 
     assert np.allclose(wf.electric_field, wf2.electric_field)
+
+def test_surface_aberration_at_distance():
+    grid = make_pupil_grid(64, 1)
+    wf = Wavefront(grid.ones(), 1e-6)
+    aberration = SurfaceAberration(grid, 1e-7, 1, exponent=-3)
+    sad = SurfaceAberrationAtDistance(grid, aberration, 100e-3)
+
+    wf_out = sad.forward(wf)
+    wf_back = sad.backward(wf_out)
+
+    assert np.allclose(wf.electric_field, wf_back.electric_field)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -7,19 +7,8 @@ import warnings
 
 def test_agnostic_apodizer():
     aperture_achromatic = make_circular_aperture(1)
-    aperture_chromatic = lambda input_grid, wavelength: make_circular_aperture(wavelength)(input_grid)
-
-    apod_achromatic = Apodizer(aperture_achromatic)
-    apod_chromatic = Apodizer(aperture_chromatic)
-
-    phase_chromatic = lambda input_grid, wavelength: zernike(2, 0)(input_grid) * wavelength
-    apod_phase_chromatic = PhaseApodizer(phase_chromatic)
-
     phase_achromatic = zernike(2, 0)
-    apod_phase_achromatic = PhaseApodizer(phase_achromatic)
-
     filter_curve = lambda wavelength: np.sqrt(wavelength)
-    apod_filter = Apodizer(filter_curve)
 
     for wl in [0.2, 0.4, 0.7]:
         for num_pix in [32, 64, 128]:
@@ -27,18 +16,15 @@ def test_agnostic_apodizer():
                 pupil_grid = make_pupil_grid(num_pix, diameter)
                 wf = Wavefront(pupil_grid.ones(), wl)
 
+                apod_achromatic = Apodizer(aperture_achromatic(pupil_grid))
                 pup = apod_achromatic(wf).electric_field
                 assert np.allclose(pup, aperture_achromatic(pupil_grid))
 
-                pup = apod_chromatic(wf).electric_field
-                assert np.allclose(pup, aperture_chromatic(pupil_grid, wl))
-
+                apod_phase_achromatic = PhaseApodizer(phase_achromatic(pupil_grid))
                 pup = apod_phase_achromatic(wf).electric_field
                 assert np.allclose(pup, np.exp(1j * phase_achromatic(pupil_grid)))
 
-                pup = apod_phase_chromatic(wf).electric_field
-                assert np.allclose(pup, np.exp(1j * phase_chromatic(pupil_grid, wl)))
-
+                apod_filter = Apodizer(filter_curve)
                 pup = apod_filter(wf).electric_field
                 assert np.allclose(pup, filter_curve(wl))
 
@@ -579,7 +565,7 @@ def test_pickle_optical_element():
     focal_grid = make_focal_grid(4, 16)
 
     elem1 = FraunhoferPropagator(pupil_grid, focal_grid)
-    elem2 = SurfaceApodizer(pupil_grid.ones(), lambda wvl: 1.5 + wvl)
+    elem2 = SurfaceApodizer(pupil_grid.ones(), 1.5)
     elems = [elem1, elem2]
 
     for elem in elems:
@@ -715,7 +701,7 @@ def test_thin_lens():
     grid = make_pupil_grid(256, 2 * pupil_diameter)
 
     focal_length = 300e-1
-    lens = ThinLens(focal_length, lambda x: 1.5, 1e-6)
+    lens = ThinLens(focal_length, 1.5, 1e-6)
 
     aperture = evaluate_supersampled(make_circular_aperture(pupil_diameter), grid, 8)
     assert abs((lens.focal_length - focal_length) / focal_length) < 1e-10
@@ -784,12 +770,11 @@ def test_prism():
     prism.prism_angle = 2 * np.deg2rad(3. + 53.0 / 60.0)
     assert np.allclose(prism.minimal_deviation_angle(750e-9), 0.06958405951915544)
 
-    Dtel = 1
-    Dgrid = 1.1 * Dtel
-    sr = np.mean(test_wavelengths) / Dtel
-
-    grid = make_pupil_grid(128, Dgrid)
-    aperture = make_circular_aperture(Dtel)(grid)
+    pupil_diameter = 1
+    grid_diameter = 1.1 * pupil_diameter
+    sr = np.mean(test_wavelengths) / pupil_diameter
+    grid = make_pupil_grid(128, grid_diameter)
+    aperture = make_circular_aperture(pupil_diameter)(grid)
 
     focal_grid = make_focal_grid(q=3, num_airy=15, spatial_resolution=sr)
     prop = FraunhoferPropagator(grid, focal_grid)


### PR DESCRIPTION
This PR rewrites the apodization class hierarchy to inherit from `OpticalElement` instead of `AgnosticOpticalElement`, eliminating all caching and grid-agnostic parameter evaluation. Dispersion optics classes (`TiltElement`, `ThinPrism`, `Prism`, `PhaseGrating`) also become standalone `OpticalElement` subclasses that compute sag/phase on-the-fly from the wavefront's grid, removing the grid constructor parameter.

This reduction in caching simplifies the transition to autodiff frameworks. Those need to know the entire calculation from start to finish to do differentiation, and caching of intermediate values limits that.

Several bugs were fixed in addition to the refactor:
1. `ThinPrism.minimal_deviation_angle()` referenced `self.prism_angle` which was never set.
2. `PhaseGrating.amplitude` property getter returned `self._amplitude` which was never set.
3. `MultiplexedComplexSurfaceApodizer.backward()` used wrong mathematical operation (division by amplitude mask rather than multiplication by its conjugate.
4. Missing docstring of `ComplexSurfaceApodizer` and `MultiplexedComplexSurfaceApodizer` classes.
5. Documentation typo ("sacalar") in the `Prism` class docstring.