### PR TITLE
Fast DFT matrix calculation

### DIFF
--- a/hcipy/_math/fourier.py
+++ b/hcipy/_math/fourier.py
@@ -1,0 +1,77 @@
+import numba
+import numexpr
+import cmath
+import numpy as np
+
+from .backends import array_namespace
+from array_api_compat import is_numpy_array, is_numpy_namespace
+
+@numba.njit(parallel=True, fastmath=True, cache=True)
+def dft_matrix_separated_numba(x0, u0, dx, du, Nx, Nu, dtype, out=None):
+    alpha = du * dx / 2.0
+    C = cmath.exp(1j * u0 * x0)
+
+    A = np.empty(Nx, dtype=dtype)
+    for i in range(Nx):
+        A[i] = cmath.exp(1j * (u0 * dx * i - alpha * i * i))
+
+    B = np.empty(Nu, dtype=dtype)
+    for k in range(Nu):
+        B[k] = cmath.exp(1j * (du * x0 * k - alpha * k * k))
+
+    T = np.empty(Nx + Nu - 1, dtype=dtype)
+    for n in range(Nx + Nu - 1):
+        T[n] = cmath.exp(1j * (alpha * n * n))
+
+    if out is None:
+        out = np.empty((Nx, Nu), dtype=dtype)
+
+    for i in numba.prange(Nx):
+        ai = C * A[i]
+        Ti = T[i : i + Nu]
+
+        for k in range(Nu):
+            out[i, k] = ai * B[k] * Ti[k]
+
+    return out
+
+def dft_matrix_separated_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype):
+    x = xp.arange(Nx, dtype=dtype) * dx + x0
+    u = xp.arange(Nu, dtype=dtype) * du + u0
+
+    return xp.exp(1j * x[:, xp.newaxis] * u[xp.newaxis, :])
+
+def dft_matrix_separated(x0, u0, dx, du, Nx, Nu, xp, dtype, conjugate=False, transpose=False, out=None):
+    if conjugate:
+        x0 = -x0
+        dx = -dx
+
+    if transpose:
+        x0, u0 = u0, x0
+        dx, du = du, dx
+        Nx, Nu = Nu, Nx
+
+    if is_numpy_namespace(xp):
+        return dft_matrix_separated_numba(x0, u0, dx, du, Nx, Nu, dtype, out=out)
+    else:
+        return dft_matrix_separated_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype)
+
+def dft_matrix_unseparated_numba(x, u, out=None):
+    return numexpr.evaluate('exp(1j * x * u)', {'x': x[:, np.newaxis], 'u': u[np.newaxis, :]}, out=out)
+
+def dft_matrix_unseparated_fallback(x, u):
+    xp = array_namespace(x, u)
+
+    return xp.exp(1j * x[:, xp.newaxis] * u[xp.newaxis, :])
+
+def dft_matrix_unseparated(x, u, conjugate=False, transpose=False, out=None):
+    if conjugate:
+        x = -x
+
+    if transpose:
+        x, u = u, x
+
+    if is_numpy_array(x):
+        return dft_matrix_unseparated_numba(x, u, out=out)
+    else:
+        return dft_matrix_unseparated_fallback(x, u)

--- a/hcipy/_math/fourier.py
+++ b/hcipy/_math/fourier.py
@@ -7,7 +7,46 @@ from .backends import array_namespace
 from array_api_compat import is_numpy_array, is_numpy_namespace
 
 @numba.njit(parallel=True, fastmath=True, cache=True)
