### PR TITLE
Atmosphere interpolation speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 .ipynb_checkpoints/
 _version.py
 .DS_Store
+__pycache__/

--- a/hcipy/_math/subpixel_shift.py
+++ b/hcipy/_math/subpixel_shift.py
@@ -35,7 +35,7 @@ def _quintic_weights(shift):
 
 
 @njit(parallel=True, fastmath=True, cache=True)
-def _row_pass(img, kernel, radius, out, tile):
+def _row_pass(img, kernel, radius, out):
     """Numba-parallel horizontal (row) pass of a separable convolution.
 
     For each output pixel ``(y, x)``:
@@ -58,37 +58,25 @@ def _row_pass(img, kernel, radius, out, tile):
         Half-width of the kernel (``len(kernel) // 2``).
     out : ndarray of shape (H, W)
         Output buffer, overwritten in place.
-    tile : int
-        Side length of the square cache tile.
     """
     H, W = img.shape
-    n_tiles_y = (H + tile - 1) // tile
+    Wm1 = W - 1
 
-    for ty in prange(n_tiles_y):
-        y0 = ty * tile
-        y1 = min(y0 + tile, H)
+    for y in prange(H):
+        row = img[y]
+        for x in range(W):
+            acc = 0.0
 
-        for x0 in range(0, W, tile):
-            x1 = min(x0 + tile, W)
+            for k in range(-radius, radius + 1):
+                xx = max(0, min(Wm1, x + k))
 
-            for y in range(y0, y1):
-                for x in range(x0, x1):
-                    acc = 0.0
+                acc += row[xx] * kernel[k + radius]
 
-                    for k in range(-radius, radius + 1):
-                        xx = x + k
-                        if xx < 0:
-                            xx = 0
-                        elif xx >= W:
-                            xx = W - 1
-
-                        acc += img[y, xx] * kernel[k + radius]
-
-                    out[y, x] = acc
+            out[y, x] = acc
 
 
 @njit(parallel=True, fastmath=True, cache=True)
-def _col_pass(img, kernel, radius, out, tile):
+def _col_pass(img, kernel, radius, out):
     """Numba-parallel vertical (column) pass of a separable convolution.
 
     For each output pixel ``(y, x)``:
@@ -111,37 +99,24 @@ def _col_pass(img, kernel, radius, out, tile):
         Half-width of the kernel (``len(kernel) // 2``).
     out : ndarray of shape (H, W)
         Output buffer, overwritten in place.
-    tile : int
-        Side length of the square cache tile.
     """
     H, W = img.shape
-    n_tiles_y = (H + tile - 1) // tile
+    Hm1 = H - 1
 
-    for ty in prange(n_tiles_y):
-        y0 = ty * tile
-        y1 = min(y0 + tile, H)
+    for y in prange(H):
+        for x in range(W):
+            acc = 0.0
 
-        for x0 in range(0, W, tile):
-            x1 = min(x0 + tile, W)
+            for k in range(-radius, radius + 1):
+                yy = max(0, min(Hm1, y + k))
 
-            for y in range(y0, y1):
-                for x in range(x0, x1):
-                    acc = 0.0
+                acc += img[yy, x] * kernel[k + radius]
 
-                    for k in range(-radius, radius + 1):
-                        yy = y + k
-                        if yy < 0:
-                            yy = 0
-                        elif yy >= H:
-                            yy = H - 1
-
-                        acc += img[yy, x] * kernel[k + radius]
-
-                    out[y, x] = acc
+            out[y, x] = acc
 
 
-def separable_convolve_numpy(img, kernel_row, kernel_col, tile=64):
-    """Numba-accelerated cache-tiled separable 2-D convolution.
+def separable_convolve_numpy(img, kernel_row, kernel_col):
+    """Numba-accelerated separable 2-D convolution.
 
     Only accepts :class:`numpy.ndarray` inputs.  For other array backends
     (CuPy, JAX, PyTorch, …) use :func:`separable_convolve_fallback`.
@@ -154,8 +129,6 @@ def separable_convolve_numpy(img, kernel_row, kernel_col, tile=64):
         1-D kernel applied along columns (axis 1).  Must have odd length.
     kernel_col : array-like of shape (K,)
         1-D kernel applied along rows (axis 0).  Must have odd length.
-    tile : int, optional
-        Side length of the square cache tile (default 64).
 
     Returns
     -------
@@ -183,8 +156,8 @@ def separable_convolve_numpy(img, kernel_row, kernel_col, tile=64):
     tmp = np.empty_like(img)
     out = np.empty_like(img)
 
-    _row_pass(img, kernel_row, radius_x, tmp, tile)
-    _col_pass(tmp, kernel_col, radius_y, out, tile)
+    _row_pass(img, kernel_row, radius_x, tmp)
+    _col_pass(tmp, kernel_col, radius_y, out)
 
     return out
 
