### PR TITLE
Kirchhoff-Love vibration modes

### DIFF
--- a/doc/tutorial_notebooks/KirchhoffLoveModes/KirchhoffLoveModes.ipynb
+++ b/doc/tutorial_notebooks/KirchhoffLoveModes/KirchhoffLoveModes.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5292e03",
+   "metadata": {},
+   "source": [
+    "# Kirchhoff-Love modes of a clamped hexagonal membrane\n",
+    "\n",
+    "We will calculate the vibrational modes of a flat, free hexagonal membrane with a spatially varying bending stiffness, clamped to an external surface at three points. The modes are calculated using Kirchhoff-Love plate theory.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcbeaa73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from hcipy import *\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b68a4e1",
+   "metadata": {},
+   "source": [
+    "The Kirchhoff-Love theory describes the deflection of a thin elastic plate. For free vibration, the deflection $u(x)$ is the solution of the generalized eigenvalue problem\n",
+    "\n",
+    "$$ K u = \\omega^2 M u, $$\n",
+    "\n",
+    "where $K$ is the bending-stiffness matrix and $M$ the mass matrix. Both are assembled on the grid from the bending stiffness $D(x)$ of the membrane. The resulting eigenvectors are the mode shapes, sorted by ascending natural frequency $\\omega$. In HCIPy this is done by `make_kirchhoff_love_basis()`, which takes the bending stiffness as a `Field` on a regular Cartesian grid.\n",
+    "\n",
+    "We start with a hexagonal membrane, defined through `make_hexagonal_aperture()`. The grid has to extend beyond the membrane; the membrane itself is left unclamped at its edge, and the free (natural) edge conditions emerge from the variational discretization of the bending energy.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eedd603c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circum_diameter = 1\n",
+    "\n",
+    "grid = make_pupil_grid(128, 1.2)\n",
+    "bending_stiffness = make_hexagonal_aperture(circum_diameter)(grid)\n",
+    "\n",
+    "imshow_field(bending_stiffness, cmap='Greys')\n",
+    "plt.title('Bending stiffness of the hexagonal membrane')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "921349a5",
+   "metadata": {},
+   "source": [
+    "The membrane is clamped to an external surface at three points. These clamping points are circular patches, centered about half the circumdiameter of the hexagon, in the direction of three alternating vertices. At these points the deflection is required to be zero, which is passed to `make_kirchhoff_love_basis()` through the `fixed_points` keyword.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac4b65dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patch_diameter = 0.1\n",
+    "vertex_angles = np.deg2rad([90, 210, 330])\n",
+    "\n",
+    "fixed_points = Field(np.zeros(grid.size), grid)\n",
+    "\n",
+    "for angle in vertex_angles:\n",
+    "    center = circum_diameter / 4 * np.array([np.cos(angle), np.sin(angle)])\n",
+    "    patch = make_circular_aperture(patch_diameter, center=center)(grid)\n",
+    "    fixed_points += patch > 0.5\n",
+    "\n",
+    "fixed_points = fixed_points > 0\n",
+    "\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "\n",
+    "plt.subplot(1, 2, 1)\n",
+    "imshow_field(bending_stiffness, cmap='Greys')\n",
+    "plt.title('Membrane')\n",
+    "\n",
+    "plt.subplot(1, 2, 2)\n",
+    "imshow_field(fixed_points, cmap='Greys')\n",
+    "plt.title('Clamping points')\n",
+    "\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a61b80db",
+   "metadata": {},
+   "source": [
+    "Now we can calculate the modes of the membrane.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86cd23fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_modes = 9\n",
+    "\n",
+    "modes, frequencies = make_kirchhoff_love_basis(bending_stiffness, num_modes, fixed_points=fixed_points, return_frequencies=True)\n",
+    "\n",
+    "for i, f in enumerate(frequencies):\n",
+    "    print('Mode {}: frequency = {:.3e} Hz'.format(i, f))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d339da0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14, 12))\n",
+    "\n",
+    "for i, mode in enumerate(modes):\n",
+    "    m = mode / np.max(np.abs(mode))\n",
+    "\n",
+    "    plt.subplot(3, 3, i + 1)\n",
+    "    imshow_field(m, cmap='RdBu_r', vmin=-1, vmax=1)\n",
+    "    plt.title('Mode {}'.format(i))\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9df4dd85",
+   "metadata": {},
+   "source": [
+    "Finally, we animate the modes. Each mode oscillates at its natural frequency. If the bending stiffness is in N m, the mass density in kg / m^2, and the grid coordinates in meters, the frequencies are the physical resonance frequencies in Hz. Here all quantities are dimensionless, so we animate the modes with the ratio of the frequencies, so that every mode completes a whole number of oscillation periods per animation.\n",
+    "\n",
+    "We use the `FFMpegWriter` class to write the animation to a video file. The resulting animation is shown inline in the notebook by evaluating the writer object.\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a560297a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N = int(grid.regular_coords[1][0])\n",
+    "\n",
+    "aperture_mask = np.asarray(bending_stiffness).reshape((N, N)) > 0.5\n",
+    "omega = frequencies / frequencies[0]\n",
+    "\n",
+    "plt.figure(figsize=(12, 10))\n",
+    "anim = FFMpegWriter('kirchhoff_love_modes.mp4', framerate=10)\n",
+    "\n",
+    "num_frames = 30\n",
+    "for i in range(num_frames):\n",
+    "    t = 2 * np.pi * i / num_frames\n",
+    "\n",
+    "    plt.clf()\n",
+    "    plt.suptitle('Kirchhoff-Love modes of the clamped hexagonal membrane')\n",
+    "\n",
+    "    for j, mode in enumerate(modes):\n",
+    "        m = np.asarray(mode).reshape((N, N)) / np.max(np.abs(mode))\n",
+    "        m = np.where(aperture_mask, m * np.cos(omega[j] * t), np.nan)\n",
+    "\n",
+    "        plt.subplot(3, 3, j + 1)\n",
+    "        plt.imshow(m, cmap='RdBu_r', vmin=-1, vmax=1)\n",
+    "        plt.title('Mode {}'.format(j))\n",
+    "        plt.axis('off')\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    anim.add_frame()\n",
+    "\n",
+    "plt.close()\n",
+    "anim.close()\n",
+    "\n",
+    "# Show the animation\n",
+    "anim\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "138a0a50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove created files.\n",
+    "import os\n",
+    "os.remove('kirchhoff_love_modes.mp4')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
+  },
+  "level": "intermediate",
+  "thumbnail_figure_index": -1
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/hcipy/mode_basis/__init__.py
+++ b/hcipy/mode_basis/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     'disk_harmonic',
     'disk_harmonic_energy',
     'make_disk_harmonic_basis',
+    'make_kirchhoff_love_basis',
 ]
 
 from .disk_harmonic import *
@@ -35,6 +36,7 @@ from .gaussian_hermite import *
 from .gaussian_laguerre import *
 from .gaussian_pokes import *
 from .karhunen_loeve import *
+from .kirchhoff_love import *
 from .mode_basis import *
 from .lp_fiber_modes import *
 from .zernike import *

--- a/hcipy/mode_basis/kirchhoff_love.py
+++ b/hcipy/mode_basis/kirchhoff_love.py
@@ -1,0 +1,282 @@
+import numpy as np
+import scipy.sparse
+import scipy.sparse.linalg
+from scipy.ndimage import binary_dilation, label
+
+from .mode_basis import ModeBasis
+from ..field import Field
+
+def make_kirchhoff_love_basis(bending_stiffness, num_modes, fixed_points=None,
+                              poisson_ratio=0, mass_density=None, return_frequencies=False):
+    '''Make the mode basis of a flat membrane with Kirchhoff-Love bending.
+
+    The membrane is modelled as a Kirchhoff-Love plate with a possibly
+    varying bending stiffness. The membrane is free (not clamped) at its
+    edge; the free (natural) boundary conditions emerge from a variational
+    discretization of the bending energy. Points of the membrane can be
+    clamped to an external surface through the `fixed_points` parameter.
+
+    The modes are calculated by discretizing the bending energy and the mass
+    of the membrane on the grid, and solving the generalized eigenvalue
+    problem
+
+    .. math:: K u = \\omega^2 M u,
+
+    where `K` and `M` are the discretized bending stiffness and mass matrices,
+    and :math:`\\omega = 2\\pi f` is the angular mode frequency. The modes are
+    sorted by ascending mode frequency :math:`f`.
+
+    Parameters
+    ----------
+    bending_stiffness : Field
+        The bending stiffness :math:`D(x)` of the membrane, on a
+        two-dimensional regular Cartesian grid. Values should be non-negative.
+        The membrane is formed by the points where the value is non-zero. To
+        reproduce a free edge, the active region should be inset from the edge
+        of the grid. In SI units the bending stiffness is in N m (Pa m^3).
+    num_modes : int
+        The number of modes to calculate.
+    fixed_points : Field or None
+        A Field on the same grid as `bending_stiffness`, marking the points
+        (with values above 0.5) at which the membrane is clamped to an
+        external surface. The modes are set to zero at these points. These
+        points don't need to be at the edge of the membrane.
+    poisson_ratio : scalar
+        The Poisson ratio of the material.
+    mass_density : Field or None
+        A Field on the same grid as `bending_stiffness`, giving the mass per
+        unit area of the membrane in kg / m^2. If this is None, a uniform mass
+        density of one is assumed.
+    return_frequencies : boolean
+        If True, the mode frequencies are returned alongside the mode basis.
+
+    Returns
+    -------
+    modes : ModeBasis or tuple
+        The mode basis of the membrane.
+    frequencies : ndarray
+        The mode frequencies :math:`f` in Hz. These are only returned when
+        `return_frequencies` is true. The frequencies are in Hz if the bending
+        stiffness is in N m, the mass density in kg / m^2, and the grid
+        coordinates in meters.
+
+    Raises
+    ------
+    ValueError
+        If the inputs are not valid.
+    '''
+    if not isinstance(bending_stiffness, Field):
+        raise ValueError('bending_stiffness should be a Field.')
+    grid = bending_stiffness.grid
+
+    if not grid.is_('cartesian') or not grid.is_regular:
+        raise ValueError('The grid of bending_stiffness should be a regular Cartesian grid.')
+
+    delta, dims, _ = grid.regular_coords
+
+    if len(dims) != 2:
+        raise ValueError('The grid of bending_stiffness should be two-dimensional.')
+
+    Nx = int(round(dims[0]))
+    Ny = int(round(dims[1]))
+    dx = float(np.asarray(delta)[0])
+    dy = float(np.asarray(delta)[1])
+
+    if dx <= 0 or dy <= 0:
+        raise ValueError('The grid of bending_stiffness should have positive spacing.')
+
+    size_grid = Nx * Ny
+
+    stiffness = np.asarray(bending_stiffness, dtype=float).reshape(-1)
+    if stiffness.size != size_grid:
+        raise ValueError('bending_stiffness should be defined on the grid.')
+    stiffness = stiffness.reshape((Ny, Nx))
+
+    fixed = None
+    if fixed_points is not None:
+        if not isinstance(fixed_points, Field):
+            raise ValueError('fixed_points should be a Field.')
+        fp = np.asarray(fixed_points, dtype=float).reshape(-1)
+        if fp.size != size_grid:
+            raise ValueError('fixed_points should be defined on the same grid as bending_stiffness.')
+        fixed = fp.reshape((Ny, Nx)) > 0.5
+
+    if mass_density is not None:
+        if not isinstance(mass_density, Field):
+            raise ValueError('mass_density should be a Field.')
+        md = np.asarray(mass_density, dtype=float).reshape(-1)
+        if md.size != size_grid:
+            raise ValueError('mass_density should be defined on the same grid as bending_stiffness.')
+        mass = md.reshape((Ny, Nx))
+    else:
+        mass = np.ones((Ny, Nx))
+
+    active = stiffness > 0
+
+    if not np.any(active):
+        raise ValueError('bending_stiffness should be non-zero at at least one point.')
+    if np.any(stiffness < 0):
+        raise ValueError('bending_stiffness should be non-negative.')
+    if np.any(mass[active] < 0):
+        raise ValueError('mass_density should be non-negative on the membrane.')
+
+    # The degrees of freedom are the active points of the membrane, plus a
+    # one-pixel halo around it. The halo allows the free (natural) boundary
+    # conditions to emerge from the variational principle.
+    halo = binary_dilation(active, structure=np.ones((3, 3))) & ~active
+
+    dof = active | halo
+    if fixed is not None:
+        dof[fixed] = False
+
+    node_index = np.full((Ny, Nx), -1, dtype=int)
+    node_index[dof] = np.arange(dof.sum())
+    num_dof = int(dof.sum())
+
+    if num_modes >= num_dof:
+        raise ValueError('num_modes should be smaller than the number of degrees of freedom.')
+
+    ya, xa = np.nonzero(active)
+    n_act = ya.size
+
+    def neighbor(dyi, dxi):
+        iy = ya + dyi
+        ix = xa + dxi
+        inside = (iy >= 0) & (iy < Ny) & (ix >= 0) & (ix < Nx)
+
+        res = np.full(n_act, -1, dtype=int)
+        res[inside] = node_index[np.clip(iy, 0, Ny - 1)[inside], np.clip(ix, 0, Nx - 1)[inside]]
+        return res
+
+    center = node_index[ya, xa]
+    right = neighbor(0, 1)
+    left = neighbor(0, -1)
+    down = neighbor(1, 0)
+    up = neighbor(-1, 0)
+
+    corr_pp = neighbor(1, 1)
+    corr_pm = neighbor(1, -1)
+    corr_mp = neighbor(-1, 1)
+    corr_mm = neighbor(-1, -1)
+
+    def make_stencil(indices, values):
+        '''Zero out the invalid (out of grid / not a degree of freedom) entries.'''
+        bad = indices < 0
+        values = values.copy()
+        values[bad] = 0.0
+        indices = np.maximum(indices, 0)
+        return indices, values
+
+    sxx_i = np.stack([right, center, left], axis=-1)
+    sxx_v = np.zeros_like(sxx_i, dtype=float)
+    sxx_v[:] = 1.0 / dx**2
+    sxx_v[:, 1] = -2.0 / dx**2
+    sxx_i, sxx_v = make_stencil(sxx_i, sxx_v)
+
+    syy_i = np.stack([down, center, up], axis=-1)
+    syy_v = np.zeros_like(syy_i, dtype=float)
+    syy_v[:] = 1.0 / dy**2
+    syy_v[:, 1] = -2.0 / dy**2
+    syy_i, syy_v = make_stencil(syy_i, syy_v)
+
+    sxy_i = np.stack([corr_pp, corr_mm, corr_pm, corr_mp], axis=-1)
+    sxy_v = np.zeros_like(sxy_i, dtype=float)
+    sxy_v[:, 0] = 1.0 / (4 * dx * dy)
+    sxy_v[:, 1] = 1.0 / (4 * dx * dy)
+    sxy_v[:, 2] = -1.0 / (4 * dx * dy)
+    sxy_v[:, 3] = -1.0 / (4 * dx * dy)
+    sxy_i, sxy_v = make_stencil(sxy_i, sxy_v)
+
+    def outer_prods(idx_a, val_a):
+        n, k = idx_a.shape
+        rows = np.broadcast_to(idx_a[:, :, None], (n, k, k)).ravel()
+        cols = np.broadcast_to(idx_a[:, None, :], (n, k, k)).ravel()
+        vals = val_a[:, :, None] * val_a[:, None, :]
+        return rows, cols, vals
+
+    def cross_prods(idx_a, val_a, idx_b, val_b):
+        n = idx_a.shape[0]
+        ka = idx_a.shape[1]
+        kb = idx_b.shape[1]
+        rows = np.broadcast_to(idx_a[:, :, None], (n, ka, kb)).ravel()
+        cols = np.broadcast_to(idx_b[:, None, :], (n, ka, kb)).ravel()
+        vals = val_a[:, :, None] * val_b[:, None, :]
+        return rows, cols, vals
+
+    stiffness_scale = stiffness[ya, xa] * (dx * dy)
+
+    rows = []
+    cols = []
+    vals = []
+
+    # u_xx^2 and u_yy^2 terms.
+    r, c, v = outer_prods(sxx_i, sxx_v)
+    rows.append(r); cols.append(c); vals.append((stiffness_scale[:, None, None] * v).ravel())
+
+    r, c, v = outer_prods(syy_i, syy_v)
+    rows.append(r); cols.append(c); vals.append((stiffness_scale[:, None, None] * v).ravel())
+
+    # 2 (1 - nu) u_xy^2 term.
+    r, c, v = outer_prods(sxy_i, sxy_v)
+    rows.append(r); cols.append(c); vals.append((2 * (1 - poisson_ratio) * stiffness_scale[:, None, None] * v).ravel())
+
+    # 2 nu u_xx u_yy coupling terms.
+    r, c, v = cross_prods(sxx_i, sxx_v, syy_i, syy_v)
+    rows.append(r); cols.append(c); vals.append((poisson_ratio * stiffness_scale[:, None, None] * v).ravel())
+
+    r, c, v = cross_prods(syy_i, syy_v, sxx_i, sxx_v)
+    rows.append(r); cols.append(c); vals.append((poisson_ratio * stiffness_scale[:, None, None] * v).ravel())
+
+    rows_full = np.concatenate(rows)
+    cols_full = np.concatenate(cols)
+    vals_full = np.concatenate(vals)
+
+    K = scipy.sparse.csr_matrix((vals_full, (rows_full, cols_full)), shape=(num_dof, num_dof))
+
+    mass_mat = np.zeros((Ny, Nx))
+    mass_mat[active] = mass[active] * (dx * dy)
+
+    mass_scale = np.max(mass_mat[active])
+
+    if mass_scale == 0:
+        raise ValueError('mass_density should be non-zero at at least one point of the membrane.')
+
+    mass_mat[active] = np.maximum(mass_mat[active], mass_scale * 1e-12)
+    mass_mat[halo] = mass_scale * 1e-9
+
+    M = scipy.sparse.diags(np.maximum(mass_mat[dof], 1e-30))
+
+    num_components = label(active, structure=np.ones((3, 3)))[1]
+    extra = 3 * num_components + 3
+    k_arpack = min(num_modes + extra, num_dof - 1)
+
+    vals_eig, vecs = scipy.sparse.linalg.eigsh(K, k=k_arpack, M=M, sigma=-1.0, which='LM')
+
+    order = np.argsort(vals_eig)
+    vals_eig = vals_eig[order]
+    vecs = vecs[:, order]
+
+    # Remove the rigid-body modes, which have a frequency of zero.
+    threshold = max(np.max(vals_eig) * 1e-8, np.finfo(float).eps)
+    keep = vals_eig > threshold
+
+    if keep.sum() < num_modes:
+        raise ValueError('Not enough modes with a non-zero frequency could be found. Consider increasing the grid resolution, or decreasing num_modes.')
+
+    mode_freqs = vals_eig[keep][:num_modes]
+    mode_vecs = vecs[:, keep][:, :num_modes]
+
+    # Normalize the modes w.r.t. the mass matrix.
+    m_diag = np.asarray(M.diagonal())
+    mode_vecs = mode_vecs / np.sqrt(np.sum(mode_vecs**2 * m_diag[:, None], axis=0))[None, :]
+
+    modes_full = np.zeros((size_grid, num_modes))
+    modes_full[np.flatnonzero(dof)] = mode_vecs
+
+    modes = [Field(modes_full[:, i], grid) for i in range(num_modes)]
+    mode_basis = ModeBasis(modes, grid)
+
+    if return_frequencies:
+        return mode_basis, np.sqrt(mode_freqs) / (2 * np.pi)
+    else:
+        return mode_basis

--- a/tests/test_mode_basis.py
+++ b/tests/test_mode_basis.py
@@ -134,6 +134,80 @@ def test_lp_modes():
             product = np.real(np.sum(m1 * m2.conj() * grid.weights))
             assert np.abs(product - 1 if i == j else 0) <= 1e-2
 
+def test_kirchhoff_love_basis():
+    grid = make_pupil_grid(48)
+    stiffness = make_circular_aperture(1)(grid)
+
+    num_modes = 5
+    modes, frequencies = make_kirchhoff_love_basis(stiffness, num_modes, return_frequencies=True)
+
+    # The modes are orthonormal w.r.t. the mass-weighted inner product,
+    # which is the area-weighted inner product for a uniform mass density.
+    T = modes.transformation_matrix
+    active = np.asarray(stiffness).ravel() > 0
+    gram = (T[active] * np.sqrt(grid.weights)).T @ (T[active] * np.sqrt(grid.weights))
+
+    assert np.allclose(gram, np.eye(num_modes), atol=1e-6)
+
+    # The frequencies are positive, and sorted in ascending order.
+    assert len(frequencies) == num_modes
+    assert np.all(frequencies > 0)
+    assert np.all(np.diff(frequencies) > 0)
+
+def test_kirchhoff_love_basis_units():
+    grid = make_pupil_grid(48)
+    stiffness = make_circular_aperture(1)(grid)
+
+    _, f = make_kirchhoff_love_basis(stiffness, 2, return_frequencies=True)
+
+    # The frequency scales as sqrt(D / (rho h a^4)). Check the scaling
+    # behavior of the returned frequencies, which are in Hz when the inputs
+    # are in SI units.
+    _, f_stiff = make_kirchhoff_love_basis(stiffness * 4, 2, return_frequencies=True)
+    assert np.allclose(f_stiff / f, 2, rtol=1e-3)
+
+    mass = Field(np.full(grid.size, 4.0), grid)
+    _, f_mass = make_kirchhoff_love_basis(stiffness, 2, mass_density=mass, return_frequencies=True)
+    assert np.allclose(f_mass / f, 0.5, rtol=1e-3)
+
+    grid_small = make_pupil_grid(48, 0.5)
+    stiffness_small = make_circular_aperture(0.5)(grid_small)
+    _, f_small = make_kirchhoff_love_basis(stiffness_small, 2, return_frequencies=True)
+    assert np.allclose(f_small / f, 4, rtol=1e-2)
+
+def test_kirchhoff_love_basis_fixed_points():
+    grid = make_pupil_grid(48)
+    stiffness = make_circular_aperture(1)(grid)
+
+    # Clamp the membrane at four points around the center.
+    fp = np.zeros(grid.size)
+    for p in [(-0.25, -0.25), (0.25, -0.25), (-0.25, 0.25), (0.25, 0.25)]:
+        fp[grid.closest_to(p)] = 1
+    fixed_points = Field(fp, grid)
+
+    modes, frequencies = make_kirchhoff_love_basis(stiffness, 5, fixed_points=fixed_points, return_frequencies=True)
+
+    # The modes are zero at the clamping points.
+    for mode in modes:
+        assert np.all(np.abs(np.asarray(mode)[fp > 0.5]) < 1e-10)
+
+    # The clamping points kill the rigid-body modes, so all frequencies are
+    # strictly positive.
+    assert np.all(frequencies > 1e-8)
+
+def test_kirchhoff_love_basis_errors():
+    grid = make_pupil_grid(32)
+    stiffness = make_circular_aperture(1)(grid)
+
+    with pytest.raises(ValueError):
+        make_kirchhoff_love_basis(stiffness.grid, 5)
+
+    with pytest.raises(ValueError):
+        make_kirchhoff_love_basis(stiffness, 5000)
+
+    with pytest.raises(ValueError):
+        make_kirchhoff_love_basis(stiffness, 5, mass_density=Field(np.zeros(grid.size), grid))
+
 def test_sparse_mode_basis():
     transformation_matrix = np.empty((100 * 100, 100))
     for i in range(100):


### PR DESCRIPTION
## Summary

This PR adds `make_kirchhoff_love_basis()` to the `mode_basis` module, which calculates the vibrational modes of a flat membrane described by Kirchhoff-Love plate theory, plus a tutorial demonstrating the functionality with an animated hexagonal membrane clamped at three points.

## New API

`make_kirchhoff_love_basis(bending_stiffness, num_modes, fixed_points=None, poisson_ratio=0, mass_density=None, return_frequencies=False)` takes the bending stiffness $$D(x)$$ as a Field on a regular Cartesian grid; the membrane is formed by the points where the field is non-zero. A `fixed_points` Field optionally marks points clamped to an external surface (modes are exactly zero there). The function returns a `ModeBasis` of `num_modes` modes, plus their frequencies when `return_frequencies=True`. If the bending stiffness is in N·m, the mass density in kg/m², and the grid coordinates in meters, the returned frequencies are the physical resonance frequencies in Hz.

## Implementation

The modes are obtained by a variational discretization of the Kirchhoff-Love bending energy with free (natural) boundary conditions at the membrane edge, which emerge from a one-pixel halo of degrees of freedom around the active region. The resulting sparse generalized eigenvalue problem $$K u = ω² M u$$ is solved with `scipy.sparse.linalg.eigsh` using shift-invert, the mass matrix is assembled from the (possibly non-uniform) mass density with the correct pixel area, rigid-body modes with zero frequency are filtered out, and the modes are normalized with respect to the mass-weighted inner product and sorted by ascending frequency.

## Tests

Three test functions cover the mode basis itself (orthonormality with respect to the mass-weighted inner product, positive and sorted frequencies), the behavior with clamping points (modes vanish exactly at the clamps and all frequencies are strictly positive since the rigid-body modes are suppressed), and the error paths. A fourth test verifies the scaling laws: quadrupling the bending stiffness doubles the frequencies, quadrupling the mass density halves them, and halving the membrane diameter quadruples them.

## Tutorial

A new intermediate-level tutorial `KirchhoffLoveModes` builds a hexagonal membrane on a 1.2-diameter pupil grid with 128 pixels, clamps it at three circular patches centered about half the circumdiameter toward alternating vertices, computes the nine lowest modes, plots them in a 3×3 gallery, and animates them with an FFMpegWriter according to their frequency.

<img width="966" height="449" alt="image" src="https://github.com/user-attachments/assets/ef62959d-fbed-42a2-b738-3d8e151c4334" />

<img width="1324" height="1190" alt="image" src="https://github.com/user-attachments/assets/2f2397c0-cf62-4b98-a240-9c1605209d25" />

## AI

I used Deepseek V4 Flash during preparation of this PR, with manual editing for style, consistency and correctness.