### PR TITLE
Add B-spline interpolation order for `InfiniteAtmosphericLayer`.

### DIFF
--- a/hcipy/_math/subpixel_shift.py
+++ b/hcipy/_math/subpixel_shift.py
@@ -4,35 +4,54 @@ from array_api_compat import is_numpy_array, is_jax_array
 from .backends import array_namespace
 
 
-def _quintic_weights(shift):
-    """Compute the 7-element quintic B-spline kernel for a fractional shift.
+def _bspline_basis(n, x):
+    """Uniform B-spline basis B_n(x) with support ``[0, n)``.
 
     Parameters
     ----------
+    n : int
+        B-spline order (``degree + 1``).
+    x : float
+        Evaluation point.
+
+    Returns
+    -------
+    float
+        ``B_n(x)``.
+    """
+    if n == 1:
+        return 1.0 if 0.0 <= x < 1.0 else 0.0
+    return (x / (n - 1)) * _bspline_basis(n - 1, x) + ((n - x) / (n - 1)) * _bspline_basis(n - 1, x - 1)
+
+
+def _bspline_weights(order, shift):
+    """Compute the B-spline convolution kernel for a given order and shift.
+
+    Parameters
+    ----------
+    order : int
+        B-spline polynomial degree (``1`` = linear, …, ``5`` = quintic).
+        Internally converted to B-spline order ``n = order + 1``.
     shift : float
         Fractional shift in ``[-0.5, 0.5]``.  The sign determines the
         padding direction of the kernel.
 
     Returns
     -------