@@ -289,7 +262,7 @@ def separable_convolve_fallback(img, kernel_row, kernel_col):
     return out
 
 
-def separable_convolve(img, kernel_row, kernel_col, tile=64):
+def separable_convolve(img, kernel_row, kernel_col):
     """Separable 2-D convolution with automatic backend dispatch.
 
     Dispatches to :func:`separable_convolve_numpy` for ``numpy.ndarray``
@@ -304,8 +277,6 @@ def separable_convolve(img, kernel_row, kernel_col, tile=64):
         1-D kernel applied along columns (axis 1).  Must have odd length.
     kernel_col : array-like of shape (K,)
         1-D kernel applied along rows (axis 0).  Must have odd length.
-    tile : int, optional
-        Tile size for the numba backend (ignored by the fallback). Default 64.
 
     Returns
     -------
@@ -313,12 +284,12 @@ def separable_convolve(img, kernel_row, kernel_col, tile=64):
         Convolved image, produced by the same backend as *img*.
     """
     if is_numpy_array(img):
-        return separable_convolve_numpy(img, kernel_row, kernel_col, tile)
+        return separable_convolve_numpy(img, kernel_row, kernel_col)
     else:
         return separable_convolve_fallback(img, kernel_row, kernel_col)
 
 
-def subpixel_shift(img, row_shift, col_shift, tile=64):
+def subpixel_shift(img, row_shift, col_shift):
     """Sub-pixel shift via separable 5th-order B-spline convolution.
 
     The image is shifted by the specified fractional amounts using quintic
@@ -338,8 +309,6 @@ def subpixel_shift(img, row_shift, col_shift, tile=64):
         Fractional shift along axis 0 (rows).  Must be in ``[-0.5, 0.5]``.
     col_shift : float
         Fractional shift along axis 1 (columns).  Must be in ``[-0.5, 0.5]``.
-    tile : int, optional
-        Tile size for the numba backend.  Default 64.
 
     Returns
     -------
@@ -349,4 +318,4 @@ def subpixel_shift(img, row_shift, col_shift, tile=64):
     wy = _quintic_weights(row_shift)
     wx = _quintic_weights(col_shift)
 
-    return separable_convolve(img, wx, wy, tile)
+    return separable_convolve(img, wx, wy)

--- a/hcipy/_math/subpixel_shift.py
+++ b/hcipy/_math/subpixel_shift.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numba import njit, prange
 from array_api_compat import is_numpy_array, is_jax_array
+from .backends import array_namespace
 
 
 def _quintic_weights(shift):
@@ -225,6 +226,8 @@ def separable_convolve_fallback(img, kernel_row, kernel_col):
     ValueError
         When either of the kernels does not have an odd length
     """
+    xp = array_namespace(img, kernel_row, kernel_col)
+
     H, W = img.shape[0], img.shape[1]
 
     rx = kernel_row.shape[0] // 2
@@ -239,7 +242,7 @@ def separable_convolve_fallback(img, kernel_row, kernel_col):
     # ---- Horizontal pass ----
     tmp = img * float(kernel_row[rx])
     for i in range(kernel_row.shape[0]):
-        w = kernel_row[i]
+        w = xp.asarray(kernel_row[i])
         s = i - rx
 
         if s > 0:
@@ -256,7 +259,7 @@ def separable_convolve_fallback(img, kernel_row, kernel_col):
     # ---- Vertical pass ----
     out = tmp * float(kernel_col[ry])
     for i in range(kernel_col.shape[0]):
-        w = kernel_col[i]
+        w = xp.asarray(kernel_col[i])
         s = i - ry
 
         if s > 0:

--- a/hcipy/_math/subpixel_shift.py
+++ b/hcipy/_math/subpixel_shift.py
@@ -219,11 +219,22 @@ def separable_convolve_fallback(img, kernel_row, kernel_col):
     -------
     out : array of shape (H, W)
         Convolved image, produced by the same backend as *img*.
+
+    Raises
+    ------
+    ValueError
+        When either of the kernels does not have an odd length
     """
     H, W = img.shape[0], img.shape[1]
 
-    rx = len(kernel_row) // 2
-    ry = len(kernel_col) // 2
+    rx = kernel_row.shape[0] // 2
+    ry = kernel_col.shape[0] // 2
+
+    if kernel_row.shape[0] % 2 == 0:
+        raise ValueError("kernel_row must have odd length")
+
+    if kernel_col.shape[0] % 2 == 0:
+        raise ValueError("kernel_col must have odd length")
 
     # ---- Horizontal pass ----
     tmp = img * float(kernel_row[rx])
@@ -314,7 +325,15 @@ def subpixel_shift(img, row_shift, col_shift):
     -------
     out : array of shape (H, W)
         Sub-pixel shifted image, produced by the same backend as *img*.
+
+    Raises
+    ------
+    ValueError
+        When *row_shift* or *col_shift* are not in ``[-0.5, 0.5]``.
     """
