### PR TITLE
Add Array API einsum.

### DIFF
--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -92,8 +92,12 @@ def einsum(subscripts, *operands, optimize=True):
     xp = array_namespace(*operands)
 
     # Dispatch to the einsum of the backend, if it has one.
-    if is_numpy_namespace(xp) or is_cupy_namespace(xp) or is_jax_namespace(xp) or is_torch_namespace(xp):
+    if is_numpy_namespace(xp) or is_cupy_namespace(xp) or is_jax_namespace(xp):
         return xp.einsum(subscripts, *operands, optimize=optimize)
+
+    if is_torch_namespace(xp):
+        # Pytorch doesn't support the optimize keyword.
+        return xp.einsum(subscripts, *operands)
 
     in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
     subs = list(in_subs)

--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -31,7 +31,7 @@ def _diagonal(tensor, ax0, ax1, xp):
     # array API fallback: move the two axes to the end, then mask with eye
     axes = [i for i in range(tensor.ndim) if i not in (ax0, ax1)] + [ax0, ax1]
     tensor = xp.permute_dims(tensor, axes)
-    return xp.sum(tensor * xp.eye(tensor.shape[-1]), axis=-1)
+    return xp.sum(tensor * xp.eye(tensor.shape[-1], dtype=tensor.dtype), axis=-1)
 
 
 def _prep_operand(sub, tensor, keep, xp):

--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -1,4 +1,5 @@
 import math
+import string
 from collections import Counter
 
 from .backends import array_namespace
@@ -21,7 +22,10 @@ def _parse_subscripts(subscripts, noperands):
         counts = Counter(in_part.replace(",", ""))
         out_part = "".join(sorted(c for c in counts if counts[c] == 1))
 
-    return in_subs, out_part
+        if "..." in in_part:
+            out_part = "..." + out_part
+
+    return list(in_subs), out_part
 
 
 def _diagonal(tensor, ax0, ax1, xp):
@@ -88,6 +92,36 @@ def pairwise_einsum(l_sub, left, r_sub, right, needed, xp):
     return "".join(result_sub), result
 
 
+def _expand_ellipsis(subs, tensors, out_sub):
+    if not any("..." in s for s in subs) and "..." not in out_sub:
+        return subs, out_sub
+
+    ranks = []
+    for s, t in zip(subs, tensors):
+        if "..." in s:
+            n = t.ndim - (len(s) - 3)
+            if n < 0:
+                raise ValueError("operand has fewer dimensions than its subscripts")
+            ranks.append(n)
+        else:
+            ranks.append(None)
+
+    rank = max((n for n in ranks if n is not None), default=0)
+    letters = "".join(c for c in string.ascii_uppercase if c not in "".join(subs))[:rank]
+    if len(letters) < rank:
+        raise ValueError("not enough unused index letters for ellipsis")
+
+    for k, (s, n) in enumerate(zip(subs, ranks)):
+        if n is None:
+            continue
+        subs[k] = s.replace("...", letters[-n:] if n else "", 1)
+
+    if "..." in out_sub:
+        out_sub = out_sub.replace("...", letters, 1)
+
+    return subs, out_sub
+
+
 def einsum(subscripts, *operands, optimize=True):
     xp = array_namespace(*operands)
 
@@ -95,13 +129,17 @@ def einsum(subscripts, *operands, optimize=True):
     if is_numpy_namespace(xp) or is_cupy_namespace(xp) or is_jax_namespace(xp):
         return xp.einsum(subscripts, *operands, optimize=optimize)
 
+    in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
+    tensors = [xp.asarray(t) for t in operands]
+
+    in_subs, out_sub = _expand_ellipsis(in_subs, tensors, out_sub)
+    subscripts = ','.join(in_subs) + '->' + out_sub
+
     if is_torch_namespace(xp):
         # Pytorch doesn't support the optimize keyword.
+        # Pytorch also has a different way of handling ellipses, so
+        # calling torch.einsum() after expanding the ellipses.
         return xp.einsum(subscripts, *operands)
-
-    in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
-    subs = list(in_subs)
-    tensors = [xp.asarray(t) for t in operands]
 
     if optimize:
         import opt_einsum as oe
@@ -117,12 +155,12 @@ def einsum(subscripts, *operands, optimize=True):
             raise ValueError(f"path step {tuple(step)} pops more than 2 "
                              "operands; only 1- and 2-operand steps are "
                              "supported")
-        popped_subs = [subs.pop(i) for i in step]
+        popped_subs = [in_subs.pop(i) for i in step]
         popped_tensors = [tensors.pop(i) for i in step]
 
         # "needed" = final output letters + every letter still alive in any
         # tensor we haven't reached yet in the path
-        needed = set(out_sub) | set("".join(subs))
+        needed = set(out_sub) | set("".join(in_subs))
 
         if len(popped_tensors) == 1:
             new_sub, new_tensor = _prep_operand(popped_subs[0], popped_tensors[0], needed, xp)
@@ -132,10 +170,10 @@ def einsum(subscripts, *operands, optimize=True):
                 popped_subs[1], popped_tensors[1], needed, xp
             )
 
-        subs.append(new_sub)
+        in_subs.append(new_sub)
         tensors.append(new_tensor)
 
-    final_sub, final_tensor = subs[0], tensors[0]
+    final_sub, final_tensor = in_subs[0], tensors[0]
     final_sub, final_tensor = _prep_operand(final_sub, final_tensor, set(out_sub), xp)
 
     perm = tuple(final_sub.index(c) for c in out_sub)

--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -76,12 +76,15 @@ def pairwise_einsum(l_sub, left, r_sub, right, needed):
     return "".join(result_sub), result
 
 
-def einsum(subscripts, *operands, path=None):
+def einsum(subscripts, *operands, optimize=False):
     in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
     subs = list(in_subs)
     tensors = [np.asarray(t) for t in operands]
 
-    if path is None:
+    if optimize:
+        import opt_einsum as oe
+        path, _ = oe.contract_path(subscripts, *tensors)
+    else:
         path = [(0, 1)] * (len(tensors) - 1)
 
     for step in path:

--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -2,6 +2,7 @@ import math
 from collections import Counter
 
 from .backends import array_namespace
+from array_api_compat import is_numpy_namespace, is_cupy_namespace, is_jax_namespace, is_torch_namespace
 
 
 def _parse_subscripts(subscripts, noperands):
@@ -87,8 +88,12 @@ def pairwise_einsum(l_sub, left, r_sub, right, needed, xp):
     return "".join(result_sub), result
 
 
-def einsum(subscripts, *operands, optimize=False):
+def einsum(subscripts, *operands, optimize=True):
     xp = array_namespace(*operands)
+
+    # Dispatch to the einsum of the backend, if it has one.
+    if is_numpy_namespace(xp) or is_cupy_namespace(xp) or is_jax_namespace(xp) or is_torch_namespace(xp):
+        return xp.einsum(subscripts, *operands, optimize=optimize)
 
     in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
     subs = list(in_subs)

--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -1,6 +1,7 @@
 import math
 from collections import Counter
-import numpy as np
+
+from .backends import array_namespace
 
 
 def _parse_subscripts(subscripts, noperands):
@@ -22,7 +23,17 @@ def _parse_subscripts(subscripts, noperands):
     return in_subs, out_part
 
 
-def _prep_operand(sub, tensor, keep):
+def _diagonal(tensor, ax0, ax1, xp):
+    diag = getattr(xp, "diagonal", None)
+    if diag is not None:
+        return diag(tensor, 0, ax0, ax1)
+    # array API fallback: move the two axes to the end, then mask with eye
+    axes = [i for i in range(tensor.ndim) if i not in (ax0, ax1)] + [ax0, ax1]
+    tensor = xp.permute_dims(tensor, axes)
+    return xp.sum(tensor * xp.eye(tensor.shape[-1]), axis=-1)
+
+
+def _prep_operand(sub, tensor, keep, xp):
     sub = list(sub)
     while True:
         seen = {}
@@ -36,20 +47,20 @@ def _prep_operand(sub, tensor, keep):
             break
         ax0, ax1 = pair
         c = sub[ax0]
-        tensor = np.diagonal(tensor, axis1=ax0, axis2=ax1)
+        tensor = _diagonal(tensor, ax0, ax1, xp)
         sub = [s for k, s in enumerate(sub) if k not in (ax0, ax1)] + [c]
     sub = "".join(sub)
 
     drop_axes = tuple(i for i, c in enumerate(sub) if c not in keep)
     if drop_axes:
-        tensor = tensor.sum(axis=drop_axes)
+        tensor = xp.sum(tensor, axis=drop_axes)
         sub = "".join(c for c in sub if c in keep)
     return sub, tensor
 
 
-def pairwise_einsum(l_sub, left, r_sub, right, needed):
-    l_sub, left = _prep_operand(l_sub, left, set(r_sub) | needed)
-    r_sub, right = _prep_operand(r_sub, right, set(l_sub) | needed)
+def pairwise_einsum(l_sub, left, r_sub, right, needed, xp):
+    l_sub, left = _prep_operand(l_sub, left, set(r_sub) | needed, xp)
+    r_sub, right = _prep_operand(r_sub, right, set(l_sub) | needed, xp)
 
     dims = dict(zip(l_sub + r_sub, left.shape + right.shape))
 
@@ -58,28 +69,30 @@ def pairwise_einsum(l_sub, left, r_sub, right, needed):
     M = [c for c in l_sub if c not in r_sub]                  # free, left-only
     N = [c for c in r_sub if c not in l_sub]                  # free, right-only
 
-    Lp = np.transpose(left,  [l_sub.index(c) for c in B + M + K])
-    Rp = np.transpose(right, [r_sub.index(c) for c in B + K + N])
+    Lp = xp.permute_dims(left, tuple(l_sub.index(c) for c in B + M + K))
+    Rp = xp.permute_dims(right, tuple(r_sub.index(c) for c in B + K + N))
 
