### PR TITLE
Add Michelson fringe visibility metric

### DIFF
--- a/hcipy/metrics/__init__.py
+++ b/hcipy/metrics/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     'get_strehl_from_pupil',
     'get_mean_intensity_in_roi',
     'get_mean_raw_contrast',
+    'get_fringe_visibility',
     'binned_profile',
     'azimutal_profile',
     'radial_profile'

--- a/hcipy/metrics/contrast.py
+++ b/hcipy/metrics/contrast.py
@@ -73,3 +73,50 @@ def get_mean_raw_contrast(img, mask, ref_img):
     strehl = get_strehl_from_focal(img, ref_img)
 
     return mean_intensity / strehl
+
+def get_fringe_visibility(intensity):
+    '''Get the Michelson fringe visibility from intensity samples.
+
+    The visibility is calculated from the maximum and minimum intensity
+    values as
+
+    .. math:: V = \\frac{I_\\mathrm{max} - I_\\mathrm{min}}
+                       {I_\\mathrm{max} + I_\\mathrm{min}}.
+
+    Parameters
+    ----------
+    intensity : Field or array_like
+        The non-negative intensity samples of an interference pattern.
+
+    Returns
+    -------
+    scalar
+        The Michelson fringe visibility.
+
+    Raises
+    ------
+    ValueError
+        If the input is empty, contains non-finite or negative values,
+        or contains only zero-valued intensities.
+    '''
+    intensity = np.asarray(intensity)
+
+    if intensity.size == 0:
+        raise ValueError('The intensity samples must not be empty.')
+
+    if not np.all(np.isfinite(intensity)):
+        raise ValueError('The intensity samples must be finite.')
+
+    if np.any(intensity < 0):
+        raise ValueError('The intensity samples must be non-negative.')
+
+    intensity_min = np.min(intensity)
+    intensity_max = np.max(intensity)
+    denominator = intensity_max + intensity_min
+
+    if denominator == 0:
+        raise ValueError(
+            'Fringe visibility is undefined when all intensities are zero.'
+        )
+
+    return (intensity_max - intensity_min) / denominator

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,1 +1,45 @@
-# check fwhm, contrast, strehl of known functions
+import numpy as np
+import pytest
+
+from hcipy import get_fringe_visibility
+
+
+@pytest.mark.parametrize(
+    'intensity, expected',
+    [
+        ([0, 1, 0, 1], 1.0),
+        ([1, 3, 1, 3], 0.5),
+        ([2, 2, 2, 2], 0.0),
+    ]
+)
+def test_get_fringe_visibility(intensity, expected):
+    visibility = get_fringe_visibility(intensity)
+
+    assert visibility == pytest.approx(expected)
+
+
+def test_get_fringe_visibility_is_scaling_invariant():
+    intensity = np.array([1, 2, 5, 3], dtype=float)
+
+    visibility = get_fringe_visibility(intensity)
+    scaled_visibility = get_fringe_visibility(10 * intensity)
+
+    assert scaled_visibility == pytest.approx(visibility)
+
+
+@pytest.mark.parametrize(
+    'intensity, error_message',
+    [
+        ([], 'must not be empty'),
+        ([0, 0, 0], 'undefined'),
+        ([-1, 1, 2], 'must be non-negative'),
+        ([1, np.nan, 2], 'must be finite'),
+        ([1, np.inf, 2], 'must be finite'),
+    ]
+)
+def test_get_fringe_visibility_rejects_invalid_input(
+    intensity,
+    error_message
+):
+    with pytest.raises(ValueError, match=error_message):
+        get_fringe_visibility(intensity)


### PR DESCRIPTION
## Summary

This PR adds a generic utility for calculating Michelson fringe visibility
from intensity samples:

\[
V = \frac{I_{\max} - I_{\min}}{I_{\max} + I_{\min}}
\]

The implementation uses NumPy only and is independent of any specific
detector model or simulation workflow.

## Changes

- Add `get_fringe_visibility()` to `hcipy.metrics`
- Export the function through the public HCIPy API
- Validate empty, non-finite, negative, and all-zero inputs
- Add tests for perfect, partial, and zero fringe contrast
- Add a test for positive-scaling invariance

## Validation

- Focused metrics tests: 9 passed
- Full test suite: 1731 passed, 205 skipped, 1 xpassed
- Flake8: passed
- Documentation build: succeeded
- API documentation generated successfully
- Validated as a replacement for the local visibility calculation in the
  Detector-Plane Imaging simulation

## Scope

This contribution is limited to the generic visibility metric. It does not
include detector simulation, noise modelling, pixel binning, automatic
fringe-profile extraction, or DPI-specific functionality.

Implements the generic metric discussed in #344.