+    if not (-0.5 <= row_shift <= 0.5) or not (-0.5 <= col_shift <= 0.5):
+        raise ValueError("row_shift and col_shift must be in [-0.5, 0.5]")
+
     wy = _quintic_weights(row_shift)
     wx = _quintic_weights(col_shift)
 

--- a/hcipy/_math/subpixel_shift.py
+++ b/hcipy/_math/subpixel_shift.py
@@ -1,0 +1,352 @@
+import numpy as np
+from numba import njit, prange
+from array_api_compat import is_numpy_array, is_jax_array
+
+
+def _quintic_weights(shift):
+    """Compute the 7-element quintic B-spline kernel for a fractional shift.
+
+    Parameters
+    ----------
+    shift : float
+        Fractional shift in ``[-0.5, 0.5]``.  The sign determines the
+        padding direction of the kernel.
+
+    Returns
+    -------
+    ndarray of shape (7,)
+        The 7-element 1-D convolution kernel.
+    """
+    f = abs(shift)
+    b = np.empty(6)
+    for i, offset in enumerate([2.0 + f, 1.0 + f, f, 1.0 - f, 2.0 - f, 3.0 - f]):
+        s = 0.0
+        x = offset + 3.0
+        for c in (1.0, -6.0, 15.0, -20.0, 15.0, -6.0, 1.0):
+            if x > 0.0:
+                s += c * (x ** 5)
+            x -= 1.0
+        b[i] = s / 120.0
+
+    if shift >= 0:
+        return np.asarray([0.0, b[0], b[1], b[2], b[3], b[4], b[5]], dtype=b.dtype)
+    else:
+        return np.asarray([b[5], b[4], b[3], b[2], b[1], b[0], 0.0], dtype=b.dtype)
+
+
+@njit(parallel=True, fastmath=True, cache=True)
+def _row_pass(img, kernel, radius, out, tile):
+    """Numba-parallel horizontal (row) pass of a separable convolution.
+
+    For each output pixel ``(y, x)``:
+
+    .. math::
+
+        \\mathtt{out}[y, x] = \\sum_{k=-\\mathtt{radius}}^{\\mathtt{radius}}
+        \\mathtt{kernel}[k + \\mathtt{radius}] \\cdot
+        \\mathtt{img}[y, \\operatorname{clamp}(x + k, 0, W-1)]
+
+    Out-of-bounds indices are clamped to the nearest edge (``mode='nearest'``).
+
+    Parameters
+    ----------
+    img : ndarray of shape (H, W)
+        Input image.
+    kernel : ndarray of shape (2 * radius + 1,)
+        1-D convolution kernel.
+    radius : int
+        Half-width of the kernel (``len(kernel) // 2``).
+    out : ndarray of shape (H, W)
+        Output buffer, overwritten in place.
+    tile : int
+        Side length of the square cache tile.
+    """
+    H, W = img.shape
+    n_tiles_y = (H + tile - 1) // tile
+
+    for ty in prange(n_tiles_y):
+        y0 = ty * tile
+        y1 = min(y0 + tile, H)
+
+        for x0 in range(0, W, tile):
+            x1 = min(x0 + tile, W)
+
+            for y in range(y0, y1):
+                for x in range(x0, x1):
+                    acc = 0.0
+
+                    for k in range(-radius, radius + 1):
+                        xx = x + k
+                        if xx < 0:
+                            xx = 0
+                        elif xx >= W:
+                            xx = W - 1
+
+                        acc += img[y, xx] * kernel[k + radius]
+
+                    out[y, x] = acc
+
+
+@njit(parallel=True, fastmath=True, cache=True)
+def _col_pass(img, kernel, radius, out, tile):
+    """Numba-parallel vertical (column) pass of a separable convolution.
+
+    For each output pixel ``(y, x)``:
+
+    .. math::
+
+        \\mathtt{out}[y, x] = \\sum_{k=-\\mathtt{radius}}^{\\mathtt{radius}}
+        \\mathtt{kernel}[k + \\mathtt{radius}] \\cdot
+        \\mathtt{tmp}[\\operatorname{clamp}(y + k, 0, H-1), x]
+
+    Out-of-bounds indices are clamped to the nearest edge (``mode='nearest'``).
+
+    Parameters
+    ----------
+    img : ndarray of shape (H, W)
+        Intermediate image from the horizontal pass.
+    kernel : ndarray of shape (2 * radius + 1,)
+        1-D convolution kernel.
+    radius : int
+        Half-width of the kernel (``len(kernel) // 2``).
+    out : ndarray of shape (H, W)
+        Output buffer, overwritten in place.
+    tile : int
+        Side length of the square cache tile.
+    """
+    H, W = img.shape
+    n_tiles_y = (H + tile - 1) // tile
+
+    for ty in prange(n_tiles_y):
+        y0 = ty * tile
+        y1 = min(y0 + tile, H)
+
+        for x0 in range(0, W, tile):
+            x1 = min(x0 + tile, W)
+
+            for y in range(y0, y1):
+                for x in range(x0, x1):
+                    acc = 0.0
+
+                    for k in range(-radius, radius + 1):
+                        yy = y + k
+                        if yy < 0:
+                            yy = 0
+                        elif yy >= H:
+                            yy = H - 1
+
+                        acc += img[yy, x] * kernel[k + radius]
+
+                    out[y, x] = acc
+
+
+def separable_convolve_numpy(img, kernel_row, kernel_col, tile=64):
+    """Numba-accelerated cache-tiled separable 2-D convolution.
+
+    Only accepts :class:`numpy.ndarray` inputs.  For other array backends
+    (CuPy, JAX, PyTorch, …) use :func:`separable_convolve_fallback`.
+
+    Parameters
+    ----------
+    img : ndarray of shape (H, W)
+        Input image.
+    kernel_row : array-like of shape (K,)
+        1-D kernel applied along columns (axis 1).  Must have odd length.
+    kernel_col : array-like of shape (K,)
+        1-D kernel applied along rows (axis 0).  Must have odd length.
+    tile : int, optional
+        Side length of the square cache tile (default 64).
+
+    Returns
+    -------
+    out : ndarray of shape (H, W)
+        Convolved image.
+
+    Raises
+    ------
+    ValueError
+        If either kernel has even length.
+    """
+    kernel_row = np.asarray(kernel_row, dtype=img.dtype)
+    kernel_col = np.asarray(kernel_col, dtype=img.dtype)
+
+    radius_x = len(kernel_row) // 2
+    radius_y = len(kernel_col) // 2
+
+    if len(kernel_row) != 2 * radius_x + 1:
+        raise ValueError("kernel_row must have odd length")
+
+    if len(kernel_col) != 2 * radius_y + 1:
+        raise ValueError("kernel_col must have odd length")
+
+    img = np.ascontiguousarray(img)
+    tmp = np.empty_like(img)
+    out = np.empty_like(img)
+
+    _row_pass(img, kernel_row, radius_x, tmp, tile)
+    _col_pass(tmp, kernel_col, radius_y, out, tile)
+
+    return out
+
+
+def _iadd(a, indices, b):
+    """Accumulate ``b`` into ``a[indices]``, returning the result.
+
+    Uses ``a.at[indices].add(b)`` for array backends that expose an ``.at``
+    property (e.g. JAX), and in-place ``a[indices] += b`` for all others
+    (NumPy, CuPy, PyTorch, …).
+
+    Parameters
+    ----------
+    a : array
+        Array to accumulate into.
+    indices : tuple of slice or int
+        Indexing tuple understood by the backend.
+    b : array
+        Values to add.
+
+    Returns
+    -------
+    array
+        ``a`` after the accumulation (possibly a new array for immutable
+        backends).
+    """
+    if is_jax_array(a):
+        return a.at[indices].add(b)
+
+    a[indices] += b
+    return a
+
+
+def separable_convolve_fallback(img, kernel_row, kernel_col):
+    """Separable 2-D convolution via slice-based weighted accumulation.
+
+    Expressed as view-based weighted sums (no ``take(…, mode='clip')``) for
+    maximum Array-API portability.  Works on any array backend (NumPy, CuPy,
+    JAX, PyTorch, …) without modification.
+
+    The convolution is split into two 1-D passes:
+
+    1. **Horizontal pass**: each row is convolved with *kernel_row*.
+    2. **Vertical pass**: each column of the result is convolved with
+       *kernel_col*.
+
+    Boundary conditions are ``mode='nearest'`` (clamp to edge).
+
+    Parameters
+    ----------
+    img : array of shape (H, W)
+        Input image.
+    kernel_row : array-like of shape (K,)
+        1-D kernel applied along columns (axis 1).  Must have odd length.
+    kernel_col : array-like of shape (K,)
+        1-D kernel applied along rows (axis 0).  Must have odd length.
+
+    Returns
+    -------
+    out : array of shape (H, W)
+        Convolved image, produced by the same backend as *img*.
+    """
+    H, W = img.shape[0], img.shape[1]
+
+    rx = len(kernel_row) // 2
+    ry = len(kernel_col) // 2
+
+    # ---- Horizontal pass ----
+    tmp = img * float(kernel_row[rx])
+    for i in range(kernel_row.shape[0]):
+        w = kernel_row[i]
+        s = i - rx
+
+        if s > 0:
+            tmp = _iadd(tmp, (slice(None), slice(None, W - s)),
+                        img[:, s:] * w)
+            tmp = _iadd(tmp, (slice(None), slice(W - s, None)),
+                        img[:, -1:] * w)
+        elif s < 0:
+            tmp = _iadd(tmp, (slice(None), slice(-s, None)),
+                        img[:, :W + s] * w)
+            tmp = _iadd(tmp, (slice(None), slice(None, -s)),
+                        img[:, :1] * w)
+
+    # ---- Vertical pass ----
+    out = tmp * float(kernel_col[ry])
+    for i in range(kernel_col.shape[0]):
+        w = kernel_col[i]
+        s = i - ry
+
+        if s > 0:
+            out = _iadd(out, (slice(None, H - s), slice(None)),
+                        tmp[s:, :] * w)
+            out = _iadd(out, (slice(H - s, None), slice(None)),
+                        tmp[-1:, :] * w)
+        elif s < 0:
+            out = _iadd(out, (slice(-s, None), slice(None)),
+                        tmp[:H + s, :] * w)
+            out = _iadd(out, (slice(None, -s), slice(None)),
+                        tmp[:1, :] * w)
+
+    return out
+
+
+def separable_convolve(img, kernel_row, kernel_col, tile=64):
+    """Separable 2-D convolution with automatic backend dispatch.
+
+    Dispatches to :func:`separable_convolve_numpy` for ``numpy.ndarray``
+    inputs, and to :func:`separable_convolve_fallback` for all other array
+    types (CuPy, JAX, PyTorch, …).
+
+    Parameters
+    ----------
+    img : array of shape (H, W)
+        Input image.
+    kernel_row : array-like of shape (K,)
+        1-D kernel applied along columns (axis 1).  Must have odd length.
+    kernel_col : array-like of shape (K,)
+        1-D kernel applied along rows (axis 0).  Must have odd length.
+    tile : int, optional
+        Tile size for the numba backend (ignored by the fallback). Default 64.
+
+    Returns
+    -------
+    out : array of shape (H, W)
+        Convolved image, produced by the same backend as *img*.
+    """
+    if is_numpy_array(img):
+        return separable_convolve_numpy(img, kernel_row, kernel_col, tile)
+    else:
+        return separable_convolve_fallback(img, kernel_row, kernel_col)
+
+
+def subpixel_shift(img, row_shift, col_shift, tile=64):
+    """Sub-pixel shift via separable 5th-order B-spline convolution.
+
+    The image is shifted by the specified fractional amounts using quintic
+    B-spline interpolation (no IIR pre-filter — acceptable for band-limited
+    atmospheric data).
+
+    ``row_shift`` and ``col_shift`` **must** be in ``[-0.5, 0.5]``.
+    The caller is responsible for removing integer-pixel shifts (e.g. via
+    :func:`numpy.roll` or :func:`numpy.roll` equivalents on other backends)
+    before calling this function.
+
+    Parameters
+    ----------
+    img : array of shape (H, W)
+        Input image.
+    row_shift : float
+        Fractional shift along axis 0 (rows).  Must be in ``[-0.5, 0.5]``.
+    col_shift : float
+        Fractional shift along axis 1 (columns).  Must be in ``[-0.5, 0.5]``.
+    tile : int, optional
+        Tile size for the numba backend.  Default 64.
+
+    Returns
+    -------
+    out : array of shape (H, W)
+        Sub-pixel shifted image, produced by the same backend as *img*.
+    """
+    wy = _quintic_weights(row_shift)
+    wx = _quintic_weights(col_shift)
+
+    return separable_convolve(img, wx, wy, tile)

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -3,12 +3,11 @@ from __future__ import division
 from .atmospheric_model import AtmosphericLayer, phase_covariance_von_karman, fried_parameter_from_Cn_squared
 from ..field import Field, RegularCoords, UnstructuredCoords, CartesianGrid
 from .finite_atmospheric_layer import FiniteAtmosphericLayer
