### PR TITLE
Make field operations compatible with Array API.

### DIFF
--- a/hcipy/field/operations.py
+++ b/hcipy/field/operations.py
@@ -1,6 +1,19 @@
-from .field import Field
+from .field import Field, NewStyleField, is_field
 import numpy as np
 import string
+from .._math.einsum import einsum
+from .._math.backends import array_namespace, is_scalar
+
+def _normalize_field(a):
+    """Extract the underlying array from a field for numpy compatibility.
+
+    OldStyleField subclasses np.ndarray and can be used directly.
+    NewStyleField stores its data in ``.data`` and is not ndarray-compatible.
+    """
+    if isinstance(a, NewStyleField):
+        return a.data
+    else:
+        return a
 
 def field_einsum(subscripts, *operands, **kwargs):
     '''Evaluates the Einstein summation convention on the operand fields.
@@ -64,12 +77,12 @@ def field_einsum(subscripts, *operands, **kwargs):
         If all of the fields don't have    the same grid size. If the number of
         operands is not equal to the number of subscripts specified.
     '''
-    is_field = [isinstance(o, Field) for o in operands]
-    if not np.count_nonzero(is_field):
-        return np.einsum(subscripts, *operands, **kwargs)
+    operand_is_field = [is_field(o) for o in operands]
+    if not any(operand_is_field):
+        return einsum(subscripts, *operands, **kwargs)
 
-    field_sizes = [o.grid.size for i, o in enumerate(operands) if is_field[i]]
-    element_sizes = [o.shape[-1] for i, o in enumerate(operands) if is_field[i]]
+    field_sizes = [o.grid.size for i, o in enumerate(operands) if operand_is_field[i]]
+    element_sizes = [o.shape[-1] for i, o in enumerate(operands) if operand_is_field[i]]
 
     if not np.allclose(field_sizes, field_sizes[0]) or not np.allclose(element_sizes, element_sizes[0]):
         raise ValueError('All fields must be the same size for a field_einsum().')
@@ -91,7 +104,7 @@ def field_einsum(subscripts, *operands, **kwargs):
     unused_index = [a for a in string.ascii_lowercase if a not in subscripts][0]
 
     # Add the field dimension to the input field operands.
-    ss = [s + unused_index if is_field[i] else s for i, s in enumerate(ss)]
+    ss = [s + unused_index if operand_is_field[i] else s for i, s in enumerate(ss)]
 
     # Recombine all operands into the final subscripts
     if len(splitted_string) == 2:
@@ -99,8 +112,18 @@ def field_einsum(subscripts, *operands, **kwargs):
     else:
         subscripts_new = ','.join(ss)
 
-    res = np.einsum(subscripts_new, *operands, **kwargs)
-    grid = operands[np.flatnonzero(np.array(is_field))[0]].grid
+    unwrapped = [_normalize_field(o) if operand_is_field[i] else o for i, o in enumerate(operands)]
+
+    if 'out' in kwargs:
+        kwargs['out'] = _normalize_field(kwargs['out'])
+
+    res = einsum(subscripts_new, *unwrapped, **kwargs)
+
+    grid = None
+    for o in operands:
+        if hasattr(o, 'grid'):
+            grid = o.grid
+            break
 
     if 'out' in kwargs:
         kwargs['out'] = Field(res, grid)
@@ -126,21 +149,23 @@ def field_dot(a, b, out=None):
     # Find out if a or b are vectors or higher dimensional tensors
     if hasattr(a, 'tensor_order'):
         amat = a.tensor_order > 1
-    elif np.isscalar(a):
+    elif is_scalar(a):
         if out is None:
             return a * b
         else:
-            return np.multiply(a, b, out)
+            xp = array_namespace(a, b)
+            return xp.multiply(a, b, out=out)
     else:
         amat = a.ndim > 1
 
     if hasattr(b, 'tensor_order'):
         bmat = b.tensor_order > 1
-    elif np.isscalar(b):
+    elif is_scalar(b):
         if out is None:
             return a * b
         else:
-            return np.multiply(a, b, out)
+            xp = array_namespace(a, b)
+            return xp.multiply(a, b, out=out)
     else:
         bmat = b.ndim > 1
 
@@ -208,9 +233,10 @@ def field_inverse_tikhonov(f, rcond=1e-15):
         if f.tensor_order != 2:
             raise ValueError("Field must be a tensor field of order 2 to be able to calculate inverses.")
 