-    Lp = np.reshape(Lp, (math.prod(dims[c] for c in B), math.prod(dims[c] for c in M),
+    Lp = xp.reshape(Lp, (math.prod(dims[c] for c in B), math.prod(dims[c] for c in M),
                          math.prod(dims[c] for c in K)))
-    Rp = np.reshape(Rp, (math.prod(dims[c] for c in B), math.prod(dims[c] for c in K),
+    Rp = xp.reshape(Rp, (math.prod(dims[c] for c in B), math.prod(dims[c] for c in K),
                          math.prod(dims[c] for c in N)))
 
     if not K:
         result = Lp * Rp
     else:
-        result = np.matmul(Lp, Rp)
+        result = xp.matmul(Lp, Rp)
 
     result_sub = B + M + N
-    result = np.reshape(result, tuple(dims[c] for c in result_sub))
+    result = xp.reshape(result, tuple(dims[c] for c in result_sub))
     return "".join(result_sub), result
 
 
 def einsum(subscripts, *operands, optimize=False):
+    xp = array_namespace(*operands)
+
     in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
     subs = list(in_subs)
-    tensors = [np.asarray(t) for t in operands]
+    tensors = [xp.asarray(t) for t in operands]
 
     if optimize:
         import opt_einsum as oe
@@ -103,20 +116,18 @@ def einsum(subscripts, *operands, optimize=False):
         needed = set(out_sub) | set("".join(subs))
 
         if len(popped_tensors) == 1:
-            new_sub, new_tensor = _prep_operand(
-                popped_subs[0], popped_tensors[0], needed
-            )
+            new_sub, new_tensor = _prep_operand(popped_subs[0], popped_tensors[0], needed, xp)
         else:
             new_sub, new_tensor = pairwise_einsum(
                 popped_subs[0], popped_tensors[0],
-                popped_subs[1], popped_tensors[1], needed
+                popped_subs[1], popped_tensors[1], needed, xp
             )
 
         subs.append(new_sub)
         tensors.append(new_tensor)
 
     final_sub, final_tensor = subs[0], tensors[0]
-    final_sub, final_tensor = _prep_operand(final_sub, final_tensor, set(out_sub))
+    final_sub, final_tensor = _prep_operand(final_sub, final_tensor, set(out_sub), xp)
 
-    perm = [final_sub.index(c) for c in out_sub]
-    return np.transpose(final_tensor, perm)
+    perm = tuple(final_sub.index(c) for c in out_sub)
+    return xp.permute_dims(final_tensor, perm)

--- a/hcipy/_math/einsum.py
+++ b/hcipy/_math/einsum.py
@@ -1,0 +1,119 @@
+import math
+from collections import Counter
+import numpy as np
+
+
+def _parse_subscripts(subscripts, noperands):
+    subscripts = subscripts.replace(" ", "")
+    if "->" in subscripts:
+        in_part, out_part = subscripts.split("->")
+    else:
+        in_part, out_part = subscripts, None
+
+    in_subs = in_part.split(",")
+    if len(in_subs) != noperands:
+        raise ValueError(f"got {noperands} operands but {len(in_subs)} subscripts")
+
+    if out_part is None:
+        # implicit output: every letter that appears exactly once, alphabetical
+        counts = Counter(in_part.replace(",", ""))
+        out_part = "".join(sorted(c for c in counts if counts[c] == 1))
+
+    return in_subs, out_part
+
+
+def _prep_operand(sub, tensor, keep):
+    sub = list(sub)
+    while True:
+        seen = {}
+        pair = None
+        for axis, c in enumerate(sub):
+            if c in seen:
+                pair = (seen[c], axis)
+                break
+            seen[c] = axis
+        if pair is None:
+            break
+        ax0, ax1 = pair
+        c = sub[ax0]
+        tensor = np.diagonal(tensor, axis1=ax0, axis2=ax1)
+        sub = [s for k, s in enumerate(sub) if k not in (ax0, ax1)] + [c]
+    sub = "".join(sub)
+
+    drop_axes = tuple(i for i, c in enumerate(sub) if c not in keep)
+    if drop_axes:
+        tensor = tensor.sum(axis=drop_axes)
+        sub = "".join(c for c in sub if c in keep)
+    return sub, tensor
+
+
+def pairwise_einsum(l_sub, left, r_sub, right, needed):
+    l_sub, left = _prep_operand(l_sub, left, set(r_sub) | needed)
+    r_sub, right = _prep_operand(r_sub, right, set(l_sub) | needed)
+
+    dims = dict(zip(l_sub + r_sub, left.shape + right.shape))
+
+    B = [c for c in l_sub if c in r_sub and c in needed]      # batch
+    K = [c for c in l_sub if c in r_sub and c not in needed]  # contracted
+    M = [c for c in l_sub if c not in r_sub]                  # free, left-only
+    N = [c for c in r_sub if c not in l_sub]                  # free, right-only
+
+    Lp = np.transpose(left,  [l_sub.index(c) for c in B + M + K])
+    Rp = np.transpose(right, [r_sub.index(c) for c in B + K + N])
+
+    Lp = np.reshape(Lp, (math.prod(dims[c] for c in B), math.prod(dims[c] for c in M),
+                         math.prod(dims[c] for c in K)))
+    Rp = np.reshape(Rp, (math.prod(dims[c] for c in B), math.prod(dims[c] for c in K),
+                         math.prod(dims[c] for c in N)))
+
+    if not K:
+        result = Lp * Rp
+    else:
+        result = np.matmul(Lp, Rp)
+
+    result_sub = B + M + N
+    result = np.reshape(result, tuple(dims[c] for c in result_sub))
+    return "".join(result_sub), result
+
+
+def einsum(subscripts, *operands, path=None):
+    in_subs, out_sub = _parse_subscripts(subscripts, len(operands))
+    subs = list(in_subs)
+    tensors = [np.asarray(t) for t in operands]
+
+    if path is None:
+        path = [(0, 1)] * (len(tensors) - 1)
+
+    for step in path:
+        # pop high-to-low so positions don't shift; pairwise contraction is
+        # commutative, so the pop order within a step doesn't matter
+        step = sorted(step, reverse=True)
+        if len(step) > 2:
+            raise ValueError(f"path step {tuple(step)} pops more than 2 "
+                             "operands; only 1- and 2-operand steps are "
+                             "supported")
+        popped_subs = [subs.pop(i) for i in step]
+        popped_tensors = [tensors.pop(i) for i in step]
+
+        # "needed" = final output letters + every letter still alive in any
+        # tensor we haven't reached yet in the path
+        needed = set(out_sub) | set("".join(subs))
+
+        if len(popped_tensors) == 1:
+            new_sub, new_tensor = _prep_operand(
+                popped_subs[0], popped_tensors[0], needed
+            )
+        else:
+            new_sub, new_tensor = pairwise_einsum(
+                popped_subs[0], popped_tensors[0],
+                popped_subs[1], popped_tensors[1], needed
+            )
+
+        subs.append(new_sub)
+        tensors.append(new_tensor)
+
+    final_sub, final_tensor = subs[0], tensors[0]
+    final_sub, final_tensor = _prep_operand(final_sub, final_tensor, set(out_sub))
+
+    perm = [final_sub.index(c) for c in out_sub]
+    return np.transpose(final_tensor, perm)

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -98,7 +98,7 @@ def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
 
 def _normalize_size(size):
     if size is None:
-        return None
+        return ()
     elif not isinstance(size, tuple):
         return (size,)
     return size
@@ -307,7 +307,7 @@ class RandomGeneratorTorch(RandomGenerator):
     def normal(self, mean=0.0, std=1.0, *, size=None):
         size = _normalize_size(size)
 
-        if size is None or len(size) == 0:
+        if len(size) == 0:
             return self._xp.randn(1, generator=self._rng)[0] * std + mean
         else:
             return self._xp.randn(*size, generator=self._rng) * std + mean
@@ -315,7 +315,7 @@ class RandomGeneratorTorch(RandomGenerator):
     def poisson(self, lam=1.0, *, size=None):
         size = _normalize_size(size)
 
-        if size is None or len(size) == 0:
+        if len(size) == 0:
             lam_tensor = self._xp.ones(1) * lam
             return self._xp.poisson(lam_tensor, generator=self._rng)[0]
         else:
@@ -325,7 +325,7 @@ class RandomGeneratorTorch(RandomGenerator):
     def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
         size = _normalize_size(size)
 
-        if size is None or len(size) == 0:
+        if len(size) == 0:
             return _torch_gamma(scale, shape_param, size=(1,), generator=self._rng)[0]
         else:
             return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
@@ -333,7 +333,7 @@ class RandomGeneratorTorch(RandomGenerator):
     def uniform(self, low=0.0, high=1.0, *, size=None):
         size = _normalize_size(size)
 
-        if size is None or len(size) == 0:
+        if len(size) == 0:
             return self._xp.rand(1, generator=self._rng)[0] * (high - low) + low
         else:
             return self._xp.rand(*size, generator=self._rng) * (high - low) + low
@@ -341,7 +341,7 @@ class RandomGeneratorTorch(RandomGenerator):
     def exponential(self, scale=1.0, *, size=None):
         size = _normalize_size(size)
 
-        if size is None or len(size) == 0:
+        if len(size) == 0:
             return -scale * self._xp.log(self._xp.rand(1, generator=self._rng)[0])
         else:
             return -scale * self._xp.log(self._xp.rand(*size, generator=self._rng))
@@ -351,7 +351,7 @@ class RandomGeneratorTorch(RandomGenerator):
 
         size = _normalize_size(size)
 
-        if size is None or len(size) == 0:
+        if len(size) == 0:
             draw_size = (1,)
             scalar = True
         else:

--- a/hcipy/_math/random.py
+++ b/hcipy/_math/random.py
@@ -98,7 +98,7 @@ def _torch_gamma(scale=1.0, shape=1.0, size=None, generator=None):
 
 def _normalize_size(size):
     if size is None:
-        return (1,)
+        return None
     elif not isinstance(size, tuple):
         return (size,)
     return size
@@ -257,27 +257,27 @@ class RandomGeneratorNumpy(RandomGenerator):
 
     def normal(self, mean=0.0, std=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._rng.normal(mean, std, size)
+        return self._xp.asarray(self._rng.normal(mean, std, size))
 
     def poisson(self, lam=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._rng.poisson(lam, size)
+        return self._xp.asarray(self._rng.poisson(lam, size))
 
     def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._rng.gamma(shape_param, scale, size)
+        return self._xp.asarray(self._rng.gamma(shape_param, scale, size))
 
     def uniform(self, low=0.0, high=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._rng.uniform(low, high, size)
+        return self._xp.asarray(self._rng.uniform(low, high, size))
 
     def exponential(self, scale=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._rng.exponential(scale, size)
+        return self._xp.asarray(self._rng.exponential(scale, size))
 
     def choice(self, a, *, size=None, replace=True, p=None):
         size = _normalize_size(size)
-        return self._rng.choice(a, size, replace=replace, p=p)
+        return self._xp.asarray(self._rng.choice(a, size, replace=replace, p=p))
 
 
 class RandomGeneratorCupy(RandomGeneratorNumpy):
@@ -306,30 +306,59 @@ class RandomGeneratorTorch(RandomGenerator):
 
     def normal(self, mean=0.0, std=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._xp.randn(*size, generator=self._rng) * std + mean
+
+        if size is None or len(size) == 0:
+            return self._xp.randn(1, generator=self._rng)[0] * std + mean
+        else:
+            return self._xp.randn(*size, generator=self._rng) * std + mean
 
     def poisson(self, lam=1.0, *, size=None):
         size = _normalize_size(size)
-        lam_tensor = self._xp.ones(size=size) * lam
-        return self._xp.poisson(lam_tensor, generator=self._rng)
+
+        if size is None or len(size) == 0:
+            lam_tensor = self._xp.ones(1) * lam
+            return self._xp.poisson(lam_tensor, generator=self._rng)[0]
+        else:
+            lam_tensor = self._xp.ones(size=size) * lam
+            return self._xp.poisson(lam_tensor, generator=self._rng)
 
     def gamma(self, scale=1.0, shape_param=1.0, *, size=None):
         size = _normalize_size(size)
-        return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
+
+        if size is None or len(size) == 0:
+            return _torch_gamma(scale, shape_param, size=(1,), generator=self._rng)[0]
+        else:
+            return _torch_gamma(scale, shape_param, size=size, generator=self._rng)
 
     def uniform(self, low=0.0, high=1.0, *, size=None):
         size = _normalize_size(size)
-        return self._xp.rand(*size, generator=self._rng) * (high - low) + low
+
+        if size is None or len(size) == 0:
+            return self._xp.rand(1, generator=self._rng)[0] * (high - low) + low
+        else:
+            return self._xp.rand(*size, generator=self._rng) * (high - low) + low
 
     def exponential(self, scale=1.0, *, size=None):
         size = _normalize_size(size)
-        return -scale * self._xp.log(self._xp.rand(*size, generator=self._rng))
+
+        if size is None or len(size) == 0:
+            return -scale * self._xp.log(self._xp.rand(1, generator=self._rng)[0])
+        else:
+            return -scale * self._xp.log(self._xp.rand(*size, generator=self._rng))
 
     def choice(self, a, *, size=None, replace=True, p=None):
         import math as _math
 
         size = _normalize_size(size)
-        n = _math.prod(size)
+
+        if size is None or len(size) == 0:
+            draw_size = (1,)
+            scalar = True
+        else:
+            draw_size = size
+            scalar = False
+
+        n = _math.prod(draw_size)
 
         if isinstance(a, int):
             population = None
@@ -339,16 +368,22 @@ class RandomGeneratorTorch(RandomGenerator):
             n_pop = len(population)
 
         if p is None:
-            indices = self._xp.randint(0, n_pop, size, generator=self._rng)
+            indices = self._xp.randint(0, n_pop, draw_size, generator=self._rng)
         else:
             p_tensor = self._xp.asarray(p, dtype=self._xp.float64)
             p_tensor = p_tensor / p_tensor.sum()
             indices = self._xp.multinomial(p_tensor, n, replacement=replace, generator=self._rng)
-            indices = indices.reshape(size)
+            indices = indices.reshape(draw_size)
 
         if population is None:
-            return indices
-        return population[indices]
+            result = indices
+        else:
+            result = population[indices]
+
+        if scalar:
+            return result[0]
+        else:
+            return result
 
 
 class RandomGeneratorJax(RandomGenerator):

--- a/hcipy/field/__init__.py
+++ b/hcipy/field/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
     'field_inverse_truncated',
     'field_inverse_truncated_modal',
     'field_svd',
-    'make_field_operation',
     'field_conjugate_transpose',
     'field_transpose',
     'field_determinant',

--- a/hcipy/field/operations.py
+++ b/hcipy/field/operations.py
@@ -532,31 +532,3 @@ def field_kron(a, b):
     res = (aa[:, np.newaxis, :, np.newaxis, :] * bb[np.newaxis, :, np.newaxis, :, :]).reshape(output_shape)
 
     return Field(res, grid)
-
-def make_field_operation(op):
-    pass
-'''
-def make_field_operation(op):
-    def inner(*args, **kwargs):
-        # Determine which args are fields.
-        is_field = [hasattr(arg, 'grid') for arg in args]
-
-        if not np.any(is_field):
-            return op(*args, **kwargs)
-
-        # At least one argument has a field
-        grid_size = np.flatnonzero(is_field)[0]].grid.size
-
-        if len(args) == 1:
-            # Only one argument; use loop comprehension
-            res = np.array([op(args[0][...,i]) for i in range(grid_size)])
-
-            return Field(, args[0].grid)
-
-        # More than one argument operation.
-        res = []
-        for i in range(grid_size):
-            a = tuple([args[j][...,i] if is_field[j] else args[j] for j in len(args)])
-            res.append(op(*a, **kwargs))
-        return Field(res, )
-        '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "packaging",
     "tqdm",
     "array_api_compat",
+    "opt_einsum",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "tqdm",
     "threadpoolctl",
     "array_api_compat",
-    "numba",
+    "opt_einsum",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,9 @@ def get_backend(backend_name):
             pytest.skip(f'{backend_name} not available')
     elif backend_name == 'jax':
         try:
+            import jax
+            jax.config.update('jax_enable_x64', True)
+
             import jax.numpy as jnp
             return jnp
         except ImportError:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -599,40 +599,119 @@ def test_dft_matrix_separated_out():
     assert result is out
 
 
-_EINSUM_CASES = [
-    ("ij,jk->ik", [(4, 5), (5, 6)]),                   # plain matmul
-    ("bij,bjk->bik", [(3, 4, 5), (3, 5, 6)]),           # batched matmul
-    ("ii->", [(5, 5)]),                                 # trace
-    ("ii->i", [(5, 5)]),                                # diagonal
-    ("ij->ji", [(4, 5)]),                               # transpose
-    ("i,j->ij", [(4,), (5,)]),                          # outer product
-    ("i,i->", [(6,), (6,)]),                            # dot product
-    ("ij,ij->ij", [(4, 5), (4, 5)]),                    # hadamard
-    ("abcd,cdef->abef", [(3, 4, 5, 6), (5, 6, 7, 8)]),  # multi-index contraction
-    ("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)]),            # diagonals + contraction
-]
-
-
-@pytest.mark.parametrize('subscripts, shapes', _EINSUM_CASES)
-def test_einsum(subscripts, shapes):
+@pytest.mark.parametrize('subscripts, shapes', [
+    # basic contractions
+    pytest.param("ij,jk->ik", [(4, 5), (5, 6)], id="matmul"),
+    pytest.param("bij,bjk->bik", [(3, 4, 5), (3, 5, 6)], id="batched-matmul"),
+    pytest.param("ii->", [(5, 5)], id="trace"),
+    pytest.param("ii->i", [(5, 5)], id="diagonal"),
+    pytest.param("ij->ji", [(4, 5)], id="transpose"),
+    pytest.param("i,j->ij", [(4,), (5,)], id="outer-product"),
+    pytest.param("i,i->", [(6,), (6,)], id="dot-product"),
+    pytest.param("ij,ij->ij", [(4, 5), (4, 5)], id="hadamard"),
+    pytest.param("abcd,cdef->abef", [(3, 4, 5, 6), (5, 6, 7, 8)], id="multi-index-contraction"),
+    pytest.param("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)], id="diagonals-plus-contraction"),
+    # implicit output
+    pytest.param("ij,jk", [(4, 5), (5, 6)], id="implicit-matmul"),
+    pytest.param("i,j", [(4,), (5,)], id="implicit-outer"),
+    pytest.param("ii", [(5, 5)], id="implicit-trace"),
+    # scalar (0-d) operands
+    pytest.param(",i->i", [(), (5,)], id="scalar-times-vector"),
+    pytest.param(",ij->ij", [(), (4, 5)], id="scalar-times-matrix"),
+    pytest.param("i,->i", [(5,), ()], id="vector-times-scalar"),
+    pytest.param(",->", [(), ()], id="scalar-scalar"),
+    # empty dimensions
+    pytest.param("ij,jk->ik", [(0, 5), (5, 6)], id="empty-dimension"),
+    pytest.param("ij,kj->ik", [(0, 5), (4, 5)], id="empty-result"),
+    # multi-operand chains
+    pytest.param("ij,jk,kl->il", [(2, 3), (3, 4), (4, 5)], id="three-operand-chain"),
+    pytest.param("ij,jk,kl,lm->im", [(2, 3), (3, 4), (4, 5), (5, 6)], id="four-operand"),
+    # single-operand einsum
+    pytest.param("ij->", [(3, 4)], id="sum-all"),
+    pytest.param("ij->i", [(3, 4)], id="sum-axis-0"),
+    pytest.param("ij->j", [(3, 4)], id="sum-axis-1"),
+    # diagonals within one operand
+    pytest.param("iij->j", [(4, 4, 5)], id="trace-with-extra-axes"),
+    pytest.param("iijj->", [(3, 3, 4, 4)], id="double-trace"),
+    pytest.param("iii->i", [(3, 3, 3)], id="triple-diagonal"),
+    pytest.param("ij,jkk->ik", [(4, 5), (5, 6, 6)], id="diagonal-on-right"),
+    pytest.param("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)], id="diagonals-on-both"),
+    # broadcast / batch over several dims
+    pytest.param("abij,abjk->abik", [(2, 3, 4, 5), (2, 3, 5, 6)], id="multi-batch-dims"),
+    pytest.param("bi,cj->bcij", [(2, 3), (4, 5)], id="batch-outer"),
+    # stress / high-dimensional
+    pytest.param("abcdef,bcdefg->ag", [(2, 3, 4, 5, 2, 3), (3, 4, 5, 2, 3, 6)], id="6d-contraction"),
+    pytest.param("abcij,abcjk->abcik", [(2, 3, 4, 5, 6), (2, 3, 4, 6, 7)], id="high-dim-batched"),
+    pytest.param("ij,ij->", [(6, 7), (6, 7)], id="all-batch"),
+    pytest.param("dc,ba->abcd", [(7, 6), (5, 4)], id="shuffled-index-order"),
+    # edge cases
+    pytest.param("ij,jk->ik", [(1, 1), (1, 1)], id="size-one-dims"),
+    pytest.param("i->", [(1,)], id="single-element-tensor"),
+    pytest.param("i,j,k->ijk", [(3,), (4,), (5,)], id="outer-product-3way"),
+    pytest.param("bij,bjk->bik", [(20, 10, 12), (20, 12, 8)], id="large-batched"),
+    pytest.param("ijk->kji", [(4, 5, 6)], id="chain-transpose"),
+])
+@pytest.mark.parametrize('optimize', [
+    pytest.param(False, id='simple'),
+    pytest.param(True, id='opt_einsum'),
+])
+def test_einsum(subscripts, shapes, optimize):
     rng = np.random.default_rng(0)
-    arrays = [rng.random(s) for s in shapes]
+    arrays = [np.asarray(rng.random(s), dtype=np.float64) for s in shapes]
     expected = np.einsum(subscripts, *arrays)
-    got = einsum(subscripts, *arrays)
-    np.testing.assert_allclose(got, expected, rtol=1e-10)
+    got = einsum(subscripts, *arrays, optimize=optimize)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
 
 
-def test_einsum_opt_einsum_path():
-    # multi-operand chain, driven by an opt_einsum path if available
-    oe = pytest.importorskip('opt_einsum')
-
+@pytest.mark.parametrize('optimize', [
+    pytest.param(False, id='simple'),
+    pytest.param(True, id='opt_einsum'),
+])
+def test_einsum_five_operand_sum(optimize):
     rng = np.random.default_rng(0)
     eq = "pi,qj,ijkl,rk,sl->pqrs"
     C = rng.random((4, 4))
     I = rng.random((4, 4, 4, 4))
     arrays = [C, C, I, C, C]
 
-    path, _ = oe.contract_path(eq, *arrays)
     expected = np.einsum(eq, *arrays)
-    got = einsum(eq, *arrays, path=path)
-    np.testing.assert_allclose(got, expected, rtol=1e-8)
+    got = einsum(eq, *arrays, optimize=optimize)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
+
+
+@pytest.mark.parametrize('dtype', [
+    pytest.param(np.float32, id='float32'),
+    pytest.param(np.float64, id='float64'),
+    pytest.param(np.complex64, id='complex64'),
+    pytest.param(np.complex128, id='complex128'),
+])
+def test_einsum_dtype(dtype):
+    rng = np.random.default_rng(0)
+    a = rng.random((4, 5)).astype(dtype)
+    b = rng.random((5, 6)).astype(dtype)
+
+    if np.issubdtype(dtype, np.complexfloating):
+        a = a + 1j * rng.random((4, 5)).astype(dtype)
+        b = b + 1j * rng.random((5, 6)).astype(dtype)
+
+    rtol = 1e-6 if np.finfo(dtype).bits <= 32 else 1e-12
+
+    expected = np.einsum("ij,jk->ik", a, b)
+    got = einsum("ij,jk->ik", a, b)
+
+    assert got.dtype == dtype
+    np.testing.assert_allclose(got, expected, rtol=rtol)
+
+
+def test_einsum_int_input():
+    a = np.array([[1, 2], [3, 4]])
+    b = np.array([[5, 6], [7, 8]])
+
+    expected = np.einsum("ij,jk->ik", a, b)
+    got = einsum("ij,jk->ik", a, b)
+    np.testing.assert_array_equal(got, expected)
+
+
+def test_einsum_result_is_scalar():
+    result = einsum("i,i->", np.array([1.0, 2.0]), np.array([3.0, 4.0]))
+    assert isinstance(result, np.ndarray) and result.ndim == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -651,6 +651,17 @@ def test_dft_matrix_separated_out():
     pytest.param("i,j,k->ijk", [(3,), (4,), (5,)], id="outer-product-3way"),
     pytest.param("bij,bjk->bik", [(20, 10, 12), (20, 12, 8)], id="large-batched"),
     pytest.param("ijk->kji", [(4, 5, 6)], id="chain-transpose"),
+    # ellipsis
+    pytest.param("...i,...i->...", [(3, 4), (4,)], id="ellipsis-matvec-broadcast"),
+    pytest.param("...ij,...jk->...ik", [(2, 3, 4), (4, 5)], id="ellipsis-matmul-broadcast"),
+    pytest.param("...ij,...ij->...", [(2, 3, 4), (3, 4)], id="ellipsis-common-batch"),
+    pytest.param("i...i->...", [(3, 5, 3)], id="ellipsis-middle"),
+    pytest.param("ij->...ij", [(4, 5)], id="out-only-ellipsis"),
+    pytest.param("...i->...", [(3, 4)], id="ellipsis-reduce-index"),
+    # implicit output with ellipsis
+    pytest.param("...i", [(3, 4)], id="implicit-ellipsis"),
+    pytest.param("...i,...i", [(3, 4), (4,)], id="implicit-ellipsis-broadcast"),
+    pytest.param("i...i", [(3, 5, 3)], id="implicit-ellipsis-middle"),
 ])
 @pytest.mark.parametrize('optimize', [False, True])
 def test_einsum(xp, subscripts, shapes, optimize):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -2,6 +2,7 @@ import pytest
 import hcipy
 import numpy as np
 from hcipy._math.backends import to_numpy, array_namespace
+from hcipy._math.einsum import einsum
 from hcipy._math.fourier import dft_matrix_regular, dft_matrix_separated
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
@@ -596,3 +597,42 @@ def test_dft_matrix_separated_out():
     result = dft_matrix_separated(x, u, out=out)
 
     assert result is out
+
+
+_EINSUM_CASES = [
+    ("ij,jk->ik", [(4, 5), (5, 6)]),                   # plain matmul
+    ("bij,bjk->bik", [(3, 4, 5), (3, 5, 6)]),           # batched matmul
+    ("ii->", [(5, 5)]),                                 # trace
+    ("ii->i", [(5, 5)]),                                # diagonal
+    ("ij->ji", [(4, 5)]),                               # transpose
+    ("i,j->ij", [(4,), (5,)]),                          # outer product
+    ("i,i->", [(6,), (6,)]),                            # dot product
+    ("ij,ij->ij", [(4, 5), (4, 5)]),                    # hadamard
+    ("abcd,cdef->abef", [(3, 4, 5, 6), (5, 6, 7, 8)]),  # multi-index contraction
+    ("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)]),            # diagonals + contraction
+]
+
+
+@pytest.mark.parametrize('subscripts, shapes', _EINSUM_CASES)
+def test_einsum(subscripts, shapes):
+    rng = np.random.default_rng(0)
+    arrays = [rng.random(s) for s in shapes]
+    expected = np.einsum(subscripts, *arrays)
+    got = einsum(subscripts, *arrays)
+    np.testing.assert_allclose(got, expected, rtol=1e-10)
+
+
+def test_einsum_opt_einsum_path():
+    # multi-operand chain, driven by an opt_einsum path if available
+    oe = pytest.importorskip('opt_einsum')
+
+    rng = np.random.default_rng(0)
+    eq = "pi,qj,ijkl,rk,sl->pqrs"
+    C = rng.random((4, 4))
+    I = rng.random((4, 4, 4, 4))
+    arrays = [C, C, I, C, C]
+
+    path, _ = oe.contract_path(eq, *arrays)
+    expected = np.einsum(eq, *arrays)
+    got = einsum(eq, *arrays, path=path)
+    np.testing.assert_allclose(got, expected, rtol=1e-8)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -306,40 +306,119 @@ def test_array_namespace(xp):
     _ = array_namespace(arr)
 
 
-_EINSUM_CASES = [
-    ("ij,jk->ik", [(4, 5), (5, 6)]),                   # plain matmul
-    ("bij,bjk->bik", [(3, 4, 5), (3, 5, 6)]),           # batched matmul
-    ("ii->", [(5, 5)]),                                 # trace
-    ("ii->i", [(5, 5)]),                                # diagonal
-    ("ij->ji", [(4, 5)]),                               # transpose
-    ("i,j->ij", [(4,), (5,)]),                          # outer product
-    ("i,i->", [(6,), (6,)]),                            # dot product
-    ("ij,ij->ij", [(4, 5), (4, 5)]),                    # hadamard
-    ("abcd,cdef->abef", [(3, 4, 5, 6), (5, 6, 7, 8)]),  # multi-index contraction
-    ("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)]),            # diagonals + contraction
-]
-
-
-@pytest.mark.parametrize('subscripts, shapes', _EINSUM_CASES)
-def test_einsum(subscripts, shapes):
+@pytest.mark.parametrize('subscripts, shapes', [
+    # basic contractions
+    pytest.param("ij,jk->ik", [(4, 5), (5, 6)], id="matmul"),
+    pytest.param("bij,bjk->bik", [(3, 4, 5), (3, 5, 6)], id="batched-matmul"),
+    pytest.param("ii->", [(5, 5)], id="trace"),
+    pytest.param("ii->i", [(5, 5)], id="diagonal"),
+    pytest.param("ij->ji", [(4, 5)], id="transpose"),
+    pytest.param("i,j->ij", [(4,), (5,)], id="outer-product"),
+    pytest.param("i,i->", [(6,), (6,)], id="dot-product"),
+    pytest.param("ij,ij->ij", [(4, 5), (4, 5)], id="hadamard"),
+    pytest.param("abcd,cdef->abef", [(3, 4, 5, 6), (5, 6, 7, 8)], id="multi-index-contraction"),
+    pytest.param("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)], id="diagonals-plus-contraction"),
+    # implicit output
+    pytest.param("ij,jk", [(4, 5), (5, 6)], id="implicit-matmul"),
+    pytest.param("i,j", [(4,), (5,)], id="implicit-outer"),
+    pytest.param("ii", [(5, 5)], id="implicit-trace"),
+    # scalar (0-d) operands
+    pytest.param(",i->i", [(), (5,)], id="scalar-times-vector"),
+    pytest.param(",ij->ij", [(), (4, 5)], id="scalar-times-matrix"),
+    pytest.param("i,->i", [(5,), ()], id="vector-times-scalar"),
+    pytest.param(",->", [(), ()], id="scalar-scalar"),
+    # empty dimensions
+    pytest.param("ij,jk->ik", [(0, 5), (5, 6)], id="empty-dimension"),
+    pytest.param("ij,kj->ik", [(0, 5), (4, 5)], id="empty-result"),
+    # multi-operand chains
+    pytest.param("ij,jk,kl->il", [(2, 3), (3, 4), (4, 5)], id="three-operand-chain"),
+    pytest.param("ij,jk,kl,lm->im", [(2, 3), (3, 4), (4, 5), (5, 6)], id="four-operand"),
+    # single-operand einsum
+    pytest.param("ij->", [(3, 4)], id="sum-all"),
+    pytest.param("ij->i", [(3, 4)], id="sum-axis-0"),
+    pytest.param("ij->j", [(3, 4)], id="sum-axis-1"),
+    # diagonals within one operand
+    pytest.param("iij->j", [(4, 4, 5)], id="trace-with-extra-axes"),
+    pytest.param("iijj->", [(3, 3, 4, 4)], id="double-trace"),
+    pytest.param("iii->i", [(3, 3, 3)], id="triple-diagonal"),
+    pytest.param("ij,jkk->ik", [(4, 5), (5, 6, 6)], id="diagonal-on-right"),
+    pytest.param("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)], id="diagonals-on-both"),
+    # broadcast / batch over several dims
+    pytest.param("abij,abjk->abik", [(2, 3, 4, 5), (2, 3, 5, 6)], id="multi-batch-dims"),
+    pytest.param("bi,cj->bcij", [(2, 3), (4, 5)], id="batch-outer"),
+    # stress / high-dimensional
+    pytest.param("abcdef,bcdefg->ag", [(2, 3, 4, 5, 2, 3), (3, 4, 5, 2, 3, 6)], id="6d-contraction"),
+    pytest.param("abcij,abcjk->abcik", [(2, 3, 4, 5, 6), (2, 3, 4, 6, 7)], id="high-dim-batched"),
+    pytest.param("ij,ij->", [(6, 7), (6, 7)], id="all-batch"),
+    pytest.param("dc,ba->abcd", [(7, 6), (5, 4)], id="shuffled-index-order"),
+    # edge cases
+    pytest.param("ij,jk->ik", [(1, 1), (1, 1)], id="size-one-dims"),
+    pytest.param("i->", [(1,)], id="single-element-tensor"),
+    pytest.param("i,j,k->ijk", [(3,), (4,), (5,)], id="outer-product-3way"),
+    pytest.param("bij,bjk->bik", [(20, 10, 12), (20, 12, 8)], id="large-batched"),
+    pytest.param("ijk->kji", [(4, 5, 6)], id="chain-transpose"),
+])
+@pytest.mark.parametrize('optimize', [
+    pytest.param(False, id='simple'),
+    pytest.param(True, id='opt_einsum'),
+])
+def test_einsum(subscripts, shapes, optimize):
     rng = np.random.default_rng(0)
-    arrays = [rng.random(s) for s in shapes]
+    arrays = [np.asarray(rng.random(s), dtype=np.float64) for s in shapes]
     expected = np.einsum(subscripts, *arrays)
-    got = einsum(subscripts, *arrays)
-    np.testing.assert_allclose(got, expected, rtol=1e-10)
+    got = einsum(subscripts, *arrays, optimize=optimize)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
 
 
-def test_einsum_opt_einsum_path():
-    # multi-operand chain, driven by an opt_einsum path if available
-    oe = pytest.importorskip('opt_einsum')
-
+@pytest.mark.parametrize('optimize', [
+    pytest.param(False, id='simple'),
+    pytest.param(True, id='opt_einsum'),
+])
+def test_einsum_five_operand_sum(optimize):
     rng = np.random.default_rng(0)
     eq = "pi,qj,ijkl,rk,sl->pqrs"
     C = rng.random((4, 4))
     I = rng.random((4, 4, 4, 4))
     arrays = [C, C, I, C, C]
 
-    path, _ = oe.contract_path(eq, *arrays)
     expected = np.einsum(eq, *arrays)
-    got = einsum(eq, *arrays, path=path)
-    np.testing.assert_allclose(got, expected, rtol=1e-8)
+    got = einsum(eq, *arrays, optimize=optimize)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
+
+
+@pytest.mark.parametrize('dtype', [
+    pytest.param(np.float32, id='float32'),
+    pytest.param(np.float64, id='float64'),
+    pytest.param(np.complex64, id='complex64'),
+    pytest.param(np.complex128, id='complex128'),
+])
+def test_einsum_dtype(dtype):
+    rng = np.random.default_rng(0)
+    a = rng.random((4, 5)).astype(dtype)
+    b = rng.random((5, 6)).astype(dtype)
+
+    if np.issubdtype(dtype, np.complexfloating):
+        a = a + 1j * rng.random((4, 5)).astype(dtype)
+        b = b + 1j * rng.random((5, 6)).astype(dtype)
+
+    rtol = 1e-6 if np.finfo(dtype).bits <= 32 else 1e-12
+
+    expected = np.einsum("ij,jk->ik", a, b)
+    got = einsum("ij,jk->ik", a, b)
+
+    assert got.dtype == dtype
+    np.testing.assert_allclose(got, expected, rtol=rtol)
+
+
+def test_einsum_int_input():
+    a = np.array([[1, 2], [3, 4]])
+    b = np.array([[5, 6], [7, 8]])
+
+    expected = np.einsum("ij,jk->ik", a, b)
+    got = einsum("ij,jk->ik", a, b)
+    np.testing.assert_array_equal(got, expected)
+
+
+def test_einsum_result_is_scalar():
+    result = einsum("i,i->", np.array([1.0, 2.0]), np.array([3.0, 4.0]))
+    assert isinstance(result, np.ndarray) and result.ndim == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -386,7 +386,7 @@ def test_einsum(xp, subscripts, shapes, optimize):
 
     got = einsum(subscripts, *arrays, optimize=optimize)
 
-    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-11)
+    np.testing.assert_allclose(np.asarray(got), expected, atol=1e-14)
 
 @pytest.mark.parametrize('dtype', ['float32', 'float64', 'complex64', 'complex128'])
 def test_einsum_dtype(xp, dtype):
@@ -400,13 +400,13 @@ def test_einsum_dtype(xp, dtype):
         a = a + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(4, 5)), dtype_xp)
         b = b + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
-    rtol = 1e-5 if xp.finfo(dtype_xp).bits <= 32 else 1e-11
+    atol = 1e-6 if xp.finfo(dtype_xp).bits <= 32 else 1e-14
 
     expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
 
     assert got.dtype == dtype_xp
-    np.testing.assert_allclose(np.asarray(got), expected, rtol=rtol)
+    np.testing.assert_allclose(np.asarray(got), expected, atol=atol)
 
 def test_einsum_int_input(xp):
     a = xp.asarray([[1, 2], [3, 4]])

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -203,6 +203,13 @@ def test_random_generator_different_sizes(xp, distribution, args):
 
     generation_func = getattr(rng, distribution)
 
+    # Test 0D array
+    arr_0d = generation_func(size=tuple(), **args[0])
+    assert arr_0d.shape == tuple()
+
+    arr_0d = generation_func(size=None, **args[0])
+    assert arr_0d.shape == tuple()
+
     # Test 1D array
     arr_1d = generation_func(size=5, **args[0])
     assert arr_1d.shape == (5,)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -358,16 +358,14 @@ def test_array_namespace(xp):
     pytest.param("bij,bjk->bik", [(20, 10, 12), (20, 12, 8)], id="large-batched"),
     pytest.param("ijk->kji", [(4, 5, 6)], id="chain-transpose"),
 ])
-@pytest.mark.parametrize('optimize', [
-    pytest.param(False, id='simple'),
-    pytest.param(True, id='opt_einsum'),
-])
-def test_einsum(subscripts, shapes, optimize):
-    rng = np.random.default_rng(0)
-    arrays = [np.asarray(rng.random(s), dtype=np.float64) for s in shapes]
-    expected = np.einsum(subscripts, *arrays)
+@pytest.mark.parametrize('optimize', [False, True])
+def test_einsum(xp, subscripts, shapes, optimize):
+    rng = make_random_generator(xp)
+    arrays = [xp.astype(rng.normal(size=s), xp.float64) for s in shapes]
+    arrays_numpy = [np.asarray(arr) for arr in arrays]
+    expected = np.einsum(subscripts, *arrays_numpy)
     got = einsum(subscripts, *arrays, optimize=optimize)
-    np.testing.assert_allclose(got, expected, rtol=1e-12)
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-12)
 
 
 @pytest.mark.parametrize('optimize', [

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -357,6 +357,17 @@ def test_array_namespace(xp):
     pytest.param("i,j,k->ijk", [(3,), (4,), (5,)], id="outer-product-3way"),
     pytest.param("bij,bjk->bik", [(20, 10, 12), (20, 12, 8)], id="large-batched"),
     pytest.param("ijk->kji", [(4, 5, 6)], id="chain-transpose"),
+    # ellipsis
+    pytest.param("...i,...i->...", [(3, 4), (4,)], id="ellipsis-matvec-broadcast"),
+    pytest.param("...ij,...jk->...ik", [(2, 3, 4), (4, 5)], id="ellipsis-matmul-broadcast"),
+    pytest.param("...ij,...ij->...", [(2, 3, 4), (3, 4)], id="ellipsis-common-batch"),
+    pytest.param("i...i->...", [(3, 5, 3)], id="ellipsis-middle"),
+    pytest.param("ij->...ij", [(4, 5)], id="out-only-ellipsis"),
+    pytest.param("...i->...", [(3, 4)], id="ellipsis-reduce-index"),
+    # implicit output with ellipsis
+    pytest.param("...i", [(3, 4)], id="implicit-ellipsis"),
+    pytest.param("...i,...i", [(3, 4), (4,)], id="implicit-ellipsis-broadcast"),
+    pytest.param("i...i", [(3, 5, 3)], id="implicit-ellipsis-middle"),
 ])
 @pytest.mark.parametrize('optimize', [False, True])
 def test_einsum(xp, subscripts, shapes, optimize):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,6 +4,7 @@ import numpy as np
 from hcipy._math.random import make_random_generator
 from hcipy._math.stats import median, nanmedian
 from hcipy._math.backends import to_numpy, array_namespace
+from hcipy._math.einsum import einsum
 import math
 
 
@@ -303,3 +304,42 @@ def test_to_numpy(xp):
 def test_array_namespace(xp):
     arr = xp.zeros(10)
     _ = array_namespace(arr)
+
+
+_EINSUM_CASES = [
+    ("ij,jk->ik", [(4, 5), (5, 6)]),                   # plain matmul
+    ("bij,bjk->bik", [(3, 4, 5), (3, 5, 6)]),           # batched matmul
+    ("ii->", [(5, 5)]),                                 # trace
+    ("ii->i", [(5, 5)]),                                # diagonal
+    ("ij->ji", [(4, 5)]),                               # transpose
+    ("i,j->ij", [(4,), (5,)]),                          # outer product
+    ("i,i->", [(6,), (6,)]),                            # dot product
+    ("ij,ij->ij", [(4, 5), (4, 5)]),                    # hadamard
+    ("abcd,cdef->abef", [(3, 4, 5, 6), (5, 6, 7, 8)]),  # multi-index contraction
+    ("iij,jkk->ik", [(4, 4, 5), (5, 6, 6)]),            # diagonals + contraction
+]
+
+
+@pytest.mark.parametrize('subscripts, shapes', _EINSUM_CASES)
+def test_einsum(subscripts, shapes):
+    rng = np.random.default_rng(0)
+    arrays = [rng.random(s) for s in shapes]
+    expected = np.einsum(subscripts, *arrays)
+    got = einsum(subscripts, *arrays)
+    np.testing.assert_allclose(got, expected, rtol=1e-10)
+
+
+def test_einsum_opt_einsum_path():
+    # multi-operand chain, driven by an opt_einsum path if available
+    oe = pytest.importorskip('opt_einsum')
+
+    rng = np.random.default_rng(0)
+    eq = "pi,qj,ijkl,rk,sl->pqrs"
+    C = rng.random((4, 4))
+    I = rng.random((4, 4, 4, 4))
+    arrays = [C, C, I, C, C]
+
+    path, _ = oe.contract_path(eq, *arrays)
+    expected = np.einsum(eq, *arrays)
+    got = einsum(eq, *arrays, path=path)
+    np.testing.assert_allclose(got, expected, rtol=1e-8)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -651,16 +651,14 @@ def test_dft_matrix_separated_out():
     pytest.param("bij,bjk->bik", [(20, 10, 12), (20, 12, 8)], id="large-batched"),
     pytest.param("ijk->kji", [(4, 5, 6)], id="chain-transpose"),
 ])
-@pytest.mark.parametrize('optimize', [
-    pytest.param(False, id='simple'),
-    pytest.param(True, id='opt_einsum'),
-])
-def test_einsum(subscripts, shapes, optimize):
-    rng = np.random.default_rng(0)
-    arrays = [np.asarray(rng.random(s), dtype=np.float64) for s in shapes]
-    expected = np.einsum(subscripts, *arrays)
+@pytest.mark.parametrize('optimize', [False, True])
+def test_einsum(xp, subscripts, shapes, optimize):
+    rng = make_random_generator(xp)
+    arrays = [xp.astype(rng.normal(size=s), xp.float64) for s in shapes]
+    arrays_numpy = [np.asarray(arr) for arr in arrays]
+    expected = np.einsum(subscripts, *arrays_numpy)
     got = einsum(subscripts, *arrays, optimize=optimize)
-    np.testing.assert_allclose(got, expected, rtol=1e-12)
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-12)
 
 
 @pytest.mark.parametrize('optimize', [

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -305,7 +305,6 @@ def test_array_namespace(xp):
     arr = xp.zeros(10)
     _ = array_namespace(arr)
 
-
 @pytest.mark.parametrize('subscripts, shapes', [
     # basic contractions
     pytest.param("ij,jk->ik", [(4, 5), (5, 6)], id="matmul"),
@@ -333,6 +332,7 @@ def test_array_namespace(xp):
     # multi-operand chains
     pytest.param("ij,jk,kl->il", [(2, 3), (3, 4), (4, 5)], id="three-operand-chain"),
     pytest.param("ij,jk,kl,lm->im", [(2, 3), (3, 4), (4, 5), (5, 6)], id="four-operand"),
+    pytest.param("pi,qj,ijkl,rk,sl->pqrs", [(4, 4), (4, 4), (4, 4, 4, 4), (4, 4), (4, 4)], id="five-operand"),
     # single-operand einsum
     pytest.param("ij->", [(3, 4)], id="sum-all"),
     pytest.param("ij->i", [(3, 4)], id="sum-axis-0"),
@@ -362,61 +362,42 @@ def test_array_namespace(xp):
 def test_einsum(xp, subscripts, shapes, optimize):
     rng = make_random_generator(xp)
     arrays = [xp.astype(rng.normal(size=s), xp.float64) for s in shapes]
+
     arrays_numpy = [np.asarray(arr) for arr in arrays]
     expected = np.einsum(subscripts, *arrays_numpy)
+
     got = einsum(subscripts, *arrays, optimize=optimize)
-    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-12)
 
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-11)
 
-@pytest.mark.parametrize('optimize', [
-    pytest.param(False, id='simple'),
-    pytest.param(True, id='opt_einsum'),
-])
-def test_einsum_five_operand_sum(optimize):
-    rng = np.random.default_rng(0)
-    eq = "pi,qj,ijkl,rk,sl->pqrs"
-    C = rng.random((4, 4))
-    I = rng.random((4, 4, 4, 4))
-    arrays = [C, C, I, C, C]
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'complex64', 'complex128'])
+def test_einsum_dtype(xp, dtype):
+    dtype_xp = getattr(xp, dtype)
+    rng = make_random_generator(xp)
 
-    expected = np.einsum(eq, *arrays)
-    got = einsum(eq, *arrays, optimize=optimize)
-    np.testing.assert_allclose(got, expected, rtol=1e-12)
+    a = xp.astype(rng.normal(size=(4, 5)), dtype_xp)
+    b = xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
+    if xp.isdtype(dtype_xp, 'complex floating'):
+        a = a + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(4, 5)), dtype_xp)
+        b = b + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
-@pytest.mark.parametrize('dtype', [
-    pytest.param(np.float32, id='float32'),
-    pytest.param(np.float64, id='float64'),
-    pytest.param(np.complex64, id='complex64'),
-    pytest.param(np.complex128, id='complex128'),
-])
-def test_einsum_dtype(dtype):
-    rng = np.random.default_rng(0)
-    a = rng.random((4, 5)).astype(dtype)
-    b = rng.random((5, 6)).astype(dtype)
+    rtol = 1e-5 if xp.finfo(dtype_xp).bits <= 32 else 1e-11
 
-    if np.issubdtype(dtype, np.complexfloating):
-        a = a + 1j * rng.random((4, 5)).astype(dtype)
-        b = b + 1j * rng.random((5, 6)).astype(dtype)
-
-    rtol = 1e-6 if np.finfo(dtype).bits <= 32 else 1e-12
-
-    expected = np.einsum("ij,jk->ik", a, b)
+    expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
 
-    assert got.dtype == dtype
-    np.testing.assert_allclose(got, expected, rtol=rtol)
+    assert got.dtype == dtype_xp
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=rtol)
 
+def test_einsum_int_input(xp):
+    a = xp.asarray([[1, 2], [3, 4]])
+    b = xp.asarray([[5, 6], [7, 8]])
 
-def test_einsum_int_input():
-    a = np.array([[1, 2], [3, 4]])
-    b = np.array([[5, 6], [7, 8]])
-
-    expected = np.einsum("ij,jk->ik", a, b)
+    expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
-    np.testing.assert_array_equal(got, expected)
+    np.testing.assert_array_equal(np.asarray(got), expected)
 
-
-def test_einsum_result_is_scalar():
-    result = einsum("i,i->", np.array([1.0, 2.0]), np.array([3.0, 4.0]))
-    assert isinstance(result, np.ndarray) and result.ndim == 0
+def test_einsum_result_is_scalar(xp):
+    result = einsum("i,i->", xp.asarray([1.0, 2.0]), xp.asarray([3.0, 4.0]))
+    assert result.ndim == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -626,6 +626,7 @@ def test_dft_matrix_separated_out():
     # multi-operand chains
     pytest.param("ij,jk,kl->il", [(2, 3), (3, 4), (4, 5)], id="three-operand-chain"),
     pytest.param("ij,jk,kl,lm->im", [(2, 3), (3, 4), (4, 5), (5, 6)], id="four-operand"),
+    pytest.param("pi,qj,ijkl,rk,sl->pqrs", [(4, 4), (4, 4), (4, 4, 4, 4), (4, 4), (4, 4)], id="five-operand"),
     # single-operand einsum
     pytest.param("ij->", [(3, 4)], id="sum-all"),
     pytest.param("ij->i", [(3, 4)], id="sum-axis-0"),
@@ -655,61 +656,42 @@ def test_dft_matrix_separated_out():
 def test_einsum(xp, subscripts, shapes, optimize):
     rng = make_random_generator(xp)
     arrays = [xp.astype(rng.normal(size=s), xp.float64) for s in shapes]
+
     arrays_numpy = [np.asarray(arr) for arr in arrays]
     expected = np.einsum(subscripts, *arrays_numpy)
+
     got = einsum(subscripts, *arrays, optimize=optimize)
-    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-12)
 
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-11)
 
-@pytest.mark.parametrize('optimize', [
-    pytest.param(False, id='simple'),
-    pytest.param(True, id='opt_einsum'),
-])
-def test_einsum_five_operand_sum(optimize):
-    rng = np.random.default_rng(0)
-    eq = "pi,qj,ijkl,rk,sl->pqrs"
-    C = rng.random((4, 4))
-    I = rng.random((4, 4, 4, 4))
-    arrays = [C, C, I, C, C]
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'complex64', 'complex128'])
+def test_einsum_dtype(xp, dtype):
+    dtype_xp = getattr(xp, dtype)
+    rng = make_random_generator(xp)
 
-    expected = np.einsum(eq, *arrays)
-    got = einsum(eq, *arrays, optimize=optimize)
-    np.testing.assert_allclose(got, expected, rtol=1e-12)
+    a = xp.astype(rng.normal(size=(4, 5)), dtype_xp)
+    b = xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
+    if xp.isdtype(dtype_xp, 'complex floating'):
+        a = a + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(4, 5)), dtype_xp)
+        b = b + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
-@pytest.mark.parametrize('dtype', [
-    pytest.param(np.float32, id='float32'),
-    pytest.param(np.float64, id='float64'),
-    pytest.param(np.complex64, id='complex64'),
-    pytest.param(np.complex128, id='complex128'),
-])
-def test_einsum_dtype(dtype):
-    rng = np.random.default_rng(0)
-    a = rng.random((4, 5)).astype(dtype)
-    b = rng.random((5, 6)).astype(dtype)
+    rtol = 1e-5 if xp.finfo(dtype_xp).bits <= 32 else 1e-11
 
-    if np.issubdtype(dtype, np.complexfloating):
-        a = a + 1j * rng.random((4, 5)).astype(dtype)
-        b = b + 1j * rng.random((5, 6)).astype(dtype)
-
-    rtol = 1e-6 if np.finfo(dtype).bits <= 32 else 1e-12
-
-    expected = np.einsum("ij,jk->ik", a, b)
+    expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
 
-    assert got.dtype == dtype
-    np.testing.assert_allclose(got, expected, rtol=rtol)
+    assert got.dtype == dtype_xp
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=rtol)
 
+def test_einsum_int_input(xp):
+    a = xp.asarray([[1, 2], [3, 4]])
+    b = xp.asarray([[5, 6], [7, 8]])
 
-def test_einsum_int_input():
-    a = np.array([[1, 2], [3, 4]])
-    b = np.array([[5, 6], [7, 8]])
-
-    expected = np.einsum("ij,jk->ik", a, b)
+    expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
-    np.testing.assert_array_equal(got, expected)
+    np.testing.assert_array_equal(np.asarray(got), expected)
 
-
-def test_einsum_result_is_scalar():
-    result = einsum("i,i->", np.array([1.0, 2.0]), np.array([3.0, 4.0]))
-    assert isinstance(result, np.ndarray) and result.ndim == 0
+def test_einsum_result_is_scalar(xp):
+    result = einsum("i,i->", xp.asarray([1.0, 2.0]), xp.asarray([3.0, 4.0]))
+    assert result.ndim == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -680,7 +680,7 @@ def test_einsum(xp, subscripts, shapes, optimize):
 
     got = einsum(subscripts, *arrays, optimize=optimize)
 
-    np.testing.assert_allclose(np.asarray(got), expected, rtol=1e-11)
+    np.testing.assert_allclose(np.asarray(got), expected, atol=1e-14)
 
 @pytest.mark.parametrize('dtype', ['float32', 'float64', 'complex64', 'complex128'])
 def test_einsum_dtype(xp, dtype):
@@ -694,13 +694,13 @@ def test_einsum_dtype(xp, dtype):
         a = a + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(4, 5)), dtype_xp)
         b = b + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
-    rtol = 1e-5 if xp.finfo(dtype_xp).bits <= 32 else 1e-11
+    atol = 1e-6 if xp.finfo(dtype_xp).bits <= 32 else 1e-14
 
     expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
 
     assert got.dtype == dtype_xp
-    np.testing.assert_allclose(np.asarray(got), expected, rtol=rtol)
+    np.testing.assert_allclose(np.asarray(got), expected, atol=atol)
 
 def test_einsum_int_input(xp):
     a = xp.asarray([[1, 2], [3, 4]])

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -198,6 +198,13 @@ def test_random_generator_different_sizes(xp, distribution, args):
 
     generation_func = getattr(rng, distribution)
 
+    # Test 0D array
+    arr_0d = generation_func(size=tuple(), **args[0])
+    assert arr_0d.shape == tuple()
+
+    arr_0d = generation_func(size=None, **args[0])
+    assert arr_0d.shape == tuple()
+
     # Test 1D array
     arr_1d = generation_func(size=5, **args[0])
     assert arr_1d.shape == (5,)


### PR DESCRIPTION
This PR adds a from-scratch, array-API-compatible `einsum` implementation along with cross-backend tests. A large majority of Field operations use einsum in some way, necessitating this new implementation.

## Implementation

`einsum(subscripts, *operands, optimize=True)` is a drop-in replacement for `np.einsum()` (with reduced features) yet working for all Array API backends. The implementation defers to the native implementation for Numpy, Cupy, Jax and Pytorch. As a generic fallback, `opt_einsum` (new dependency) decomposes the contraction into a series of pairwise contractions. Each pairwise step classifies indices into batch/contracted/free groups, reshapes both operands to 3D and delegates to a single batched matmul (or an elementwise multiply when there is no contracted index), then reshapes back. Repeated indices within one operand are collapsed with a diagonal helper that uses the backend's native `diagonal` when available.

This PR also fixes some behavior for the random generators, involving scalars. I also added a test to specifically target that bug.

## Tests

The parametrized case list covers 41 equations (matmul, batched contractions, diagonals, implicit output, scalars, empty dimensions, up to five operands), each run with both optimization modes across the `xp` fixture and compared against `np.einsum` on the same data. Additional tests cover dtype preservation across four dtypes, integer inputs, and scalar results.

## AI

This PR made use of Deepseek V4 Flash and Pro, along with a painful amount of rewriting for implementation simplicity.