+from .._math.subpixel_shift import subpixel_shift
 
 import numpy as np
 from scipy import linalg
-from scipy.ndimage import affine_transform
 
-import warnings
 import copy
 import math
 
@@ -358,15 +357,9 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
             # Use fifth-order Bezier interpolation to interpolate the achromatic phase screen to the correct position.
             # This is to avoid sudden shifts by discrete pixels.
             ps = self._achromatic_screen.shaped
-
-            with warnings.catch_warnings():
-                # Suppress warnings about the changed behaviour in affine_transform for 1D arrays.
-                # We know about this and are expecting the behaviour as is.
-                warnings.filterwarnings('ignore', message='The behaviour of affine_transform')
-                warnings.filterwarnings('ignore', message='The behavior of affine_transform')
-
-                screen = affine_transform(ps, np.array([1, 1]), np.asarray(sub_delta / self.input_grid.delta)[::-1], mode='nearest', order=5)
-                self._shifted_achromatic_screen = Field(screen.ravel(), self._achromatic_screen.grid)
+            shift_px = sub_delta / self.input_grid.delta    # [x_px, y_px]
+            screen = subpixel_shift(ps, shift_px[1], shift_px[0])
+            self._shifted_achromatic_screen = Field(screen.ravel(), self._achromatic_screen.grid)
         else:
             self._shifted_achromatic_screen = self._achromatic_screen
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "imageio",
     "xxhash",
     "numexpr",