-        res = np.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
+        xp = array_namespace(_normalize_field(f))
+        res = xp.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
         for i in range(f.grid.size):
-            res[..., i] = inverse_tikhonov(f[..., i], rcond)
+            res[..., i] = xp.asarray(inverse_tikhonov(_normalize_field(f[..., i]), rcond))
         return Field(res, f.grid)
     else:
         return inverse_tikhonov(f, rcond)
@@ -244,9 +270,10 @@ def field_inverse_truncated(f, rcond=1e-15):
         if f.tensor_order != 2:
             raise ValueError("Field must be a tensor field of order 2 to be able to calculate inverses.")
 
-        res = np.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
+        xp = array_namespace(_normalize_field(f))
+        res = xp.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
         for i in range(f.grid.size):
-            res[..., i] = inverse_truncated(f[..., i], rcond)
+            res[..., i] = xp.asarray(inverse_truncated(_normalize_field(f[..., i]), rcond))
         return Field(res, f.grid)
     else:
         return inverse_truncated(f, rcond)
@@ -280,9 +307,10 @@ def field_inverse_truncated_modal(f, num_modes):
         if f.tensor_order != 2:
             raise ValueError("Field must be a tensor field of order 2 to be able to calculate inverses.")
 
-        res = np.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
+        xp = array_namespace(_normalize_field(f))
+        res = xp.empty((f.tensor_shape[1], f.tensor_shape[0], f.grid.size))
         for i in range(f.grid.size):
-            res[..., i] = inverse_truncated_modal(np.asarray(f[..., i]), num_modes)
+            res[..., i] = xp.asarray(inverse_truncated_modal(_normalize_field(f[..., i]), num_modes))
         return Field(res, f.grid)
     else:
         return inverse_truncated_modal(f, num_modes)
@@ -310,10 +338,13 @@ def field_inv(f):
         if f.tensor_order != 2:
             raise ValueError('Field must be a tensor field of order 2 to be able to compute inverses.')
 
-        res = np.moveaxis(np.linalg.inv(np.moveaxis(f, -1, 0)), 0, -1)
-        return Field(res, f.grid)
+        data = _normalize_field(f)
+        xp = array_namespace(data)
+        res = xp.linalg.inv(xp.moveaxis(data, -1, 0))
+        return Field(xp.moveaxis(res, 0, -1), f.grid)
     else:
-        return np.linalg.inv(f)
+        xp = array_namespace(f)
+        return xp.linalg.inv(f)
 
 def field_svd(f, full_matrices=True, compute_uv=True):
     '''Calculate the singular value decomposition for a tensor field of order 2.
@@ -338,20 +369,20 @@ def field_svd(f, full_matrices=True, compute_uv=True):
         The unitary matrices. Only returned if `compute_uv` is True.
     '''
 
-    res = np.linalg.svd(np.moveaxis(f, -1, 0), full_matrices, compute_uv)
+    data = _normalize_field(f)
+    xp = array_namespace(data)
 
     if compute_uv:
-        U, S, Vh = res
-        U = Field(np.moveaxis(U, 0, -1), f.grid)
-        Vh = Field(np.moveaxis(Vh, 0, -1), f.grid)
-    else:
-        S = res
+        U, S, Vh = xp.linalg.svd(xp.moveaxis(data, -1, 0), full_matrices=full_matrices)
+        U = Field(xp.moveaxis(U, 0, -1), f.grid)
+        Vh = Field(xp.moveaxis(Vh, 0, -1), f.grid)
+        S = Field(xp.moveaxis(S, 0, -1), f.grid)
 
-    S = Field(np.moveaxis(S, 0, -1), f.grid)
-
-    if compute_uv:
         return U, S, Vh
     else:
+        S = xp.linalg.svdvals(xp.moveaxis(data, -1, 0))
+        S = Field(xp.moveaxis(S, 0, -1), f.grid)
+
         return S
 
 def field_conjugate_transpose(a):
@@ -374,13 +405,17 @@ def field_conjugate_transpose(a):
         if a.tensor_order != 2:
             raise ValueError('Need a tensor field of rank 2.')
 