-def dft_matrix_separated_numba(x0, u0, dx, du, Nx, Nu, dtype, out=None):
+def _dft_matrix_regular_numpy(x0, u0, dx, du, Nx, Nu, dtype, out=None):
+    """Compute a DFT matrix for equally spaced grids, using numba.
+
+    The DFT matrix is defined as ``out[i, k] = exp(1j * u[k] * x[i])`` with
+    ``x[i] = x0 + i * dx`` and ``u[k] = u0 + k * du``. Because both grids are
+    equally spaced, the matrix can be factorised as
+
+    .. math:: \\exp\\left(1j \\, u_k x_i\\right) = C \\, A_i \\, B_k \\, T_{i+k},
+
+    where ``C`` is a constant and ``A``, ``B`` and ``T`` are precomputed
+    arrays of length ``Nx``, ``Nu`` and ``Nx + Nu - 1`` respectively. This
+    reduces the number of expensive complex exponential evaluations from
+    ``Nx * Nu`` to ``Nx + Nu``; all other entries are obtained with complex
+    multiplications. The rows of the output are computed in parallel.
+
+    Parameters
+    ----------
+    x0 : float
+        The starting coordinate of the ``x`` grid.
+    u0 : float
+        The starting coordinate of the ``u`` grid.
+    dx : float
+        The spacing of the ``x`` grid.
+    du : float
+        The spacing of the ``u`` grid.
+    Nx : int
+        The number of rows of the output matrix (the size of the ``x`` grid).
+    Nu : int
+        The number of columns of the output matrix (the size of the ``u`` grid).
+    dtype : dtype
+        The complex dtype of the output matrix.
+    out : Array, optional
+        An array of shape ``(Nx, Nu)`` and of the given `dtype` in which the
+        result is stored. If not given, a new array is allocated.
+
+    Returns
+    -------
+    Array
+        The DFT matrix of shape ``(Nx, Nu)``.
+    """
     alpha = du * dx / 2.0
     C = cmath.exp(1j * u0 * x0)
 
@@ -35,13 +74,88 @@ def dft_matrix_separated_numba(x0, u0, dx, du, Nx, Nu, dtype, out=None):
 
     return out
 
-def dft_matrix_separated_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype):
-    x = xp.arange(Nx, dtype=dtype) * dx + x0
-    u = xp.arange(Nu, dtype=dtype) * du + u0
+def _dft_matrix_regular_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype):
+    """Compute a DFT matrix for equally spaced grids, using any Array API namespace.
+
+    This is a fallback implementation of :func:`dft_matrix_regular` for
+    non-NumPy backends. The grids ``x`` and ``u`` are reconstructed from their
+    starting coordinates and spacings using the real dtype matching `dtype`,
+    after which the matrix is evaluated directly as
+    ``exp(1j * x[i] * u[k])``.
+
+    Parameters
+    ----------
+    x0 : float
+        The starting coordinate of the ``x`` grid.
+    u0 : float
+        The starting coordinate of the ``u`` grid.
+    dx : float
+        The spacing of the ``x`` grid.
+    du : float
+        The spacing of the ``u`` grid.
+    Nx : int
+        The number of rows of the output matrix (the size of the ``x`` grid).
+    Nu : int
+        The number of columns of the output matrix (the size of the ``u`` grid).
+    xp : module
+        The Array API namespace to use for the computation.
+    dtype : dtype
+        The complex dtype of the output matrix.
+
+    Returns
+    -------
+    Array
+        The DFT matrix of shape ``(Nx, Nu)``.
+    """
+    float_dtype = xp.float32 if dtype == xp.complex64 else xp.float64
+
+    x = xp.arange(Nx, dtype=float_dtype) * dx + x0
+    u = xp.arange(Nu, dtype=float_dtype) * du + u0
 
     return xp.exp(1j * x[:, xp.newaxis] * u[xp.newaxis, :])
 