+    "numba",
     "asdf",
     "packaging",
     "tqdm",

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -62,7 +62,7 @@ def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, 
     aperture = make_circular_aperture(pupil_diameter)(pupil_grid)
 
     Cn_squared = Cn_squared_from_fried_parameter(fried_parameter, wavelength)
-    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, use_interpolation=False)
+    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, use_interpolation=True)
 
     num_iterations = 2000
     total_variance = []

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -40,6 +40,10 @@ def zernike_variance_von_karman(n, m, R, k0, Cn_squared, wavelength):
 
     return coeffs_all * (term11 * term12 + term21 * term22)
 
+@pytest.mark.parametrize('velocity', [
+    pytest.param([7, 7]),
+    pytest.param([-7, -7])
+])
 @pytest.mark.parametrize('propagate_phase_screen', [
     pytest.param(True, id='infinite'),
     pytest.param(False, id='finite')
@@ -51,15 +55,14 @@ def zernike_variance_von_karman(n, m, R, k0, Cn_squared, wavelength):
     pytest.param(0.5e-6, 1, 0.3, 10, id='larger_fried_parameter', marks=pytest.mark.slow),
     pytest.param(0.5e-6, 1, 0.1, 40, id='larger_outer_diameter', marks=pytest.mark.slow)
 ])