-        return Field(np.swapaxes(a.conj(), 0, 1), a.grid)
+        data = _normalize_field(a)
+        xp = array_namespace(data)
+        res = xp.permute_dims(xp.conj(data), (1, 0, 2))
+        return Field(res, a.grid)
     else:
         # if its an array, it must be two dimensional
         if len(a.shape) != 2:
             raise ValueError('Need a two dimensional array.')
 
-        return np.swapaxes(a.conj(), 0, 1)
+        xp = array_namespace(a)
+        return xp.permute_dims(xp.conj(a), (1, 0))
 
 def field_transpose(a):
     '''Performs the transpose of a rank 2 tensor field or two dimensional array.
@@ -401,13 +436,17 @@ def field_transpose(a):
         if a.tensor_order != 2:
             raise ValueError('Need a tensor field of rank 2.')
 
-        return Field(np.swapaxes(a, 0, 1), a.grid)
+        data = _normalize_field(a)
+        xp = array_namespace(data)
+        res = xp.permute_dims(data, (1, 0, 2))
+        return Field(res, a.grid)
     else:
         # if its an array, it must be two dimensional
         if len(a.shape) != 2:
             raise ValueError('Need a two dimensional array.')
 
-        return np.swapaxes(a, 0, 1)
+        xp = array_namespace(a)
+        return xp.permute_dims(a, (1, 0))
 
 def field_determinant(a):
     '''Calculates the determinant of a tensor field.
@@ -431,10 +470,12 @@ def field_determinant(a):
     if not all(n == a.tensor_shape[0] for n in a.tensor_shape):
         raise ValueError('Need square matrix for determinant.')
 
-    # First we need to swap the axes in order to use np.linalg.det
-    Temp = np.swapaxes(a, 0, 2)
+    # First we need to swap the axes in order to use xp.linalg.det
+    data = _normalize_field(a)
+    xp = array_namespace(data)
+    Temp = xp.permute_dims(data, (2, 0, 1))
 
-    return Field(np.linalg.det(Temp), a.grid)
+    return Field(xp.linalg.det(Temp), a.grid)
 
 def field_adjoint(a):
     '''Calculates the adjoint of a tensor field.
@@ -455,10 +496,14 @@ def field_adjoint(a):
     # Calculating the determinant.
     determinant = field_determinant(a)
 
-    if np.any(np.isclose(determinant, 0)):
+    det_data = _normalize_field(determinant)
+    xp = array_namespace(det_data)
+
+    if xp.any(xp.abs(det_data) <= 1e-8):
         raise ValueError('Matrix is non-invertible due to zero determinant.')
 
-    return Field(determinant[np.newaxis, np.newaxis, :] * field_inv(a), a.grid)
+    res = xp.reshape(det_data, (1, 1, -1)) * _normalize_field(field_inv(a))
+    return Field(res, a.grid)
 
 def field_cross(a, b):
     '''Calculates the cross product of two vector fields.
@@ -481,7 +526,11 @@ def field_cross(a, b):
     if a.shape[0] != 3 or b.shape[0] != 3:
         raise ValueError('Vector needs to be of length 3 for cross product.')
 
