### PR TITLE
Use PyPI trusted publishing for releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           path: dist/
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
 
   attach-to-release:
     name: Attach distribution to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install build
+        run: python -m pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hcipy
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  attach-to-release:
+    name: Attach distribution to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Attach distribution to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/doc/development/new_release.rst
+++ b/doc/development/new_release.rst
@@ -16,7 +16,7 @@ This page is intended for the maintainer of HCIPy, and contains step-by-step ins
 
         pytest ./tests --runslow
 
-    Also make sure that the latest CI for the master branch on `Azure Pipelines <https://dev.azure.com/ehpor/hcipy/_build?definitionId=1>`__ is passing. Build the documentation and check if it is building without errors or problematic warnings.
+    Also make sure that the latest CI for the master branch is passing. Build the documentation and check if it is building without errors or problematic warnings.
 
     .. code-block:: shell
 
@@ -27,9 +27,7 @@ This page is intended for the maintainer of HCIPy, and contains step-by-step ins
 
 2. Write release notes mimicking other release notes. Add those release notes to the :doc:`changelog <../changelog>` in the documentation and commit these changes.
 
-3.  Add tag information on Github. You can do this by releasing a new version. Add the written release notes, mimicking previous release notes. After you've released the new version, a new tag will have been added on the Github repository.
-
-4.  Fetch the tags on your local git repository. Update the version information, and check that the version was changed:
+3.  Fetch the tags on your local git repository and update the version information:
 
     .. code-block:: shell
 
@@ -37,7 +35,7 @@ This page is intended for the maintainer of HCIPy, and contains step-by-step ins
         python setup.py egg_info
         python setup.py --version
 
-5.  Re-build the documentation:
+4.  Re-build the documentation:
 
     .. code-block:: shell
 
@@ -54,27 +52,23 @@ This page is intended for the maintainer of HCIPy, and contains step-by-step ins
 
     where ``0.5.1`` has been changed to the correct version number.
 
-6.  Build the source distribution and wheels:
+5.  Publish a new release on GitHub. Navigate to the repository's Releases page, click "Draft a new release", select the appropriate tag (or create a new one, e.g. ``v0.5.1``), add the release notes, and click "Publish release".
 
-    .. code-block:: shell
+    Upon publishing the release, a GitHub Actions workflow will automatically:
 
-        python3 -m build
+    - Build the source distribution and wheels.
+    - Publish the distribution to PyPI using `Trusted Publishing <https://docs.pypi.org/trusted-publishers/>`__.
+    - Attach the built distribution files to the GitHub Release.
 
-    Then submit to PyPI:
+    No manual upload to PyPI is required.
 
-    .. code-block:: shell
-
-        python -m twine upload dist/*
-
-    Enter username and password, and everything will be uploaded. Then add the source distribution and wheel to the Github release as assets.
-
-7.  Update all links on the website (*www/index.html*, *www/news.html* and *docs/stable/index.html*) and add release to list of releases. Upload website to AWS S3:
+6.  Update all links on the website (*www/index.html*, *www/news.html* and *docs/stable/index.html*) and add release to list of releases. Upload website to AWS S3:
 
     .. code-block:: shell
 
         aws s3 sync --acl public-read --delete --cache-control max-age=604800,public www s3://hcipy.org
         aws s3 sync --acl public-read --cache-control max-age=604800,public docs s3://docs.hcipy.org
 
-8.  Purge the `CloudFlare <https://cloudflare.com>`__ cache for `hcipy.org <https://hcipy.org>`__. This step is not necessary. Without it the website will update in at maximum seven days, due to caching of the old website by CloudFlare.
+7.  Purge the `CloudFlare <https://cloudflare.com>`__ cache for `hcipy.org <https://hcipy.org>`__. This step is not necessary. Without it the website will update in at maximum seven days, due to caching of the old website by CloudFlare.
 
-9.  Update this document with any issues, problems or peculiarities that you encountered for later reference.
+8.  Update this document with any issues, problems or peculiarities that you encountered for later reference.


### PR DESCRIPTION
## Summary

Pin `pypa/gh-action-pypi-publish` to a specific commit SHA instead of the floating `release/v1` tag in `.github/workflows/release.yml`.

The release workflow relies on trusted publishing (OpenID Connect): it requests `id-token: write` and publishes to PyPI with no stored API token or password. With trusted publishing, PyPI verifies the token-exchange request comes from this repository's GitHub Actions environment, so no secrets are involved in the workflow at all.

## Why pin to a SHA

Referencing `release/v1` is mutable — the tag can be moved to point at a new commit. If the action repository is ever compromised (or a new release introduces a supply-chain risk), a build on our side could silently execute the changed code with permissions to publish a release to PyPI, all without any token in place to protect us. Pinning to an exact commit hash ensures the exact code we reviewed runs, and `dependabot.yml` is configured to open PRs when upstream releases new versions so we can review and update deliberately.

## For review

This depends on @ehpor setting up trusted publishing on PyPI, which relies on me getting access to my account. See pypi/support/issues/11130.