-def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, outer_scale, propagate_phase_screen):
-    velocity = 10.0  # meters/sec
+def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, outer_scale, propagate_phase_screen, velocity):
     num_modes = 1000
 
     pupil_grid = make_pupil_grid(64, pupil_diameter)
     aperture = make_circular_aperture(pupil_diameter)(pupil_grid)
 
     Cn_squared = Cn_squared_from_fried_parameter(fried_parameter, wavelength)
-    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, [velocity / np.sqrt(2), velocity / np.sqrt(2)], use_interpolation=False)
+    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, use_interpolation=False)
 
     num_iterations = 2000
     total_variance = []
@@ -67,7 +70,7 @@ def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, 
     for it in range(num_iterations):
         layer.reset(make_independent_realization=True)
         if propagate_phase_screen:
-            layer.t = np.sqrt(2) * pupil_diameter / velocity
+            layer.t = np.sqrt(2) * pupil_diameter / np.linalg.norm(velocity)
 
         phase = layer.phase_for(wavelength)
         total_variance.append(np.var(phase[aperture > 0]))
@@ -81,6 +84,10 @@ def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, 
 
     assert (variance_measured / variance_theory - 1) < 0.1
 
+@pytest.mark.parametrize('velocity', [
+    pytest.param([7, 7]),
+    pytest.param([-7, -7])
+])
 @pytest.mark.parametrize('propagate_phase_screen', [
     pytest.param(True, id='infinite'),
     pytest.param(False, id='finite')
@@ -92,14 +99,13 @@ def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, 
     pytest.param(0.5e-6, 1, 0.3, 10, id='larger_fried_parameter', marks=pytest.mark.slow),
     pytest.param(0.5e-6, 1, 0.1, 40, id='larger_outer_diameter', marks=pytest.mark.slow)
 ])
-def test_atmosphere_zernike_variances(wavelength, pupil_diameter, fried_parameter, outer_scale, propagate_phase_screen):
-    velocity = 10.0  # meters/sec
+def test_atmosphere_zernike_variances(wavelength, pupil_diameter, fried_parameter, outer_scale, propagate_phase_screen, velocity):
     num_modes = 50
 
     pupil_grid = make_pupil_grid(128, pupil_diameter)
 
     Cn_squared = Cn_squared_from_fried_parameter(fried_parameter, wavelength)
-    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, [velocity / np.sqrt(2), velocity / np.sqrt(2)], use_interpolation=False)
+    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, use_interpolation=False)
 
     zernike_modes = make_zernike_basis(num_modes + 20, pupil_diameter, pupil_grid, starting_mode=2, radial_cutoff=False)
 
