### PR TITLE
Add tests for performing Fourier transforms on tensor fields.

### DIFF
--- a/hcipy/fourier/zoom_fast_fourier_transform.py
+++ b/hcipy/fourier/zoom_fast_fourier_transform.py
@@ -81,12 +81,17 @@ class ZoomFastFourierTransform(FourierTransform):
         '''
         self._compute_shifts_and_weights(field.dtype)
 
+        # The CZT is applied along the last axis, so each grid axis (which are
+        # the trailing axes of the shaped field, with any tensor axes leading)
+        # is moved to the last position, transformed, and moved back.
         f = (field * self.input_weights).shaped
 
         for i, (czt, shift) in enumerate(zip(self.czts, self.shifts)):
-            f = np.moveaxis(f, -i, 0)
+            axis = -i - 1
+
+            f = np.moveaxis(f, axis, -1)
             f = czt(f) * shift
-            f = np.moveaxis(f, -i, 0)
+            f = np.moveaxis(f, -1, axis)
 
         shape = tuple(field.tensor_shape) + (-1,)
 
@@ -110,9 +115,11 @@ class ZoomFastFourierTransform(FourierTransform):
         f = (field * self.output_weights).shaped
 
         for i, (czt, shift) in enumerate(zip(self.inv_czts, self.inv_shifts)):
-            f = np.moveaxis(f, -i, 0)
+            axis = -i - 1
+
+            f = np.moveaxis(f, axis, -1)
             f = czt(f) * shift
-            f = np.moveaxis(f, -i, 0)
+            f = np.moveaxis(f, -1, axis)
 
         shape = tuple(field.tensor_shape) + (-1,)
 

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -270,6 +270,43 @@ def test_mft_precomputations():
             assert (mft.M1 is not None) == precompute_matrices
             assert (mft.intermediate_array is not None) == allocate_intermediate
 
+def _apply_per_component(func, field):
+    if field.is_scalar_field:
+        return func(field)
+
+    f = field.reshape((-1, field.grid.size))
+    res = [func(Field(ff, field.grid)) for ff in f]
+
+    new_shape = tuple(field.tensor_shape) + (-1,)
+    return Field(np.array(res).reshape(new_shape), field.grid)
+
+@pytest.mark.parametrize('tensor_shape', [(3,), (3, 2), (4, 3, 2)])
+@pytest.mark.parametrize('dims', [16, [16, 17]])
+def test_fourier_transform_tensor_fields(tensor_shape, dims):
+    np.random.seed(0)
+
+    input_grid = make_uniform_grid(dims, 1, has_center=True).shifted(0.1)
+
+    f_shape = tensor_shape + (input_grid.size,)
+    f_in = Field(np.random.randn(*f_shape) + 1j * np.random.randn(*f_shape), input_grid).astype(np.complex128)
+
+    fourier_transforms = make_all_fourier_transforms(input_grid, q=1.3, fov=0.8, shift=0.1)
+
+    for ft in fourier_transforms:
+        # Check the forward transform against a manual loop over the tensor components.
+        f_out = ft.forward(f_in)
+        f_out_ref = _apply_per_component(ft.forward, f_in)
+
+        assert f_out.shape == f_out_ref.shape
+        assert np.allclose(f_out, f_out_ref)
+
+        # Check the backward transform against a manual loop over the tensor components.
+        f_in_roundtrip = ft.backward(f_out)
+        f_in_roundtrip_ref = _apply_per_component(ft.backward, f_out)
+
+        assert f_in_roundtrip.shape == f_in_roundtrip_ref.shape
+        assert np.allclose(f_in_roundtrip, f_in_roundtrip_ref)
+
 def test_fourier_filter():
     for n in [16, 17, [16, 17]]:
         for q in [1, 2, 3]:

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -278,7 +278,7 @@ def _apply_per_component(func, field):
     res = [func(Field(ff, field.grid)) for ff in f]
 
     new_shape = tuple(field.tensor_shape) + (-1,)
-    return Field(np.array(res).reshape(new_shape), field.grid)
+    return Field(np.array(res).reshape(new_shape), res[0].grid)
 
 @pytest.mark.parametrize('tensor_shape', [(3,), (3, 2), (4, 3, 2)])
 @pytest.mark.parametrize('dims', [16, [16, 17]])
@@ -298,6 +298,7 @@ def test_fourier_transform_tensor_fields(tensor_shape, dims):
         f_out_ref = _apply_per_component(ft.forward, f_in)
 
         assert f_out.shape == f_out_ref.shape
+        assert f_out.grid == f_out_ref.grid
         assert np.allclose(f_out, f_out_ref)
 
         # Check the backward transform against a manual loop over the tensor components.
@@ -305,6 +306,7 @@ def test_fourier_transform_tensor_fields(tensor_shape, dims):
         f_in_roundtrip_ref = _apply_per_component(ft.backward, f_out)
 
         assert f_in_roundtrip.shape == f_in_roundtrip_ref.shape
+        assert f_in_roundtrip.grid == f_in_roundtrip_ref.grid
         assert np.allclose(f_in_roundtrip, f_in_roundtrip_ref)
 
 def test_fourier_filter():


### PR DESCRIPTION
Add a test for the correctness of Fourier transforms over tensor fields. The Fourier transform should broadcast over the tensor dimensions, as if each component is Fourier transformed independently.

This PR also fixes a bug in `ZoomFastFourierTransform` which performed its transforms around the wrong axes when given a non-scalar field.