-def dft_matrix_separated(x0, u0, dx, du, Nx, Nu, xp, dtype, conjugate=False, transpose=False, out=None):
+def dft_matrix_regular(x0, u0, dx, du, Nx, Nu, xp, dtype, conjugate=False, transpose=False, out=None):
+    """Compute a DFT matrix for equally spaced grids.
+
+    The DFT matrix is defined as ``out[i, k] = exp(1j * u[k] * x[i])`` with
+    ``x[i] = x0 + i * dx`` and ``u[k] = u0 + k * du``. On the NumPy backend
+    the matrix is computed with the numba implementation
+    :func:`_dft_matrix_regular_numpy`; on other backends it is computed
+    directly with :func:`_dft_matrix_regular_fallback`.
+
+    Parameters
+    ----------
+    x0 : float
+        The starting coordinate of the ``x`` grid.
+    u0 : float
+        The starting coordinate of the ``u`` grid.
+    dx : float
+        The spacing of the ``x`` grid.
+    du : float
+        The spacing of the ``u`` grid.
+    Nx : int
+        The number of rows of the output matrix (the size of the ``x`` grid).
+    Nu : int
+        The number of columns of the output matrix (the size of the ``u`` grid).
+    xp : module
+        The Array API namespace of the backend on which to compute the matrix.
+    dtype : dtype
+        The complex dtype of the output matrix.
+    conjugate : bool
+        If True, return the complex conjugate of the matrix.
+    transpose : bool
+        If True, return the transpose of the matrix. The output matrix then
+        has shape ``(Nu, Nx)``.
+    out : Array, optional
+        An array of the right shape in which the result is stored. Only
+        used on the NumPy backend; if not given, a new array is allocated.
+
+    Returns
+    -------
+    Array
+        The DFT matrix of shape ``(Nx, Nu)`` (or ``(Nu, Nx)`` if `transpose`
+        is True).
+    """
     if conjugate:
         x0 = -x0
         dx = -dx
@@ -52,19 +166,87 @@ def dft_matrix_separated(x0, u0, dx, du, Nx, Nu, xp, dtype, conjugate=False, tra
         Nx, Nu = Nu, Nx
 
     if is_numpy_namespace(xp):
-        return dft_matrix_separated_numba(x0, u0, dx, du, Nx, Nu, dtype, out=out)
+        return _dft_matrix_regular_numpy(x0, u0, dx, du, Nx, Nu, dtype, out=out)
     else:
-        return dft_matrix_separated_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype)
+        return _dft_matrix_regular_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype)
 
-def dft_matrix_unseparated_numba(x, u, out=None):
+def _dft_matrix_separated_numpy(x, u, out=None):
+    """Compute a DFT matrix for separated grids, using numexpr.
+
+    The DFT matrix is defined as ``out[i, k] = exp(1j * u[k] * x[i])`` for
+    separated (not necessarily equally spaced) grids `x` and `u`. The
+    computation is vectorized with numexpr.
+
+    Parameters
+    ----------
+    x : Array
+        The first grid, of shape ``(Nx,)``.
+    u : Array
+        The second grid, of shape ``(Nu,)``.
+    out : Array, optional
+        An array of shape ``(Nx, Nu)`` in which the result is stored. If not
+        given, a new array is allocated.
+
+    Returns
+    -------
+    Array
+        The DFT matrix of shape ``(Nx, Nu)``.
+    """
     return numexpr.evaluate('exp(1j * x * u)', {'x': x[:, np.newaxis], 'u': u[np.newaxis, :]}, out=out)
 
-def dft_matrix_unseparated_fallback(x, u):
+def _dft_matrix_separated_fallback(x, u):
+    """Compute a DFT matrix for arbitrary grids, using any Array API namespace.
+
+    This is a fallback implementation of :func:`dft_matrix_separated` for
+    non-NumPy backends. The matrix is evaluated directly as
+    ``exp(1j * x[i] * u[k])``.
+
+    Parameters
+    ----------
+    x : Array
+        The first grid, of shape ``(Nx,)``.
+    u : Array
+        The second grid, of shape ``(Nu,)``.
+
+    Returns
+    -------
+    Array
+        The DFT matrix of shape ``(Nx, Nu)``.
+    """
     xp = array_namespace(x, u)
 
     return xp.exp(1j * x[:, xp.newaxis] * u[xp.newaxis, :])
 
