### PR TITLE
Misc bugfixes.

### DIFF
--- a/hcipy/atmosphere/atmospheric_model.py
+++ b/hcipy/atmosphere/atmospheric_model.py
@@ -43,7 +43,7 @@ class AtmosphericLayer(OpticalElement):
     height : scalar
         The height of the atmospheric layer above the ground.
     '''
-    def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0):
+    def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0):
         self.input_grid = input_grid
         self.Cn_squared = Cn_squared
         self.L0 = L0

--- a/hcipy/atmosphere/finite_atmospheric_layer.py
+++ b/hcipy/atmosphere/finite_atmospheric_layer.py
@@ -40,7 +40,7 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
         If a BitGenerator or Generator are passed, these will be wrapped and used
         instead. Default: None.
     '''
-    def __init__(self, input_grid, Cn_squared=None, L0=np.inf, velocity=0, height=0, oversampling=2, seed=None):
+    def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0, oversampling=2, seed=None):
         self._noise = None
         self._achromatic_screen = None
 

--- a/hcipy/atmosphere/finite_atmospheric_layer.py
+++ b/hcipy/atmosphere/finite_atmospheric_layer.py
@@ -150,6 +150,6 @@ class FiniteAtmosphericLayer(AtmosphericLayer):
         return self._L0
 
     @outer_scale.setter
-    def L0(self, L0):  # noqa: N802
+    def outer_scale(self, L0):  # noqa: N802
         self._L0 = L0
         self._noise = None

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -373,7 +373,7 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
         return self._L0
 
     @outer_scale.setter
-    def L0(self, L0):  # noqa: N802
+    def outer_scale(self, L0):
         self._L0 = L0
 
         self._recalculate_matrices()

--- a/hcipy/atmosphere/modal_adaptive_optics_layer.py
+++ b/hcipy/atmosphere/modal_adaptive_optics_layer.py
@@ -155,7 +155,7 @@ class ModalAdaptiveOpticsLayer(AtmosphericLayer):
         return self.layer.L0
 
     @outer_scale.setter
-    def L0(self, L0):  # noqa: N802
+    def outer_scale(self, L0):
         self.layer.L0 = L0
 
     def reset(self):

--- a/hcipy/config/config.py
+++ b/hcipy/config/config.py
@@ -2,10 +2,7 @@ import os
 import yaml
 from pathlib import Path
 
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
+from importlib.resources import files
 
 class _ConfigurationItem:
     def __init__(self, mapping=None):