@@ -115,7 +121,7 @@ def test_atmosphere_zernike_variances(wavelength, pupil_diameter, fried_paramete
     for it in range(num_iterations):
         layer.reset(make_independent_realization=True)
         if propagate_phase_screen:
-            layer.t = np.sqrt(2) * pupil_diameter / velocity
+            layer.t = np.sqrt(2) * pupil_diameter / np.linalg.norm(velocity)
 
         phase = layer.phase_for(wavelength)
         coeffs = projection_matrix.dot(phase * np.sqrt(weights))[:num_modes]

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,7 +4,7 @@ import numpy as np
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
-from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _quintic_weights
+from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _quintic_weights, _row_pass, _col_pass
 import math
 
 
@@ -411,3 +411,27 @@ def test_zero_kernel(xp):
     result = separable_convolve(img, k, k)
 
     assert np.allclose(np.asarray(result), np.asarray(img))
+
+
+def test_row_col_pass_compiled():
+    rng = np.random.default_rng(0)
+    img = rng.standard_normal((64, 64))
+    kernel = rng.standard_normal(5)
+    kernel /= kernel.sum()
+    r = len(kernel) // 2
+
+    out_py = np.zeros_like(img)
+    out_jit = np.ones_like(img)
+
+    _row_pass.py_func(img, kernel, r, out_py, 64)
+    _row_pass(img, kernel, r, out_jit, 64)
+
+    assert np.allclose(out_py, out_jit)
+
+    out_py = np.zeros_like(img)
+    out_jit = np.ones_like(img)
+
+    _col_pass.py_func(img, kernel, r, out_py, 64)
+    _col_pass(img, kernel, r, out_jit, 64)
+
+    assert np.allclose(out_py, out_jit)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -405,7 +405,7 @@ def test_subpixel_shift(xp, row_shift, col_shift):
     assert np.allclose(result, expected, atol=tol)
 
 def test_zero_kernel(xp):
-    rng = np.random.default_rng(0)
+    rng = make_random_generator(xp, seed=0)
     img = rng.normal(size=(32, 32))
     k = xp.asarray([0.0, 0.0, 1.0, 0.0, 0.0])
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,6 +4,7 @@ import numpy as np
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
+from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _quintic_weights
 import math
 
 
@@ -303,3 +304,110 @@ def test_to_numpy(xp):
 def test_array_namespace(xp):
     arr = xp.zeros(10)
     _ = array_namespace(arr)
+
+def _naive_separable_convolve(img, kernel_row, kernel_col):
+    """Per-pixel nearest-boundary reference implementation."""
+    rx = kernel_row.shape[0] // 2
+    ry = kernel_col.shape[0] // 2
+    H, W = img.shape
+
+    tmp = np.empty_like(img)
+    for y in range(H):
+        for x in range(W):
+            acc = 0.0
+
+            for k in range(-rx, rx + 1):
+                xx = x + k
+                if xx < 0:
+                    xx = 0
+                elif xx >= W:
+                    xx = W - 1
+
+                acc += img[y, xx] * kernel_row[k + rx]
+
+            tmp[y, x] = acc
+
+    out = np.empty_like(tmp)
+    for y in range(H):
+        for x in range(W):
+            acc = 0.0
+
+            for k in range(-ry, ry + 1):
+                yy = y + k
+                if yy < 0:
+                    yy = 0
+                elif yy >= H:
+                    yy = H - 1
+
+                acc += tmp[yy, x] * kernel_col[k + ry]
+
+            out[y, x] = acc
+
+    return out
+
+
+def _random_kernel(rng, radius):
+    n = 2 * radius + 1
+    k = rng.normal(size=n)
+
+    xp = array_namespace(k)
+    return k / xp.sum(k)
+
+
+@pytest.mark.parametrize('H,W,radius', [
+    (32, 32, 3),
+    (64, 64, 3),
+    (128, 32, 5),
+    (31, 31, 2),
+    (33, 33, 2),
+])
+def test_separable_convolve(xp, H, W, radius):
+    rng = make_random_generator(xp)
+
+    img = rng.normal(size=(H, W))
+    kx = _random_kernel(rng, radius)
+    ky = _random_kernel(rng, radius)
+
+    ref = _naive_separable_convolve(img, kx, ky)
+
+    result = separable_convolve(img, kx, ky)
+    result_np = np.asarray(result)
+
+    tol = 1e-5 if result.dtype == np.float32 else 1e-12
+    assert np.allclose(result_np, ref, atol=tol), f"max diff: {np.abs(result_np - ref).max()}"
+
+
+@pytest.mark.parametrize('row_shift,col_shift', [
+    (0.3, 0.7),
+    (-0.4, 0.1),
+    (0.0, -0.3),
+    (-0.5, -0.5),
+    (0.5, 0.5),
+])
+def test_subpixel_shift(xp, row_shift, col_shift):
+    rng = make_random_generator(xp)
+
+    img = rng.normal(size=(64, 64))
+
+    result = subpixel_shift(img, row_shift, col_shift)
+    result_np = np.asarray(result)
+
+    wy = _quintic_weights(row_shift)
+    wx = _quintic_weights(col_shift)
+
+    expected = separable_convolve(img, xp.asarray(wx), xp.asarray(wy))
+    expected_np = np.asarray(expected)
+
+    tol = 1e-5 if result.dtype == np.float32 else 1e-12
+    assert np.allclose(result_np, expected_np, atol=tol), \
+        f"shift=({row_shift},{col_shift}) max diff: {np.abs(result_np - expected_np).max()}"
+
+
+def test_zero_kernel(xp):
+    rng = np.random.default_rng(0)
+    img = rng.normal(size=(32, 32))
+    k = xp.asarray([0.0, 0.0, 1.0, 0.0, 0.0])
+
+    result = separable_convolve(img, k, k)
+
+    assert np.allclose(np.asarray(result), np.asarray(img))

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -368,12 +368,12 @@ def test_separable_convolve(xp, H, W, radius):
     kx = _random_kernel(rng, radius)
     ky = _random_kernel(rng, radius)
 
-    ref = _naive_separable_convolve(img, kx, ky)
+    ref = _naive_separable_convolve(np.asarray(img), np.asarray(kx), np.asarray(ky))
 
     result = separable_convolve(img, kx, ky)
     result_np = np.asarray(result)
 
-    tol = 1e-5 if result.dtype == np.float32 else 1e-12
+    tol = 1e-5 if result_np.dtype == np.float32 else 1e-12
     assert np.allclose(result_np, ref, atol=tol), f"max diff: {np.abs(result_np - ref).max()}"
 
 
@@ -398,7 +398,7 @@ def test_subpixel_shift(xp, row_shift, col_shift):
     expected = separable_convolve(img, xp.asarray(wx), xp.asarray(wy))
     expected_np = np.asarray(expected)
 
-    tol = 1e-5 if result.dtype == np.float32 else 1e-12
+    tol = 1e-5 if result_np.dtype == np.float32 else 1e-12
     assert np.allclose(result_np, expected_np, atol=tol), \
         f"shift=({row_shift},{col_shift}) max diff: {np.abs(result_np - expected_np).max()}"
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -424,15 +424,15 @@ def test_row_col_pass_compiled():
     out_py = np.zeros_like(img)
     out_jit = np.ones_like(img)
 
-    _row_pass.py_func(img, kernel, r, out_py, 64)
-    _row_pass(img, kernel, r, out_jit, 64)
+    _row_pass.py_func(img, kernel, r, out_py)
+    _row_pass(img, kernel, r, out_jit)
 
     assert np.allclose(out_py, out_jit)
 
     out_py = np.zeros_like(img)
     out_jit = np.ones_like(img)
 
-    _col_pass.py_func(img, kernel, r, out_py, 64)
-    _col_pass(img, kernel, r, out_jit, 64)
+    _col_pass.py_func(img, kernel, r, out_py)
+    _col_pass(img, kernel, r, out_jit)
 
     assert np.allclose(out_py, out_jit)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -401,7 +401,7 @@ def test_subpixel_shift(xp, row_shift, col_shift):
         mode='nearest',
     )
 