-def dft_matrix_unseparated(x, u, conjugate=False, transpose=False, out=None):
+def dft_matrix_separated(x, u, conjugate=False, transpose=False, out=None):
+    """Compute a DFT matrix for arbitrary grids.
+
+    The DFT matrix is defined as ``out[i, k] = exp(1j * u[k] * x[i])`` for
+    arbitrary (not necessarily equally spaced) grids `x` and `u`. On the
+    NumPy backend the matrix is computed with the numexpr implementation
+    :func:`_dft_matrix_separated_numpy`; on other backends it is computed
+    directly with :func:`_dft_matrix_separated_fallback`.
+
+    Parameters
+    ----------
+    x : Array
+        The first grid, of shape ``(Nx,)``.
+    u : Array
+        The second grid, of shape ``(Nu,)``.
+    conjugate : bool
+        If True, return the complex conjugate of the matrix.
+    transpose : bool
+        If True, return the transpose of the matrix. The output matrix then
+        has shape ``(Nu, Nx)``.
+    out : Array, optional
+        An array of the right shape in which the result is stored. Only
+        used on the NumPy backend; if not given, a new array is allocated.
+
+    Returns
+    -------
+    Array
+        The DFT matrix of shape ``(Nx, Nu)`` (or ``(Nu, Nx)`` if `transpose`
+        is True).
+    """
     if conjugate:
         x = -x
 
@@ -72,6 +254,6 @@ def dft_matrix_unseparated(x, u, conjugate=False, transpose=False, out=None):
         x, u = u, x
 
     if is_numpy_array(x):
-        return dft_matrix_unseparated_numba(x, u, out=out)
+        return _dft_matrix_separated_numpy(x, u, out=out)
     else:
-        return dft_matrix_unseparated_fallback(x, u)
+        return _dft_matrix_separated_fallback(x, u)

--- a/hcipy/_math/fourier.py
+++ b/hcipy/_math/fourier.py
@@ -67,7 +67,7 @@ def _dft_matrix_regular_numpy(x0, u0, dx, du, Nx, Nu, dtype, out=None):
 
     for i in numba.prange(Nx):
         ai = C * A[i]
-        Ti = T[i : i + Nu]
+        Ti = T[i:i + Nu]
 
         for k in range(Nu):
             out[i, k] = ai * B[k] * Ti[k]

--- a/hcipy/_math/fourier.py
+++ b/hcipy/_math/fourier.py
@@ -105,7 +105,7 @@ def _dft_matrix_regular_fallback(x0, u0, dx, du, Nx, Nu, xp, dtype):
     Returns
     -------
     Array
-        The DFT matrix of shape ``(Nx, Nu)``.
+        The DFT matrix of shape ``(Nx, Nu)`` and dtype ``dtype``.
     """
     float_dtype = xp.float32 if dtype == xp.complex64 else xp.float64
 
@@ -192,7 +192,10 @@ def _dft_matrix_separated_numpy(x, u, out=None):
     Array
         The DFT matrix of shape ``(Nx, Nu)``.
     """