--- a/hcipy/coronagraphy/apodizing_phase_plate.py
+++ b/hcipy/coronagraphy/apodizing_phase_plate.py
@@ -144,7 +144,7 @@ def generate_app_por(wavefront, propagator, propagator_max, contrast, num_iterat
         model.addQConstr(r2 <= 1)
 
     for i, ee in enumerate(M):
-        e = gp.quicksum((x[i] * ee[i] for i in range(n)))
+        e = gp.quicksum((x[j] * ee[j] for j in range(n)))
         model.addConstr(e <= contrast_requirement[i])
         model.addConstr(e >= -contrast_requirement[i])
 

--- a/hcipy/coronagraphy/apodizing_phase_plate.py
+++ b/hcipy/coronagraphy/apodizing_phase_plate.py
@@ -21,7 +21,7 @@ def generate_app_keller(wavefront, propagator, contrast, num_iterations, beta=0)
 
     Parameters
     ----------
-    wavefont : Wavefront
+    wavefront : Wavefront
         The input aperture as a wavefront; a phase can be provided as a
         starting point for the APP generation.
     propagator : Propagator
@@ -88,9 +88,11 @@ def generate_app_keller(wavefront, propagator, contrast, num_iterations, beta=0)
     return app
 
 def generate_app_por(wavefront, propagator, propagator_max, contrast, num_iterations=1):
-    '''Optimize a one-sided APP using a globally optimal algorithm. This algorithm does not
-    apply any symmetries for two-sided dark zones or circularly-symmetric pupils. This
-    function requires that you have installed the Gurobi optimizer.
+    '''Optimize a one-sided APP using a globally optimal algorithm.
+
+    This algorithm does not apply any symmetries for two-sided dark zones or
+    circularly-symmetric pupils. This function requires that you have installed
+    the Gurobi optimizer.
 
     Parameters
     ----------

--- a/hcipy/coronagraphy/perfect_coronagraph.py
+++ b/hcipy/coronagraphy/perfect_coronagraph.py
@@ -36,6 +36,8 @@ class PerfectCoronagraph(OpticalElement):
         radius [Guyon2006]_. If it is None, all modes are completely suppressed.
     '''
     def __init__(self, aperture, order=2, coeffs=None):
+        assert order % 2 == 0, "The coronagraph order has to be even."
+
         self.pupil_grid = aperture.grid
         modes = []
 

--- a/hcipy/coronagraphy/vortex.py
+++ b/hcipy/coronagraphy/vortex.py
@@ -189,10 +189,8 @@ class VectorVortexCoronagraph(AgnosticOpticalElement):
                     focal = Wavefront(focal.electric_field, input_stokes_vector=(1, 0, 0, 0))
 
                 focal.electric_field = field_dot(jones_matrix, focal.electric_field)
-                if i == 0:
-                    lyot = prop.backward(focal)
-                else:
-                    lyot.electric_field += prop.backward(focal).electric_field
+
+                lyot.electric_field += prop.backward(focal).electric_field
 
         lyot.wavelength = wavelength
         wavefront.wavelength = wavelength

--- a/hcipy/field/field.py
+++ b/hcipy/field/field.py
@@ -687,7 +687,7 @@ class NewStyleField(FieldBase):
     def __array__(self, dtype=None, copy=None):
         raise NotImplementedError("This Field cannot be used directly with Numpy. Use the Array API namespace instead.")
 
-_aritmetic_and_bitwise_operators = [
+_arithmetic_and_bitwise_operators = [
     # Arithmetic
     ('add', '+'),
     ('sub', '-'),
@@ -715,7 +715,7 @@ _comparison_operators = [
     ('ne', '!=')
 ]
 
-for name, symbol in _aritmetic_and_bitwise_operators:
+for name, symbol in _arithmetic_and_bitwise_operators:
     setattr(NewStyleField, f'__{name}__', _make_binary_operator(NewStyleField, symbol))
     setattr(NewStyleField, f'__i{name}__', _make_inplace_binary_operator(NewStyleField, symbol))
     setattr(NewStyleField, f'__r{name}__', _make_reflected_binary_operator(NewStyleField, symbol))

--- a/hcipy/field/polar_grid.py
+++ b/hcipy/field/polar_grid.py
@@ -54,7 +54,7 @@ class PolarGrid(Grid):
         Grid
             Itself to allow for chaining these transformations.
         '''
-        new_grid = PolarGrid(UnstructuredCoords(self.coords)).as_('cartesian')
+        new_grid = PolarGrid(UnstructuredCoords(self.coords), self.weights).as_('cartesian')
         self.coords = new_grid.shifted(shift).as_('polar').coords
 
         return self

--- a/hcipy/fourier/naive_fourier_transform.py
+++ b/hcipy/fourier/naive_fourier_transform.py
@@ -39,8 +39,7 @@ class NaiveFourierTransform(FourierTransform):
         If the output grid has a different dimension than the input grid.
     '''
     def __init__(self, input_grid, output_grid, precompute_matrices=None):
-        if input_grid.ndim != output_grid.ndim:
-            raise ValueError('The input_grid must have the same dimensions as the output_grid.')
+        self.check_if_supported(input_grid, output_grid)
 
         self.input_grid = input_grid
         self.output_grid = output_grid
@@ -141,7 +140,8 @@ class NaiveFourierTransform(FourierTransform):
             If the grids are not supported. The message will indicate why
             the grids are not supported.
         '''
-        pass
+        if input_grid.ndim != output_grid.ndim:
+            raise ValueError('The input_grid must have the same dimensions as the output_grid.')
 
     @classmethod
     def compute_complexity(cls, input_grid, output_grid):

--- a/hcipy/fourier/tuning.py
+++ b/hcipy/fourier/tuning.py
@@ -52,13 +52,15 @@ def compute_fourier_performance_dataset(fourier_class, Ns, qs, fovs, t_max=0.01)
 
         field = input_grid.ones()
 
-        if fourier_class.is_supported(input_grid, output_grid):
-            complexity = fourier_class.compute_complexity(input_grid, output_grid).num_operations
-            if fourier_class == FastFourierTransform:
-                ft = FastFourierTransform(input_grid, q, fov)
-            else:
-                ft = fourier_class(input_grid, output_grid)
-            execution_time = _time_it(lambda: ft.forward(field), t_max=t_max)
+        if not fourier_class.is_supported(input_grid, output_grid):
+            continue
+
+        complexity = fourier_class.compute_complexity(input_grid, output_grid).num_operations
+        if fourier_class == FastFourierTransform:
+            ft = FastFourierTransform(input_grid, q, fov)
+        else:
+            ft = fourier_class(input_grid, output_grid)
+        execution_time = _time_it(lambda: ft.forward(field), t_max=t_max)
 
         # Convert complexity to GFLOP.
         complexities.append(complexity / 1e9)
@@ -216,7 +218,7 @@ def _cli():
     tuned_parameters = tune_fourier_transforms(None, args.plot_out, args.show_plot)
 
     if args.coeffs_out:
-        with open('output.yaml', 'w') as f:
+        with open(args.coeffs_out, 'w') as f:
             yaml.dump(tuned_parameters, f)
 
     print('Fit results:')

--- a/hcipy/mode_basis/lp_fiber_modes.py
+++ b/hcipy/mode_basis/lp_fiber_modes.py
@@ -146,13 +146,13 @@ def make_lp_modes(grid, V_number, core_radius, return_betas=False):
         if solutions is not None:
             for ui, wi in zip(solutions[0], solutions[1]):
 
-                radial_prodile = lp_radial(m, ui, wi, R)
+                radial_profile = lp_radial(m, ui, wi, R)
                 beta = np.sqrt((V_number**2 + wi**2 - ui**2) / (2 * core_radius**2))
 
                 ms = [m, -m] if m > 0 else [m]
                 for mi in ms:
                     azimutal_profile = lp_azimuthal(mi, Theta)
-                    mode_profile = radial_prodile * azimutal_profile
+                    mode_profile = radial_profile * azimutal_profile
 
                     # Normalize the mode numerically as there is no analytical normalization
                     norm = np.sqrt(np.sum(mode_profile * mode_profile.conj() * grid.weights))

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -86,7 +86,7 @@ def zernike_to_noll(n, m):
         nn, mm = noll_to_zernike(j)
         if nn == n and mm == m:
             return j
-    raise ValueError('Could not find noll index for (%d,%d)' % n, m)
+    raise ValueError(f'Could not find noll index for n={n}, m={m}.')
 
 def zernike_radial(n, m, r, cache=None):
     '''The radial component of a Zernike polynomial.

--- a/hcipy/optics/aberration.py
+++ b/hcipy/optics/aberration.py
@@ -35,7 +35,8 @@ def make_power_law_error(pupil_grid, ptv, diameter, exponent=-2.5, aperture=None
         The surface error calculated on `pupil_grid`.
     '''
     def psd(grid):
-        res = Field(grid.as_('polar').r**exponent, grid)
+        with np.errstate(divide='ignore'):
+            res = Field(grid.as_('polar').r**exponent, grid)
         res[grid.as_('polar').r == 0] = 0
         return res
 

--- a/hcipy/optics/deformable_mirror.py
+++ b/hcipy/optics/deformable_mirror.py
@@ -2,10 +2,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 import numexpr as ne
 
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
+from importlib.resources import files
 
 from .optical_element import OpticalElement
 from ..field import make_uniform_grid, evaluate_supersampled

--- a/hcipy/optics/glass.py
+++ b/hcipy/optics/glass.py
@@ -1,9 +1,6 @@
 import numpy as np
 
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
+from importlib.resources import files
 
 def make_sellmeier_glass(A, K, L):
     r'''The Sellmeier equation for the dispersion of the refractive index of materials.

--- a/hcipy/optics/segmented_mirror.py
+++ b/hcipy/optics/segmented_mirror.py
@@ -21,6 +21,8 @@ class SegmentedDeformableMirror(DeformableMirror):
         self.actuators = np.zeros(len(segments) * 3)
         self.input_grid = segments.grid
 
+        super().__init__(self._compute_influence_functions(segments))
+
     @property
     def segments(self):
         '''The segments of this deformable mirror in a ModeBasis.
@@ -31,6 +33,17 @@ class SegmentedDeformableMirror(DeformableMirror):
     def segments(self, segments):
         self._segments = segments
 
+        self.influence_functions = self._compute_influence_functions(segments)
+
+    @staticmethod
+    def _compute_influence_functions(segments):
+        '''Compute the influence functions from mirror segments.
+
+        Parameters
+        ----------
+        segments : ModeBasis
+            The mode basis describing the mirror segments.
+        '''
         tip = []
         tilt = []
 
@@ -59,7 +72,7 @@ class SegmentedDeformableMirror(DeformableMirror):
         tip = ModeBasis(tip)
         tilt = ModeBasis(tilt)
 
-        self.influence_functions = segments + tip + tilt
+        return segments + tip + tilt
 
     def get_segment_actuators(self, segment_id):
         '''Get the actuators for an individual segment of the DM.

--- a/hcipy/plotting/field.py
+++ b/hcipy/plotting/field.py
@@ -1,4 +1,3 @@
-from copy import copy
 import numpy as np
 from matplotlib.transforms import Transform
 

--- a/hcipy/plotting/field.py
+++ b/hcipy/plotting/field.py
@@ -343,8 +343,7 @@ def imsave_field(filename, field, grid=None, vmin=None, vmax=None, norm=None, ma
         # For Matplotlib <3.5.
         cmap = mpl.cm.get_cmap(cmap)
 
-    cmap = copy(cmap)
-    cmap.set_bad(mask_color)
+    cmap = cmap.with_extremes(bad=mask_color)
 
     plt.imsave(filename, f.shaped, cmap=cmap, vmin=vmin, vmax=vmax)
 

--- a/hcipy/util/finite_difference.py
+++ b/hcipy/util/finite_difference.py
@@ -30,12 +30,12 @@ def generate_convolution_matrix(grid, kernel):
             num_x = kernel.shape[1]
             num_y = kernel.shape[0]
             kernel = kernel.ravel()
-        elif kernel.ndim == 1:
-            raise NotImplementedError("Can not create a convolution kernel from a 1D array.")
+        else:
+            raise NotImplementedError(f"Can not create a convolution kernel from a {kernel.ndim}D array.")
 
     index_y, index_x = np.indices((num_y, num_x))
     offsets = ((index_x - num_x // 2) + (index_y - num_y // 2) * grid.shape[0]).ravel()
-    convolution_matrix = sparse.diags(kernel, offsets, shape=(grid.size, grid.size))
+    convolution_matrix = sparse.diags(kernel, offsets, shape=(grid.size, grid.size), dtype=None)
     return convolution_matrix
 
 def make_laplacian_matrix(grid):

--- a/hcipy/util/spectral_noise.py
+++ b/hcipy/util/spectral_noise.py
@@ -237,7 +237,7 @@ class SpectralNoiseFactoryMultiscale(SpectralNoiseFactory):
         # * (2*np.pi)**self.input_grid.ndim is due to conversion from PSD from "per Hertz" to "per radian", which yields a factor of 2pi per dimension
         self.C_1 = np.sqrt(psd(self.input_grid_1) / self.input_grid_1.weights * (2 * np.pi)**self.input_grid_1.ndim)
         self.C_1[mask_1] = 0
-        self.C_2 = np.sqrt(psd(self.input_grid_2) / self.input_grid_2.weights * (2 * np.pi)**self.input_grid_1.ndim)
+        self.C_2 = np.sqrt(psd(self.input_grid_2) / self.input_grid_2.weights * (2 * np.pi)**self.input_grid_2.ndim)
         self.C_2[mask_2] = 0
 
     def make_random(self, seed=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
     "xxhash",
     "numexpr",
     "asdf",
-    "importlib_metadata",
-    "importlib_resources>=1.4 ; python_version<'3.9'",
+    "packaging",
     "tqdm",
     "array_api_compat",
 ]
@@ -56,7 +55,6 @@ doc = [
     "nbformat",
     "nbconvert",
     "sphinx-automodapi",
-    "tqdm",
     "ipywidgets",
 ]
 


### PR DESCRIPTION
This PR fixes a variety of bugs:

* Typos in variable names.
* Docstrings of two functions.
* Default parameters that made the class broken.
* Missing assertion for even `PerfectCoronagraph` order.
* Unnecessary package dependencies.
* Missing package dependency. 
* Supported grids for `NaiveFourierTransform`.
* Grid weights during shifting of polar grids.
* Dead code.
* Warnings emitted due to divide by zero (which was fixed already).
* Missing `super().__init__()` call in `SegmentedDeformableMirror`.
* Broken string formatting for error message.
* Deprecation of `ColorMap.set_bad()` from Matplotlib.

These bugs were found with the help of DeepSeek V4 (alongside maybe double as many false positives).