### PR TITLE
Native batching for all Fourier transforms.

### DIFF
--- a/hcipy/fourier/fast_fourier_transform.py
+++ b/hcipy/fourier/fast_fourier_transform.py
@@ -2,7 +2,7 @@ from __future__ import division
 from collections.abc import Iterable
 
 import numpy as np
-from .fourier_transform import FourierTransform, ComputationalComplexity, multiplex_for_tensor_fields, _get_float_and_complex_dtype
+from .fourier_transform import FourierTransform, ComputationalComplexity, _get_float_and_complex_dtype
 from ..field import Field, CartesianGrid, RegularCoords
 from ..config import Configuration
 import numexpr as ne
@@ -256,7 +256,7 @@ class FastFourierTransform(FourierTransform):
 
         self.shape_out = self.output_grid.shape
         self.internal_shape = self.internal_grid.shape
-        self.internal_array = np.zeros(self.internal_shape, 'complex')
+        self.internal_array = None
 
         # Calculate the part of the array in which to insert the input field (for zeropadding).
         if self.internal_shape == self.shape_in:
@@ -320,7 +320,24 @@ class FastFourierTransform(FourierTransform):
         if np.isscalar(self.shift_output) and np.allclose(self.shift_output, 1):
             self.shift_output = None
 
-    @multiplex_for_tensor_fields
+    def _compute_internal_array(self, field):
+        '''(Re)allocate the internal array for the given field if necessary.
+
+        The internal array follows the ``tensor_shape + grid.shape`` layout,
+        with the leading tensor axes of the field.
+        '''
+        _, complex_dtype = _get_float_and_complex_dtype(field.dtype)
+
+        tensor_shape = tuple(field.tensor_shape)
+
+        recompute = self.internal_array is None
+        recompute = recompute or (self.internal_array.dtype != complex_dtype)
+        recompute = recompute or (self.internal_array.ndim != field.grid.ndim + field.tensor_order)
+        recompute = recompute or (self.internal_array.shape[:field.tensor_order] != tensor_shape)
+
+        if recompute:
+            self.internal_array = np.zeros(tensor_shape + self.internal_shape, complex_dtype)
+
     def forward(self, field):
         '''Returns the forward Fourier transform of the :class:`Field` field.
 
@@ -334,37 +351,42 @@ class FastFourierTransform(FourierTransform):
         Field
             The Fourier transform of the field.
         '''
+        self._compute_internal_array(field)
+
+        tensor_shape = tuple(field.tensor_shape)
+        c = (slice(None),) * field.tensor_order
+        axes = tuple(range(-self.ndim, 0))
+
         if self.cutout_input is None:
-            self.internal_array[:] = field.reshape(self.shape_in)
+            self.internal_array[:] = field.reshape(tensor_shape + self.shape_in)
 
             if self.shift_output is not None:
                 self.internal_array *= self.shift_output.reshape(self.shape_in)
         else:
             self.internal_array[:] = 0
-            self.internal_array[self.cutout_input] = field.reshape(self.shape_in)
+            self.internal_array[c + self.cutout_input] = field.reshape(tensor_shape + self.shape_in)
 
             if self.shift_output is not None:
-                self.internal_array[self.cutout_input] *= self.shift_output.reshape(self.shape_in)
+                self.internal_array[c + self.cutout_input] *= self.shift_output.reshape(self.shape_in)
 
         if not self.emulate_fftshifts:
-            self.internal_array = np.fft.ifftshift(self.internal_array)
+            self.internal_array = np.fft.ifftshift(self.internal_array, axes=axes)
 
-        fft_array = _fft_module.fftn(self.internal_array)
+        fft_array = _fft_module.fftn(self.internal_array, axes=axes)
 
         if not self.emulate_fftshifts:
-            fft_array = np.fft.fftshift(fft_array)
+            fft_array = np.fft.fftshift(fft_array, axes=axes)
 
         if self.cutout_output is None:
-            res = fft_array.ravel()
+            res = fft_array.reshape(tensor_shape + (-1,))
         else:
-            res = fft_array[self.cutout_output].ravel()
+            res = fft_array[c + self.cutout_output].reshape(tensor_shape + (-1,))
 
         res *= self.shift_input
 
         float_dtype, complex_dtype = _get_float_and_complex_dtype(field.dtype)
         return Field(res, self.output_grid).astype(complex_dtype, copy=False)
 
-    @multiplex_for_tensor_fields
     def backward(self, field):
         '''Returns the inverse Fourier transform of the :class:`Field` field.
 
@@ -378,26 +400,32 @@ class FastFourierTransform(FourierTransform):
         Field
             The inverse Fourier transform of the field.
         '''
+        self._compute_internal_array(field)
+
+        tensor_shape = tuple(field.tensor_shape)
+        c = (slice(None),) * field.tensor_order
+        axes = tuple(range(-self.ndim, 0))
+
         if self.cutout_output is None:
-            self.internal_array[:] = field.reshape(self.shape_out)
+            self.internal_array[:] = field.reshape(tensor_shape + self.shape_out)
             self.internal_array /= self.shift_input.reshape(self.shape_out)
         else:
             self.internal_array[:] = 0
-            self.internal_array[self.cutout_output] = field.reshape(self.shape_out)
-            self.internal_array[self.cutout_output] /= self.shift_input.reshape(self.shape_out)
+            self.internal_array[c + self.cutout_output] = field.reshape(tensor_shape + self.shape_out)
+            self.internal_array[c + self.cutout_output] /= self.shift_input.reshape(self.shape_out)
 
         if not self.emulate_fftshifts:
-            self.internal_array = np.fft.ifftshift(self.internal_array)
+            self.internal_array = np.fft.ifftshift(self.internal_array, axes=axes)
 
-        fft_array = _fft_module.ifftn(self.internal_array)
+        fft_array = _fft_module.ifftn(self.internal_array, axes=axes)
 
         if not self.emulate_fftshifts:
-            fft_array = np.fft.fftshift(fft_array)
+            fft_array = np.fft.fftshift(fft_array, axes=axes)
 
         if self.cutout_input is None:
-            res = fft_array.ravel()
+            res = fft_array.reshape(tensor_shape + (-1,))
         else:
-            res = fft_array[self.cutout_input].ravel()
+            res = fft_array[c + self.cutout_input].reshape(tensor_shape + (-1,))
 
         if self.shift_output is not None:
                 res /= self.shift_output

--- a/hcipy/fourier/fourier_transform.py
+++ b/hcipy/fourier/fourier_transform.py
@@ -1,5 +1,4 @@
 import numpy as np
-from ..field import Field
 
 from dataclasses import dataclass
 import math