-    tol = 1e-5 if img.dtype == np.float32 else 1e-12
+    tol = 1e-5 if result.dtype == np.float32 else 1e-12
     assert np.allclose(result, expected, atol=tol)
 
 def test_zero_kernel(xp):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,8 +4,9 @@ import numpy as np
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
-from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _quintic_weights, _row_pass, _col_pass
+from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _row_pass, _col_pass
 import math
+from scipy.ndimage import affine_transform
 
 
 def _parameters():
@@ -378,7 +379,7 @@ def test_separable_convolve(xp, H, W, radius):
 
 
 @pytest.mark.parametrize('row_shift,col_shift', [
-    (0.3, 0.7),
+    (0.3, 0.3),
     (-0.4, 0.1),
     (0.0, -0.3),
     (-0.5, -0.5),
@@ -389,19 +390,19 @@ def test_subpixel_shift(xp, row_shift, col_shift):
 
     img = rng.normal(size=(64, 64))
 
-    result = subpixel_shift(img, row_shift, col_shift)
-    result_np = np.asarray(result)
+    result = np.asarray(subpixel_shift(img, row_shift, col_shift))
 
-    wy = _quintic_weights(row_shift)
-    wx = _quintic_weights(col_shift)
+    expected = affine_transform(
+        np.asarray(img),
+        np.eye(2),
+        offset=np.array([row_shift, col_shift]),
+        order=5,
+        prefilter=False,
+        mode='nearest',
+    )
 
-    expected = separable_convolve(img, xp.asarray(wx), xp.asarray(wy))
-    expected_np = np.asarray(expected)
-
-    tol = 1e-5 if result_np.dtype == np.float32 else 1e-12
-    assert np.allclose(result_np, expected_np, atol=tol), \
-        f"shift=({row_shift},{col_shift}) max diff: {np.abs(result_np - expected_np).max()}"
-
+    tol = 1e-5 if img.dtype == np.float32 else 1e-12
+    assert np.allclose(result, expected, atol=tol)
 
 def test_zero_kernel(xp):
     rng = np.random.default_rng(0)


### PR DESCRIPTION
Depends on #342.

Add a `subpixel_shift()` function that performs 5th-order Bezier interpolation using separated convolution. This operation is accelerated using Numba. There also is a fallback for other Array API backends, which simply use array views and in-place addition.