-    return numexpr.evaluate('exp(1j * x * u)', {'x': x[:, np.newaxis], 'u': u[np.newaxis, :]}, out=out)
+    complex_dtype = np.complex64 if x.dtype == np.float32 else np.complex128
+
+    res = numexpr.evaluate('exp(1j * x * u)', {'x': x[:, np.newaxis], 'u': u[np.newaxis, :]}, out=out)
+    return res.astype(complex_dtype, copy=False)
 
 def _dft_matrix_separated_fallback(x, u):
     """Compute a DFT matrix for arbitrary grids, using any Array API namespace.

--- a/hcipy/fourier/matrix_fourier_transform.py
+++ b/hcipy/fourier/matrix_fourier_transform.py
@@ -3,7 +3,7 @@ from scipy.linalg import blas
 from .fourier_transform import FourierTransform, ComputationalComplexity, multiplex_for_tensor_fields, _get_float_and_complex_dtype
 from ..field import Field
 from ..config import Configuration
-import numexpr as ne
+from .._math.fourier import dft_matrix_regular, dft_matrix_separated
 
 class MatrixFourierTransform(FourierTransform):
     '''A Matrix Fourier Transform (MFT) object.
@@ -89,17 +89,31 @@ class MatrixFourierTransform(FourierTransform):
                 self.weights_output = self.weights_output[0]
 
             if self.ndim == 1:
-                xu = np.outer(self.output_grid.x, self.input_grid.x)
-                self.M = ne.evaluate('exp(-1j * xu)', local_dict={'xu': xu}).astype(complex_dtype, copy=False)
+                if self.input_grid.is_regular and self.output_grid.is_regular:
+                    self.M = dft_matrix_regular(
+                        self.output_grid.zero[0], self.input_grid.zero[0],
+                        self.output_grid.delta[0], self.input_grid.delta[0],
+                        self.output_grid.size, self.input_grid.size,
+                        np, np.dtype(complex_dtype), conjugate=True)
+                else:
+                    self.M = dft_matrix_separated(self.output_grid.x, self.input_grid.x, conjugate=True).astype(complex_dtype, copy=False)
             elif self.ndim == 2:
-                x, y = self.input_grid.coords.separated_coords
-                u, v = self.output_grid.coords.separated_coords
+                if self.input_grid.is_regular and self.output_grid.is_regular:
+                    delta_in, dims_in, zero_in = self.input_grid.regular_coords
+                    delta_out, dims_out, zero_out = self.output_grid.regular_coords
 
-                vy = np.outer(v, y)
-                xu = np.outer(x, u)
+                    self.M1 = dft_matrix_regular(
+                        zero_out[1], zero_in[1], delta_out[1], delta_in[1],
+                        dims_out[1], dims_in[1], np, np.dtype(complex_dtype), conjugate=True)
+                    self.M2 = dft_matrix_regular(
+                        zero_in[0], zero_out[0], delta_in[0], delta_out[0],
+                        dims_in[0], dims_out[0], np, np.dtype(complex_dtype), conjugate=True)
+                else:
+                    x, y = self.input_grid.coords.separated_coords
+                    u, v = self.output_grid.coords.separated_coords
 
-                self.M1 = ne.evaluate('exp(-1j * vy)', local_dict={'vy': vy}).astype(complex_dtype, copy=False)
-                self.M2 = ne.evaluate('exp(-1j * xu)', local_dict={'xu': xu}).astype(complex_dtype, copy=False)
+                    self.M1 = dft_matrix_separated(v, y, conjugate=True).astype(complex_dtype, copy=False)
+                    self.M2 = dft_matrix_separated(x, u, conjugate=True).astype(complex_dtype, copy=False)
 
             self.matrices_dtype = complex_dtype
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "tqdm",
     "threadpoolctl",
     "array_api_compat",
+    "numba",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "packaging",
     "tqdm",
     "array_api_compat",
+    "numba",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,10 @@ def get_backend(backend_name):
             pytest.skip(f'{backend_name} not available')
     elif backend_name == 'jax':
         try:
+            # Enable 64-bit mode for tests.
+            import jax
+            jax.config.update('jax_enable_x64', True)
+
             import jax.numpy as jnp
             return jnp
         except ImportError:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -553,10 +553,12 @@ def test_dft_matrix_regular(xp, Nx, Nu, dtype, conjugate, transpose):
 @pytest.mark.parametrize('transpose', [False, True])
 def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
     x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
-    dtype = getattr(xp, dtype)
 
-    x = xp.asarray(np.arange(Nx, dtype=np.float64) * dx + x0, dtype=dtype)
-    u = xp.asarray(np.arange(Nu, dtype=np.float64) * du + u0, dtype=dtype)
+    dtype = getattr(xp, dtype)
+    float_dtype = xp.float32 if dtype == xp.complex64 else xp.float64
+
+    x = xp.arange(Nx, dtype=float_dtype) * dx + x0
+    u = xp.arange(Nu, dtype=float_dtype) * du + u0
 
     ref = _dft_matrix_naive(x0, u0, dx, du, Nx, Nu)
     if conjugate:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -342,10 +342,12 @@ def test_dft_matrix_regular(xp, Nx, Nu, dtype, conjugate, transpose):
 @pytest.mark.parametrize('transpose', [False, True])
 def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
     x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
-    dtype = getattr(xp, dtype)
 
-    x = xp.asarray(np.arange(Nx, dtype=np.float64) * dx + x0, dtype=dtype)
-    u = xp.asarray(np.arange(Nu, dtype=np.float64) * du + u0, dtype=dtype)
+    dtype = getattr(xp, dtype)
+    float_dtype = xp.float32 if dtype == xp.complex64 else xp.float64
+
+    x = xp.arange(Nx, dtype=float_dtype) * dx + x0
+    u = xp.arange(Nu, dtype=float_dtype) * du + u0
 
     ref = _dft_matrix_naive(x0, u0, dx, du, Nx, Nu)
     if conjugate:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -332,11 +332,12 @@ def test_dft_matrix_regular(xp, Nx, Nu, dtype, conjugate, transpose):
 
     atol = 1e-12 if dtype == xp.complex128 else 1e-6
 
+    assert result.dtype == dtype
     assert result_np.shape == ref.shape
     assert np.allclose(result_np, ref, atol=atol)
 
 @pytest.mark.parametrize('Nx, Nu', [(3, 4), (16, 8), (64, 64)])
-@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+@pytest.mark.parametrize('dtype', ['complex64', 'complex128'])
 @pytest.mark.parametrize('conjugate', [False, True])
 @pytest.mark.parametrize('transpose', [False, True])
 def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
@@ -357,6 +358,7 @@ def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
 
     atol = 1e-12 if dtype == xp.complex128 else 1e-6
 
+    assert result.dtype == dtype
     assert result_np.shape == ref.shape
     assert np.allclose(result_np, ref, atol=atol)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -543,11 +543,12 @@ def test_dft_matrix_regular(xp, Nx, Nu, dtype, conjugate, transpose):
 
     atol = 1e-12 if dtype == xp.complex128 else 1e-6
 
+    assert result.dtype == dtype
     assert result_np.shape == ref.shape
     assert np.allclose(result_np, ref, atol=atol)
 
 @pytest.mark.parametrize('Nx, Nu', [(3, 4), (16, 8), (64, 64)])
-@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+@pytest.mark.parametrize('dtype', ['complex64', 'complex128'])
 @pytest.mark.parametrize('conjugate', [False, True])
 @pytest.mark.parametrize('transpose', [False, True])
 def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
@@ -568,6 +569,7 @@ def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
 
     atol = 1e-12 if dtype == xp.complex128 else 1e-6
 
+    assert result.dtype == dtype
     assert result_np.shape == ref.shape
     assert np.allclose(result_np, ref, atol=atol)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,9 +1,10 @@
 import pytest
 import hcipy
 import numpy as np
+from hcipy._math.backends import to_numpy, array_namespace
+from hcipy._math.fourier import dft_matrix_regular, dft_matrix_separated
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
-from hcipy._math.backends import to_numpy, array_namespace
 from hcipy._math.subpixel_shift import separable_convolve, subpixel_shift, _row_pass, _col_pass
 from hcipy._math import cpu
 import io
@@ -515,3 +516,78 @@ def test_cpu_count_functions(func):
 
 def test_get_num_available_cores():
     assert cpu.get_num_available_cores() >= 1
+
+def _dft_matrix_naive(x0, u0, dx, du, Nx, Nu):
+    """Naive NumPy reference for the DFT matrix exp(1j * u[k] * x[i])."""
+    x = np.arange(Nx, dtype=np.float64) * dx + x0
+    u = np.arange(Nu, dtype=np.float64) * du + u0
+    return np.exp(1j * x[:, None] * u[None, :])
+
+
+@pytest.mark.parametrize('Nx, Nu', [(3, 4), (16, 8), (64, 64)])
+@pytest.mark.parametrize('dtype', ['complex64', 'complex128'])
+@pytest.mark.parametrize('conjugate', [False, True])
+@pytest.mark.parametrize('transpose', [False, True])
+def test_dft_matrix_regular(xp, Nx, Nu, dtype, conjugate, transpose):
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    dtype = getattr(xp, dtype)
+
+    ref = _dft_matrix_naive(x0, u0, dx, du, Nx, Nu)
+    if conjugate:
+        ref = np.conj(ref)
+    if transpose:
+        ref = ref.T
+
+    result = dft_matrix_regular(x0, u0, dx, du, Nx, Nu, xp, dtype, conjugate=conjugate, transpose=transpose)
+    result_np = np.asarray(result)
+
+    atol = 1e-12 if dtype == xp.complex128 else 1e-6
+
+    assert result_np.shape == ref.shape
+    assert np.allclose(result_np, ref, atol=atol)
+
+@pytest.mark.parametrize('Nx, Nu', [(3, 4), (16, 8), (64, 64)])
+@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+@pytest.mark.parametrize('conjugate', [False, True])
+@pytest.mark.parametrize('transpose', [False, True])
+def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    dtype = getattr(xp, dtype)
+
+    x = xp.asarray(np.arange(Nx, dtype=np.float64) * dx + x0, dtype=dtype)
+    u = xp.asarray(np.arange(Nu, dtype=np.float64) * du + u0, dtype=dtype)
+
+    ref = _dft_matrix_naive(x0, u0, dx, du, Nx, Nu)
+    if conjugate:
+        ref = np.conj(ref)
+    if transpose:
+        ref = ref.T
+
+    result = dft_matrix_separated(x, u, conjugate=conjugate, transpose=transpose)
+    result_np = np.asarray(result)
+
+    atol = 1e-12 if dtype == xp.complex128 else 1e-6
+
+    assert result_np.shape == ref.shape
+    assert np.allclose(result_np, ref, atol=atol)
+
+def test_dft_matrix_regular_out():
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    Nx, Nu = 16, 8
+    out = np.empty((Nx, Nu), dtype=np.complex128)
+
+    result = dft_matrix_regular(x0, u0, dx, du, Nx, Nu, np, np.complex128, out=out)
+
+    assert result is out
+
+def test_dft_matrix_separated_out():
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    Nx, Nu = 16, 8
+
+    x = np.asarray(np.arange(Nx, dtype=np.float64) * dx + x0)
+    u = np.asarray(np.arange(Nu, dtype=np.float64) * du + u0)
+    out = np.empty((Nx, Nu), dtype=np.complex128)
+
+    result = dft_matrix_separated(x, u, out=out)
+
+    assert result is out

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,6 +4,7 @@ import numpy as np
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
+from hcipy._math.fourier import dft_matrix_regular, dft_matrix_separated
 import math
 
 
@@ -303,3 +304,79 @@ def test_to_numpy(xp):
 def test_array_namespace(xp):
     arr = xp.zeros(10)
     _ = array_namespace(arr)
+
+
+def _dft_matrix_naive(x0, u0, dx, du, Nx, Nu):
+    """Naive NumPy reference for the DFT matrix exp(1j * u[k] * x[i])."""
+    x = np.arange(Nx, dtype=np.float64) * dx + x0
+    u = np.arange(Nu, dtype=np.float64) * du + u0
+    return np.exp(1j * x[:, None] * u[None, :])
+
+
+@pytest.mark.parametrize('Nx, Nu', [(3, 4), (16, 8), (64, 64)])
+@pytest.mark.parametrize('dtype', ['complex64', 'complex128'])
+@pytest.mark.parametrize('conjugate', [False, True])
+@pytest.mark.parametrize('transpose', [False, True])
+def test_dft_matrix_regular(xp, Nx, Nu, dtype, conjugate, transpose):
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    dtype = getattr(xp, dtype)
+
+    ref = _dft_matrix_naive(x0, u0, dx, du, Nx, Nu)
+    if conjugate:
+        ref = np.conj(ref)
+    if transpose:
+        ref = ref.T
+
+    result = dft_matrix_regular(x0, u0, dx, du, Nx, Nu, xp, dtype, conjugate=conjugate, transpose=transpose)
+    result_np = np.asarray(result)
+
+    atol = 1e-12 if dtype == xp.complex128 else 1e-6
+
+    assert result_np.shape == ref.shape
+    assert np.allclose(result_np, ref, atol=atol)
+
+@pytest.mark.parametrize('Nx, Nu', [(3, 4), (16, 8), (64, 64)])
+@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+@pytest.mark.parametrize('conjugate', [False, True])
+@pytest.mark.parametrize('transpose', [False, True])
+def test_dft_matrix_separated(xp, Nx, Nu, dtype, conjugate, transpose):
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    dtype = getattr(xp, dtype)
+
+    x = xp.asarray(np.arange(Nx, dtype=np.float64) * dx + x0, dtype=dtype)
+    u = xp.asarray(np.arange(Nu, dtype=np.float64) * du + u0, dtype=dtype)
+
+    ref = _dft_matrix_naive(x0, u0, dx, du, Nx, Nu)
+    if conjugate:
+        ref = np.conj(ref)
+    if transpose:
+        ref = ref.T
+
+    result = dft_matrix_separated(x, u, conjugate=conjugate, transpose=transpose)
+    result_np = np.asarray(result)
+
+    atol = 1e-12 if dtype == xp.complex128 else 1e-6
+
+    assert result_np.shape == ref.shape
+    assert np.allclose(result_np, ref, atol=atol)
+
+def test_dft_matrix_regular_out():
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    Nx, Nu = 16, 8
+    out = np.empty((Nx, Nu), dtype=np.complex128)
+
+    result = dft_matrix_regular(x0, u0, dx, du, Nx, Nu, np, np.complex128, out=out)
+
+    assert result is out
+
+def test_dft_matrix_separated_out():
+    x0, u0, dx, du = -0.3, 1.7, 0.2, -0.05
+    Nx, Nu = 16, 8
+
+    x = np.asarray(np.arange(Nx, dtype=np.float64) * dx + x0)
+    u = np.asarray(np.arange(Nu, dtype=np.float64) * du + u0)
+    out = np.empty((Nx, Nu), dtype=np.complex128)
+
+    result = dft_matrix_separated(x, u, out=out)
+
+    assert result is out


### PR DESCRIPTION
## Fast DFT matrix computation

This PR adds a fast, Array-API-compatible way to compute DFT matrices — the matrices `V[i,k] = exp(1j * u[k] * x[i])` used by `MatrixFourierTransform` — and switches the MFT over to it.

### New module: `hcipy/_math/fourier.py`

Two public functions, each with a NumPy fast path and an Array API fallback:

- **`dft_matrix_regular`** — for equally spaced grids (given  `x0, dx, u0, du, Nx, Nu`). The NumPy backend uses a numba parallel implementation that factorizes the matrix as `C * A[i] * B[k] * T[i+k]`, reducing complex exponentials from `O(Nx * Nu)` to `O(Nx + Nu)`; the rest are cheap complex multiplications. The other backends use the Array API.
- **`dft_matrix_separated`** — for arbitrary (separated) grids (given coordinate arrays `x`, `u`). The NumPy backend evaluates `exp(1j * x * u)` with numexpr; other backends use the Array API.

Both support `conjugate`, `transpose` and `out=`, and respect the input/requested dtype (float32 → complex64, float64 → complex128).

### `MatrixFourierTransform` uses the new functions

The matrix computation in `_compute_matrices` no longer builds `outer` products inline. Regular input/output grids now take the numba path; non-regular separated grids fall back to the numexpr-based `dft_matrix_separated` (identical behavior to before).

### Tests

- New `dft_matrix_*` tests in `tests/test_math.py` comparing against a naive NumPy implementation to numerical precision, parametrized by the `xp` fixture, including `conjugate`/`transpose` combinations, `out=` behavior, and output dtype checks.
- `tests/conftest.py` enables JAX 64-bit mode so dtype tests exercise the full precision range.

I used Deepseek V4 Pro and Flash to generate part of this PR.