@@ -298,27 +297,6 @@ def make_fourier_transform(input_grid, output_grid=None, q=1, fov=1, shift=0, pl
         return FastFourierTransform(input_grid, q, fov, shift)
     else:
         return options[best_method](input_grid, output_grid)
-
-def multiplex_for_tensor_fields(func):
-    '''A decorator for automatically multiplexing a function over the tensor directions.
-
-    This function is used internally for simplifying the implementation of the Fourier transforms.
-
-    Parameters
-    ----------
-    func : function
-        The function to multiplex. This function gets called for each of the tensor elements.
-    '''
-    def inner(self, field):
-        if field.is_scalar_field:
-            return func(self, field)
-        else:
-            f = field.reshape((-1, field.grid.size))
-            res = [func(self, ff) for ff in f]
-            new_shape = np.concatenate((field.tensor_shape, [-1]))
-            return Field(np.array(res).reshape(new_shape), res[0].grid)
-
-    return inner
 
 def _get_float_and_complex_dtype(dtype):
     '''Return the floating point and complex numpy data types with the same

--- a/hcipy/fourier/matrix_fourier_transform.py
+++ b/hcipy/fourier/matrix_fourier_transform.py
@@ -1,6 +1,6 @@
 import numpy as np
-from scipy.linalg import blas
-from .fourier_transform import FourierTransform, ComputationalComplexity, multiplex_for_tensor_fields, _get_float_and_complex_dtype
+from scipy.linalg import get_blas_funcs
+from .fourier_transform import FourierTransform, ComputationalComplexity, _get_float_and_complex_dtype
 from ..field import Field
 from ..config import Configuration
 from .._math.fourier import dft_matrix_regular, dft_matrix_separated
@@ -143,7 +143,6 @@ class MatrixFourierTransform(FourierTransform):
                 self.intermediate_array = None
                 self.intermediate_dtype = None
 
-    @multiplex_for_tensor_fields
     def forward(self, field):
         '''Returns the forward Fourier transform of the :class:`Field` field.
 
@@ -160,36 +159,47 @@ class MatrixFourierTransform(FourierTransform):
         self._compute_matrices(field.dtype)
         field = field.astype(self.matrices_dtype, copy=False)
 
-        if self.ndim == 1:
-            f = field * self.weights_input
-            res = np.dot(self.M, f)
-        elif self.ndim == 2:
-            # Use handcoded BLAS call. BLAS is better when all inputs are Fortran ordered,
-            # so we apply matrix multiplications on the transpose of each of the arrays
-            # (which are C ordered).
-            if field.dtype == 'complex64':
-                gemm = blas.cgemm
-            else:
-                gemm = blas.zgemm
+        gemm = get_blas_funcs('gemm', dtype=self.matrices_dtype)
 
+        if self.ndim == 1:
             if np.isscalar(self.weights_input):
                 # Weights can be included in the gemm call as that multiplication
                 # happens anyway (and it saves an array copy).
-                f = field.reshape(self.shape_input)
                 alpha = self.weights_input
+                f = field
             else:
                 # Fallback in case the weights is not a scalar.
-                f = (field * self.weights_input).reshape(self.shape_input)
                 alpha = 1
+                f = field * self.weights_input
 
-            gemm(1, self.M2.T, f.T, c=self.intermediate_array.T, overwrite_c=True)
-            res = gemm(alpha, self.intermediate_array.T, self.M1.T).T.reshape(-1)
+            # The leading tensor dimensions act as the batch.
+            res = np.empty(tuple(field.tensor_shape) + (self.M.shape[0],), dtype=self.matrices_dtype)
+
+            for i in np.ndindex(field.tensor_shape):
+                gemm(alpha, f[i][np.newaxis, :], self.M.T, c=res[i][np.newaxis, :], overwrite_c=True)
+        elif self.ndim == 2:
+            if np.isscalar(self.weights_input):
+                # Weights can be included in the gemm call as that multiplication
+                # happens anyway (and it saves an array copy).
+                alpha = self.weights_input
+                f = field
+            else:
+                # Fallback in case the weights is not a scalar.
+                alpha = 1
+                f = field * self.weights_input
+
+            # The leading tensor dimensions act as the batch. Reshape as a 2D array.
+            f = f.reshape(tuple(field.tensor_shape) + self.shape_input)
+            res = np.empty(tuple(field.tensor_shape) + self.shape_output, dtype=self.matrices_dtype)
+
+            for i in np.ndindex(field.tensor_shape):
+                gemm(1, self.M2.T, f[i].T, c=self.intermediate_array.T, overwrite_c=True)
+                gemm(alpha, self.intermediate_array.T, self.M1.T, c=res[i].T, overwrite_c=True)
 
         self._remove_matrices()
 
-        return Field(res, self.output_grid)
+        return Field(res.reshape(tuple(field.tensor_shape) + (-1,)), self.output_grid)
 
-    @multiplex_for_tensor_fields
     def backward(self, field):
         '''Returns the inverse Fourier transform of the :class:`Field` field.
 
@@ -206,36 +216,47 @@ class MatrixFourierTransform(FourierTransform):
         self._compute_matrices(field.dtype)
         field = field.astype(self.matrices_dtype, copy=False)
 
-        if self.ndim == 1:
-            f = field * self.weights_output
-            res = np.dot(self.M.conj().T, f)
-        elif self.ndim == 2:
-            # Use handcoded BLAS call. BLAS is better when all inputs are Fortran ordered,
-            # so we apply matrix multiplications on the transpose of each of the arrays
-            # (which are C ordered). Adjoint is handled by GEMM, which avoids an array
-            # copy for these array as well.
-            if field.dtype == 'complex64':
-                gemm = blas.cgemm
-            else:
-                gemm = blas.zgemm
+        gemm = get_blas_funcs('gemm', dtype=self.matrices_dtype)
 
+        if self.ndim == 1:
             if np.isscalar(self.weights_output):
                 # Weights can be included in the gemm call as that multiplication
                 # happens anyway (and it saves an array copy).
-                f = field.reshape(self.shape_output)
                 alpha = self.weights_output
+                f = field
             else:
                 # Fallback in case the weights is not a scalar.
-                f = (field * self.weights_output).reshape(self.shape_output)
                 alpha = 1
+                f = field * self.weights_output
 
-            # Use trans_a=2 and trans_b=2 to apply the conjugte transpose on the a and b arrays.
-            gemm(1, f.T, self.M1.T, trans_b=2, c=self.intermediate_array.T, overwrite_c=True)
-            res = gemm(alpha, self.M2.T, self.intermediate_array.T, trans_a=2).T.reshape(-1)
+            # The leading tensor dimensions act as the batch.
+            res = np.empty(tuple(field.tensor_shape) + (self.M.shape[1],), dtype=self.matrices_dtype)
+
+            for i in np.ndindex(field.tensor_shape):
+                gemm(alpha, f[i][np.newaxis, :], self.M.T, trans_b=2, c=res[i][np.newaxis, :], overwrite_c=True)
+        elif self.ndim == 2:
+            if np.isscalar(self.weights_output):
+                # Weights can be included in the gemm call as that multiplication
+                # happens anyway (and it saves an array copy).
+                alpha = self.weights_output
+                f = field
+            else:
+                # Fallback in case the weights is not a scalar.
+                alpha = 1
+                f = field * self.weights_output
+
+            # The leading tensor dimensions act as the batch. Reshape as a 2D array.
+            f = f.reshape(tuple(field.tensor_shape) + self.shape_output)
+            res = np.empty(tuple(field.tensor_shape) + self.shape_input, dtype=self.matrices_dtype)
+
+            # Use trans_a=2 and trans_b=2 to apply the conjugate transpose on the a and b arrays.
+            for i in np.ndindex(field.tensor_shape):
+                gemm(1, f[i].T, self.M1.T, trans_b=2, c=self.intermediate_array.T, overwrite_c=True)
+                gemm(alpha, self.M2.T, self.intermediate_array.T, trans_a=2, c=res[i].T, overwrite_c=True)
 
         self._remove_matrices()
 
-        return Field(res, self.input_grid)
+        return Field(res.reshape(tuple(field.tensor_shape) + (-1,)), self.input_grid)
 
     @classmethod
     def check_if_supported(cls, input_grid, output_grid):

--- a/hcipy/fourier/naive_fourier_transform.py
+++ b/hcipy/fourier/naive_fourier_transform.py
@@ -1,8 +1,10 @@
 import numpy as np
+import math
 
 from .fourier_transform import FourierTransform, ComputationalComplexity, _get_float_and_complex_dtype
 from ..field import Field
 from ..config import Configuration
+from .._math.einsum import einsum
 
 class NaiveFourierTransform(FourierTransform):
     '''The naive Fourier transform (NFT).
@@ -92,10 +94,10 @@ class NaiveFourierTransform(FourierTransform):
             The Fourier transform of the field.
         '''
         if self.precompute_matrices:
-            res = np.einsum('ij,...j->...i', self.matrix_forward, field)
+            res = einsum('ij,...j->...i', self.matrix_forward, field)
         else:
             A = np.exp(-1j * np.dot(self.coords_out.T, self.coords_in))
-            res = np.einsum('ij,...j->...i', A, field * self.input_grid.weights)
+            res = einsum('ij,...j->...i', A, field * self.input_grid.weights)
 
         float_dtype, complex_dtype = _get_float_and_complex_dtype(field.dtype)
         return Field(res, self.output_grid).astype(complex_dtype, copy=False)
@@ -114,11 +116,11 @@ class NaiveFourierTransform(FourierTransform):
             The inverse Fourier transform of the field.
         '''
         if self.precompute_matrices:
-            res = np.einsum('ij,...j->...i', self.matrix_backward, field)
+            res = einsum('ij,...j->...i', self.matrix_backward, field)
         else:
             A = np.exp(1j * np.dot(self.coords_in.T, self.coords_out))
-            res = np.einsum('ij,...j->...i', A, field * self.output_grid.weights)
-            res /= (2 * np.pi)**self.input_grid.ndim
+            res = einsum('ij,...j->...i', A, field * self.output_grid.weights)
+            res /= (2 * math.pi)**self.input_grid.ndim
 
         float_dtype, complex_dtype = _get_float_and_complex_dtype(field.dtype)
         return Field(res, self.input_grid).astype(complex_dtype, copy=False)
@@ -174,5 +176,5 @@ class NaiveFourierTransform(FourierTransform):
         return ComputationalComplexity(
             num_multiplications=num_multiplications,
             num_additions=num_additions,
-            expected_execution_time=np.inf
+            expected_execution_time=math.inf
         )

--- a/hcipy/fourier/naive_fourier_transform.py
+++ b/hcipy/fourier/naive_fourier_transform.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .fourier_transform import FourierTransform, ComputationalComplexity, multiplex_for_tensor_fields, _get_float_and_complex_dtype
+from .fourier_transform import FourierTransform, ComputationalComplexity, _get_float_and_complex_dtype
 from ..field import Field
 from ..config import Configuration
 
@@ -78,7 +78,6 @@ class NaiveFourierTransform(FourierTransform):
 
         return self._matrix_backward
 
-    @multiplex_for_tensor_fields
     def forward(self, field):
         '''Returns the forward Fourier transform of the :class:`Field` field.
 
@@ -93,14 +92,14 @@ class NaiveFourierTransform(FourierTransform):
             The Fourier transform of the field.
         '''
         if self.precompute_matrices:
-            res = self.matrix_forward.dot(field.ravel())
+            res = np.einsum('ij,...j->...i', self.matrix_forward, field)
         else:
-            res = np.array([(field * self.input_grid.weights).dot(np.exp(-1j * np.dot(p, self.coords_in))) for p in self.coords_out.T])
+            A = np.exp(-1j * np.dot(self.coords_out.T, self.coords_in))
+            res = np.einsum('ij,...j->...i', A, field * self.input_grid.weights)
 
         float_dtype, complex_dtype = _get_float_and_complex_dtype(field.dtype)
         return Field(res, self.output_grid).astype(complex_dtype, copy=False)
 
-    @multiplex_for_tensor_fields
     def backward(self, field):
         '''Returns the inverse Fourier transform of the :class:`Field` field.
 
@@ -115,9 +114,10 @@ class NaiveFourierTransform(FourierTransform):
             The inverse Fourier transform of the field.
         '''
         if self.precompute_matrices:
-            res = self.matrix_backward.dot(field.ravel())
+            res = np.einsum('ij,...j->...i', self.matrix_backward, field)
         else:
-            res = np.array([(field * self.output_grid.weights).dot(np.exp(1j * np.dot(p, self.coords_out))) for p in self.coords_in.T])
+            A = np.exp(1j * np.dot(self.coords_in.T, self.coords_out))
+            res = np.einsum('ij,...j->...i', A, field * self.output_grid.weights)
             res /= (2 * np.pi)**self.input_grid.ndim
 
         float_dtype, complex_dtype = _get_float_and_complex_dtype(field.dtype)


### PR DESCRIPTION
## Summary

This PR adds native support for tensor fields to all Fourier transforms. Previously, tensor fields (e.g. polarization vectors) were handled by the `multiplex_for_tensor_fields` decorator, which looped over the tensor components and called the scalar transform once per component, then stacked the results. All Fourier transforms now handle the tensor axes internally in a single pass, removing the decorator entirely and avoiding per-component and copying overhead.

This PR is also using `scipy.linalg.get_blas_funcs()` rather than blas directly.