### PR TITLE
Disable hypothesis deadlines during testing.

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -69,7 +69,7 @@ jobs:
         ARRAY_API_TESTS_MODULE: "exec('import hcipy; import array_api_strict; xp = hcipy.make_field_namespace(array_api_strict)')"
         ARRAY_API_STRICT_API_VERSION: 2024.12
       run: |
-        pytest ./array-api-tests/ -ra -v --cov=./ --cov-report=xml --skips-file ./.github/workflows/array-api-tests-skips.txt
+        pytest ./array-api-tests/ -ra -v --cov=./ --cov-report=xml --skips-file ./.github/workflows/array-api-tests-skips.txt --hypothesis-disable-deadline
       shell: bash -l {0}
 
     - name: Upload coverage to codecov.io


### PR DESCRIPTION
The deadline setting exists to catch performance regressions, and prevent slow tests. However, slow systems or heavily loaded CI servers can cause false-positive timeouts. This has been happening for us as well.

This PR turns the deadline setting off.