-    ndarray of shape (7,)
-        The 7-element 1-D convolution kernel.
+    ndarray of shape (K,)
+        Odd-length 1-D convolution kernel.
     """
+    n = order + 1
     f = abs(shift)
-    b = np.empty(6)
-    for i, offset in enumerate([2.0 + f, 1.0 + f, f, 1.0 - f, 2.0 - f, 3.0 - f]):
-        s = 0.0
-        x = offset + 3.0
-        for c in (1.0, -6.0, 15.0, -20.0, 15.0, -6.0, 1.0):
-            if x > 0.0:
-                s += c * (x ** 5)
-            x -= 1.0
-        b[i] = s / 120.0
-
-    if shift >= 0:
-        return np.asarray([0.0, b[0], b[1], b[2], b[3], b[4], b[5]], dtype=b.dtype)
-    else:
-        return np.asarray([b[5], b[4], b[3], b[2], b[1], b[0], 0.0], dtype=b.dtype)
+    K = n + 1 if n % 2 == 0 else n + 2
+    half = K // 2
+    kernel = np.array(
+        [_bspline_basis(n, k - half + n / 2 - f) for k in range(K)],
+        dtype=np.float64,
+    )
+    if shift < 0:
+        kernel = kernel[::-1]
+    return kernel
 
 
 @njit(parallel=True, fastmath=True, cache=True)
@@ -303,17 +322,16 @@ def separable_convolve(img, kernel_row, kernel_col):
         return separable_convolve_fallback(img, kernel_row, kernel_col)
 
 
-def subpixel_shift(img, row_shift, col_shift):
-    """Sub-pixel shift via separable 5th-order B-spline convolution.
+def subpixel_shift(img, row_shift, col_shift, order):
+    """Sub-pixel shift via separable B-spline convolution.
 
-    The image is shifted by the specified fractional amounts using quintic
-    B-spline interpolation (no IIR pre-filter — acceptable for band-limited
-    atmospheric data).
+    The image is shifted by the specified fractional amounts using
+    B-spline interpolation of the given order (no IIR pre-filter).
 
     ``row_shift`` and ``col_shift`` **must** be in ``[-0.5, 0.5]``.
     The caller is responsible for removing integer-pixel shifts (e.g. via
-    :func:`numpy.roll` or :func:`numpy.roll` equivalents on other backends)
-    before calling this function.
+    :func:`numpy.roll` or equivalent on other backends) before calling
+    this function.
 
     Parameters
     ----------
@@ -323,6 +341,8 @@ def subpixel_shift(img, row_shift, col_shift):
         Fractional shift along axis 0 (rows).  Must be in ``[-0.5, 0.5]``.
     col_shift : float
         Fractional shift along axis 1 (columns).  Must be in ``[-0.5, 0.5]``.
+    order : int
+        B-spline polynomial degree (``1`` = linear, …, ``5`` = quintic).
 
     Returns
     -------
@@ -337,7 +357,7 @@ def subpixel_shift(img, row_shift, col_shift):
     if not (-0.5 <= row_shift <= 0.5) or not (-0.5 <= col_shift <= 0.5):
         raise ValueError("row_shift and col_shift must be in [-0.5, 0.5]")
 
-    wy = _quintic_weights(row_shift)
-    wx = _quintic_weights(col_shift)
+    wy = _bspline_weights(order, row_shift)
+    wx = _bspline_weights(order, col_shift)
 
     return separable_convolve(img, wx, wy)

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -10,6 +10,7 @@ from scipy import linalg
 
 import copy
 import math
+import warnings
 
 class InfiniteAtmosphericLayer(AtmosphericLayer):
     '''An atmospheric layer that can be infinitely extended in any direction.
@@ -60,15 +61,12 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
         can be unintuitive. The default value of 2 is usually sufficient in
         most instances.
     use_interpolation : boolean
-        whether to use sub-pixel interpolation of the phase screen. Without
-        interpolation, for short integration times or fast loop speeds, the
-        phase screen may stay on the same pixel for multiple frames. With
-        interpolation, these discrete pixel transitions are smoothed out.
-        The default is True.
+        Deprecated. Please use ``interpolation_order`` instead. Setting
+        `interpolation_order` to 0 turns off interpolation. Positive values
+        enable interpolation.
     interpolation_order : int
-        B-spline polynomial degree for sub-pixel interpolation (1 = linear,
-        2 = quadratic, ..., 5 = quintic). Only used when ``use_interpolation``
-        is True. Default 5.
+        B-spline polynomial degree for sub-pixel interpolation (0 = no interpolation,
+        1 = linear, 2 = quadratic, ..., 5 = quintic). Default 5.
     seed : None, int, array of ints, SeedSequence, BitGenerator, Generator
         A seed to initialize the spectral noise. If None, then fresh, unpredictable
         entry will be pulled from the OS. If an int or array of ints, then it will
@@ -81,7 +79,7 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
     ValueError
         When the input grid is not cartesian, regularly spaced and two-dimensional.
     '''
-    def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0, stencil_length=2, use_interpolation=True, interpolation_order=5, seed=None):
+    def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0, stencil_length=2, use_interpolation=None, interpolation_order=5, seed=None):
         self._initialized = False
 
         AtmosphericLayer.__init__(self, input_grid, Cn_squared, L0, velocity, height)
@@ -95,7 +93,17 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
             raise ValueError('Input grid must be two-dimensional.')
 
         self.stencil_length = stencil_length
-        self.use_interpolation = use_interpolation
+
+        if use_interpolation is not None:
+            warnings.warn(
+                'The use_interpolation argument is deprecated. Please use '
+                'interpolation_order instead. Set interpolation_order to 0 '
+                'to turn off interpolation.',
+                DeprecationWarning
+            )
+            if not use_interpolation:
+                interpolation_order = 0
+
         self.interpolation_order = interpolation_order
         self.rng = np.random.default_rng(seed)
 
@@ -358,9 +366,9 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
             else:
                 self._extrude('top')
 
-        if self.use_interpolation:
-            # Use fifth-order Bezier interpolation to interpolate the achromatic phase screen to the correct position.
-            # This is to avoid sudden shifts by discrete pixels.
+        if self.interpolation_order > 0:
+            # Use B-spline interpolation to shift the achromatic phase screen to the
+            # correct position. This is to avoid sudden shifts by discrete pixels.
             ps = self._achromatic_screen.shaped
             shift_px = sub_delta / self.input_grid.delta    # [x_px, y_px]
             screen = subpixel_shift(ps, shift_px[1], shift_px[0], order=self.interpolation_order)

--- a/hcipy/atmosphere/infinite_atmospheric_layer.py
+++ b/hcipy/atmosphere/infinite_atmospheric_layer.py
@@ -60,11 +60,15 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
         can be unintuitive. The default value of 2 is usually sufficient in
         most instances.
     use_interpolation : boolean
-        whether to use sub-pixel interpolation of the phase screen. Fifth-order Bezier
-        interpolation is used. Without interpolation, for short integration times
-        or fast loop speeds, the phase screen may stay on the same pixel for
-        multiple frames. With interpolation, these discrete pixel transitions
-        are smoothed out. The default is True.
+        whether to use sub-pixel interpolation of the phase screen. Without
+        interpolation, for short integration times or fast loop speeds, the
+        phase screen may stay on the same pixel for multiple frames. With
+        interpolation, these discrete pixel transitions are smoothed out.
+        The default is True.
+    interpolation_order : int
+        B-spline polynomial degree for sub-pixel interpolation (1 = linear,
+        2 = quadratic, ..., 5 = quintic). Only used when ``use_interpolation``
+        is True. Default 5.
     seed : None, int, array of ints, SeedSequence, BitGenerator, Generator
         A seed to initialize the spectral noise. If None, then fresh, unpredictable
         entry will be pulled from the OS. If an int or array of ints, then it will
@@ -77,7 +81,7 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
     ValueError
         When the input grid is not cartesian, regularly spaced and two-dimensional.
     '''
-    def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0, stencil_length=2, use_interpolation=True, seed=None):
+    def __init__(self, input_grid, Cn_squared, L0=np.inf, velocity=0, height=0, stencil_length=2, use_interpolation=True, interpolation_order=5, seed=None):
         self._initialized = False
 
         AtmosphericLayer.__init__(self, input_grid, Cn_squared, L0, velocity, height)
@@ -92,6 +96,7 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
 
         self.stencil_length = stencil_length
         self.use_interpolation = use_interpolation
+        self.interpolation_order = interpolation_order
         self.rng = np.random.default_rng(seed)
 
         self._make_stencils()
@@ -358,7 +363,7 @@ class InfiniteAtmosphericLayer(AtmosphericLayer):
             # This is to avoid sudden shifts by discrete pixels.
             ps = self._achromatic_screen.shaped
             shift_px = sub_delta / self.input_grid.delta    # [x_px, y_px]
-            screen = subpixel_shift(ps, shift_px[1], shift_px[0])
+            screen = subpixel_shift(ps, shift_px[1], shift_px[0], order=self.interpolation_order)
             self._shifted_achromatic_screen = Field(screen.ravel(), self._achromatic_screen.grid)
         else:
             self._shifted_achromatic_screen = self._achromatic_screen

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -62,7 +62,7 @@ def test_atmosphere_total_variance(wavelength, pupil_diameter, fried_parameter, 
     aperture = make_circular_aperture(pupil_diameter)(pupil_grid)
 
     Cn_squared = Cn_squared_from_fried_parameter(fried_parameter, wavelength)
-    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, use_interpolation=True)
+    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity)
 
     num_iterations = 2000
     total_variance = []
@@ -105,7 +105,7 @@ def test_atmosphere_zernike_variances(wavelength, pupil_diameter, fried_paramete
     pupil_grid = make_pupil_grid(128, pupil_diameter)
 
     Cn_squared = Cn_squared_from_fried_parameter(fried_parameter, wavelength)
-    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, use_interpolation=False)
+    layer = InfiniteAtmosphericLayer(pupil_grid, Cn_squared, outer_scale, velocity, interpolation_order=0)
 
     zernike_modes = make_zernike_basis(num_modes + 20, pupil_diameter, pupil_grid, starting_mode=2, radial_cutoff=False)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -381,6 +381,7 @@ def test_separable_convolve(xp, H, W, radius):
     assert np.allclose(result_np, ref, atol=tol), f"max diff: {np.abs(result_np - ref).max()}"
 
 
+@pytest.mark.parametrize('order', [1, 2, 3, 4, 5])
 @pytest.mark.parametrize('row_shift,col_shift', [
     (0.3, 0.3),
     (-0.4, 0.1),
@@ -388,18 +389,18 @@ def test_separable_convolve(xp, H, W, radius):
     (-0.5, -0.5),
     (0.5, 0.5),
 ])
-def test_subpixel_shift(xp, row_shift, col_shift):
+def test_subpixel_shift(xp, order, row_shift, col_shift):
     rng = make_random_generator(xp)
 
     img = rng.normal(size=(64, 64))
 
-    result = np.asarray(subpixel_shift(img, row_shift, col_shift))
+    result = np.asarray(subpixel_shift(img, row_shift, col_shift, order=order))
 
     expected = affine_transform(
         np.asarray(img),
         np.eye(2),
         offset=np.array([row_shift, col_shift]),
-        order=5,
+        order=order,
         prefilter=False,
         mode='nearest',
     )


### PR DESCRIPTION
Dependent on #342 and #343.

This PR introduces arbitrary order B-spline interpolation using `subpixel_shift()` and thereby `InfiniteAtmosphericLayer`. This allows people to use lower-order interpolation when their atmospheric simulation does not require the fidelity. This gives a slight performance boost. Note: in most cases for predictive control simulations at high framerate, you need high-order interpolation.

The calculation of B-spline coefficients uses [Cox–de Boor recursion formula](https://en.wikipedia.org/wiki/De_Boor%27s_algorithm), for those that are curious. The pixel shifts are checked against `scipy.ndimage.affine_transform()` for orders 1-5.

Benchmarks on Macbook Pro M2 Max:

```bash
> python benchmark_atmosphere.py
Single-step evolution (order 0): 443.1 FPS (2.257 ms/frame, 1024x1024 screen)
Single-step evolution (order 1): 259.8 FPS (3.850 ms/frame, 1024x1024 screen)
Single-step evolution (order 2): 236.2 FPS (4.234 ms/frame, 1024x1024 screen)
Single-step evolution (order 3): 219.9 FPS (4.547 ms/frame, 1024x1024 screen)
Single-step evolution (order 4): 218.5 FPS (4.578 ms/frame, 1024x1024 screen)
Single-step evolution (order 5): 212.5 FPS (4.706 ms/frame, 1024x1024 screen)
```

For the reviewer: we could consider removing the `use_interpolation` parameter, deprecating it, and letting `interpolation_order` being zero determine that no interpolation is needed (effectively nearest-pixel interpolation).