-    return Field(np.cross(a, b, axis=0), a.grid)
+    a_data = _normalize_field(a)
+    b_data = _normalize_field(b)
+    xp = array_namespace(a_data, b_data)
+
+    return Field(xp.linalg.cross(a_data, b_data, axis=-2), a.grid)
 
 def field_kron(a, b):
     '''Calculate the Kronecker product of two fields.

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -4,195 +4,196 @@ import numpy as np
 import copy
 import pytest
 import pickle
+from hcipy._math.random import make_random_generator
+from hcipy._math.backends import all_close
+
+if Configuration().core.use_new_style_fields:
+    import array_api_strict as xp
+else:
+    import numpy as xp
 
 def test_field_dot():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    a = np.random.randn(3, grid.size)
-    A = np.random.randn(3, 3, grid.size)
+    rng = make_random_generator(xp)
+    a = rng.normal(size=(3, grid.size))
+    A = rng.normal(size=(3, 3, grid.size))
 
     a = Field(a, grid)
     A = Field(A, grid)
 
     b = field_dot(A, a)
-    bb = np.array([A[..., i].dot(a[..., i]) for i in range(grid.size)]).T
+    bb = xp.stack([xp.matmul(A[..., i].data, a[..., i].data) for i in range(grid.size)]).T
+    bb = Field(bb, grid)
 
-    assert np.allclose(b, bb)
+    assert all_close(b, bb)
 
     b = field_dot(a, a)
-    bb = np.array([a[..., i].dot(a[..., i]) for i in range(grid.size)]).T
+    bb = xp.stack([xp.matmul(a[..., i].data, a[..., i].data) for i in range(grid.size)])
+    bb = Field(bb, grid)
 
-    assert np.allclose(b, bb)
+    assert all_close(b, bb)
 
     B = field_dot(A, A)
-    BB = np.empty_like(B)
+    BB = xp.empty_like(B.data)
     for i in range(grid.size):
-        BB[..., i] = A[..., i].dot(A[..., i])
+        BB[..., i] = xp.matmul(A[..., i].data, A[..., i].data)
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
     b = field_dot(a, a)
-    bb = np.array([a[..., i].dot(a[..., i]) for i in range(grid.size)])
+    bb = xp.stack([xp.matmul(a[..., i].data, a[..., i].data) for i in range(grid.size)])
 
-    assert np.allclose(b, bb)
+    assert all_close(b, bb)
 
-    n = np.random.randn(3)
+    n = rng.normal(size=3)
 
     b = field_dot(A, n)
-    bb = np.array([A[..., i].dot(n) for i in range(grid.size)]).T
+    bb = xp.stack([xp.matmul(A[..., i].data, n) for i in range(grid.size)]).T
 
-    assert np.allclose(b, bb)
+    assert all_close(b, bb)
 
     b = field_dot(n, A)
-    bb = np.array([n.dot(A[..., i]) for i in range(grid.size)]).T
+    bb = xp.stack([xp.matmul(n, A[..., i].data) for i in range(grid.size)]).T
 
-    assert np.allclose(b, bb)
+    assert all_close(b, bb)
 
-    N = np.random.randn(3, 3)
+    N = rng.normal(size=(3, 3))
 
     B = field_dot(A, N)
-    BB = np.empty_like(B)
+    BB = xp.empty_like(B.data)
     for i in range(grid.size):
-        BB[..., i] = A[..., i].dot(N)
+        BB[..., i] = xp.matmul(A[..., i].data, N)
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
 def test_field_trace():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     B = field_trace(A)
-    BB = np.array([np.trace(A[..., i]) for i in range(grid.size)])
+    BB = xp.stack([xp.linalg.trace(A[..., i].data) for i in range(grid.size)])
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
 def test_field_inv():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     B = field_inv(A)
-    BB = np.empty_like(B)
-    for i in range(grid.size):
-        BB[..., i] = np.linalg.inv(A[..., i])
+    BB = xp.stack([xp.linalg.inv(A[..., i].data) for i in range(grid.size)], axis=-1)
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
 def test_field_transpose():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     B = field_transpose(A)
-    BB = np.empty_like(B)
-    for i in range(grid.size):
-        BB[..., i] = A[..., i].T
+    BB = xp.stack([xp.permute_dims(A[..., i].data, (1, 0)) for i in range(grid.size)], axis=-1)
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
 def test_field_conjugate_transpose():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     B = field_conjugate_transpose(A)
-    BB = np.empty_like(B)
-    for i in range(grid.size):
-        BB[..., i] = A[..., i].T.conj()
+    BB = xp.stack([xp.permute_dims(xp.conj(A[..., i].data), (1, 0)) for i in range(grid.size)], axis=-1)
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
 def test_field_adjoint():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     B = field_adjoint(A)
-    BB = np.empty_like(B)
-    for i in range(grid.size):
-        BB[..., i] = np.linalg.inv(A[..., i]) * np.linalg.det(A[..., i])
+    BB = xp.stack([xp.linalg.inv(A[..., i].data) * xp.linalg.det(A[..., i].data) for i in range(grid.size)], axis=-1)
 
-    assert np.allclose(B, BB)
+    assert all_close(B, BB)
 
 def test_field_inverse_tikhonov():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     for reg in [1e-1, 1e-3, 1e-6]:
         B = field_inverse_tikhonov(A, reg)
-        BB = np.empty_like(B)
+        BB = xp.stack([xp.asarray(inverse_tikhonov(A[..., i].data, reg)) for i in range(grid.size)], axis=-1)
 
-        for i in range(grid.size):
-            BB[..., i] = inverse_tikhonov(A[..., i], reg)
-
-        assert np.allclose(B, BB)
+        assert all_close(B, BB)
 
 def test_field_inverse_truncated():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     for reg in [1e-1, 1e-3, 1e-6]:
         B = field_inverse_truncated(A, reg)
-        BB = np.empty_like(B)
+        BB = xp.stack([xp.asarray(inverse_truncated(A[..., i].data, reg)) for i in range(grid.size)], axis=-1)
 
-        for i in range(grid.size):
-            BB[..., i] = inverse_truncated(A[..., i], reg)
-
-        assert np.allclose(B, BB)
+        assert all_close(B, BB)
 
 def test_field_inverse_truncated_modal():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, 3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, 3, grid.size)), grid)
 
     for num_modes in [1, 2]:
         B = field_inverse_truncated_modal(A, num_modes)
-        BB = np.empty_like(B)
+        BB = xp.stack([xp.asarray(inverse_truncated_modal(xp.asarray(A[..., i].data), num_modes)) for i in range(grid.size)], axis=-1)
 
-        for i in range(grid.size):
-            BB[..., i] = inverse_truncated_modal(np.asarray(A[..., i]), num_modes)
-
-        assert np.allclose(B, BB)
+        assert all_close(B, BB)
 
 def test_field_cross():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(3, grid.size), grid)
-    B = Field(np.random.randn(3, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(3, grid.size)), grid)
+    B = Field(rng.normal(size=(3, grid.size)), grid)
 
     C = field_cross(A, B)
-    CC = np.empty_like(C)
-    for i in range(grid.size):
-        CC[..., i] = np.cross(A[:, i], B[:, i])
+    CC = xp.stack([xp.linalg.cross(A[..., i].data, B[..., i].data) for i in range(grid.size)], axis=-1)
 
-    assert np.allclose(C, CC)
+    assert all_close(C, CC)
 
 def test_field_svd():
-    grid = make_pupil_grid(2)
+    grid = make_pupil_grid(2, xp=xp)
 
-    A = Field(np.random.randn(5, 10, grid.size), grid)
+    rng = make_random_generator(xp)
+    A = Field(rng.normal(size=(5, 10, grid.size)), grid)
 
     U, S, Vh = field_svd(A)
     u, s, vh = field_svd(A, False)
 
     for i in range(grid.size):
-        svd = np.linalg.svd(A[..., i])
+        svd = xp.linalg.svd(A[..., i].data)
 
-        assert np.allclose(U[..., i], svd[0])
-        assert np.allclose(S[..., i], svd[1])
-        assert np.allclose(Vh[..., i], svd[2])
+        assert all_close(U[..., i], svd[0])
+        assert all_close(S[..., i], svd[1])
+        assert all_close(Vh[..., i], svd[2])
 
-        svd2 = np.linalg.svd(A[..., i], full_matrices=False)
+        svd2 = xp.linalg.svd(A[..., i].data, full_matrices=False)
 
-        assert np.allclose(u[..., i], svd2[0])
-        assert np.allclose(s[..., i], svd2[1])
-        assert np.allclose(vh[..., i], svd2[2])
+        assert all_close(u[..., i], svd2[0])
+        assert all_close(s[..., i], svd2[1])
+        assert all_close(vh[..., i], svd2[2])
 
 def test_grid_hashing_and_comparison():
-    grid1 = make_pupil_grid(128)
+    grid1 = make_pupil_grid(128, xp=xp)
 
     grid2 = CartesianGrid(SeparatedCoords(copy.deepcopy(grid1.separated_coords)))
     assert hash(grid1) != hash(grid2)
@@ -206,7 +207,7 @@ def test_grid_hashing_and_comparison():
     assert grid2 != grid3
     assert grid3 != grid2
 
-    grid4 = make_pupil_grid(128)
+    grid4 = make_pupil_grid(128, xp=xp)
     print('start')
     assert hash(grid1) == hash(grid4)
     assert grid1 == grid4
@@ -230,7 +231,7 @@ def test_grid_hashing_and_comparison():
     assert grid1 != grid8
     assert grid7 == grid8
 
-    grid9 = make_pupil_grid(256)
+    grid9 = make_pupil_grid(256, xp=xp)
     assert hash(grid1) != hash(grid9)
     assert grid1 != grid9
 
@@ -242,17 +243,17 @@ def test_grid_hashing_and_comparison():
     assert grid1 != 'string'
 
 def test_grid_supersampled():
-    g = make_uniform_grid(128, [1, 1])
+    g = make_uniform_grid(128, [1, 1], xp=xp)
     g2 = make_supersampled_grid(g, 4)
     g3 = make_subsampled_grid(g2, 4)
 
-    assert np.allclose(g.x, g3.x)
-    assert np.allclose(g.y, g3.y)
+    assert all_close(g.x, g3.x)
+    assert all_close(g.y, g3.y)
 
     g4 = make_supersampled_grid(make_supersampled_grid(g, 2), 2)
 
-    assert np.allclose(g2.x, g4.x)
-    assert np.allclose(g2.y, g4.y)
+    assert all_close(g2.x, g4.x)
+    assert all_close(g2.y, g4.y)
 
 def allclose(x1, x2, /, *, rtol=1e-5, atol=1e-8):
     xp = x1.__array_namespace__()
@@ -269,7 +270,7 @@ def allclose(x1, x2, /, *, rtol=1e-5, atol=1e-8):
 
 @pytest.mark.parametrize('Field', [hcipy.field.NewStyleField, hcipy.field.OldStyleField])
 def test_field_arithmetic(Field):
-    grid = make_pupil_grid(16)
+    grid = make_pupil_grid(16, xp=xp)
 
     M = np.random.randn(grid.size, grid.size)
 
@@ -279,7 +280,7 @@ def test_field_arithmetic(Field):
     a = Field(a_data, grid)
     b = Field(b_data, grid)
 
-    xp = a.__array_namespace__()
+    fxps = a.__array_namespace__()
 
     assert allclose(a, b)
     assert allclose(a + b, 2)
@@ -289,7 +290,7 @@ def test_field_arithmetic(Field):
     assert is_field(a + b)
     assert is_field(a - b)
     assert is_field(a * b)
-    assert is_field(xp.exp(2j * a))
+    assert is_field(fxps.exp(2j * a))
 
     assert is_field(a.conj())
     assert is_field(a.conjugate())
@@ -314,7 +315,7 @@ def test_field_arithmetic(Field):
 
 @pytest.mark.parametrize('Field', [hcipy.field.NewStyleField, hcipy.field.OldStyleField])
 def test_field_pickle(Field):
-    grid = make_pupil_grid(16)
+    grid = make_pupil_grid(16, xp=xp)
 
     a = Field(np.ones(grid.size), grid)
 
@@ -323,4 +324,3 @@ def test_field_pickle(Field):
 
     assert allclose(a, b)
     assert a.grid == b.grid
-

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -694,13 +694,14 @@ def test_einsum_dtype(xp, dtype):
         a = a + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(4, 5)), dtype_xp)
         b = b + xp.asarray(1j, dtype=dtype_xp) * xp.astype(rng.normal(size=(5, 6)), dtype_xp)
 
+    rtol = 1e-6 if xp.finfo(dtype_xp).bits <= 32 else 1e-14
     atol = 1e-6 if xp.finfo(dtype_xp).bits <= 32 else 1e-14
 
     expected = np.einsum("ij,jk->ik", np.asarray(a), np.asarray(b))
     got = einsum("ij,jk->ik", a, b)
 
     assert got.dtype == dtype_xp
-    np.testing.assert_allclose(np.asarray(got), expected, atol=atol)
+    np.testing.assert_allclose(np.asarray(got), expected, rtol=rtol, atol=atol)
 
 def test_einsum_int_input(xp):
     a = xp.asarray([[1, 2], [3, 4]])


### PR DESCRIPTION
## Summary

This PR makes HCIPy's field operations work with the new array-API backend. This makes all tests of the core of HCIPy work for both new and old-style fields. All tensor operations (`field_einsum`, `field_dot`, `field_inv`, `field_svd`, `field_transpose`, `field_conjugate_transpose`, `field_determinant`, `field_adjoint`, `field_cross`, and the regularized inverses) now dispatch through the array-API namespace inferred from the field data — including a shared `_normalize_field()` helper for unwrapping new-style field data.

The field-operation tests rewritten to be backend-agnostic, exercising the operations against both `array_api_strict` and numpy backends and asserting equivalence to elementwise reference computations.