### PR TITLE
Add linearization of optical systems.

### DIFF
--- a/hcipy/optics/__init__.py
+++ b/hcipy/optics/__init__.py
@@ -38,6 +38,8 @@ __all__ = [
     'make_agnostic_forward',
     'make_agnostic_backward',
     'OpticalSystem',
+    'LinearizedOpticalSystem',
+    'linearize_optical_system',
     'PeriodicOpticalElement',
     'jones_to_mueller',
     'JonesMatrixOpticalElement',
@@ -71,6 +73,7 @@ __all__ = [
 ]
 
 from .optical_element import *
+from .linearization import *
 from .wavefront import *
 
 from .aberration import *

--- a/hcipy/optics/linearization.py
+++ b/hcipy/optics/linearization.py
@@ -1,0 +1,205 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..field import Field, FieldBase
+from ..mode_basis import ModeBasis
+from .wavefront import Wavefront
+
+
+@dataclass
+class LinearizedOpticalSystem:
+    '''The first-order (linearized) response of an optical system to wavefront error modes.
+
+    This model describes the output electric field of an optical system to
+    first order in the coefficients `phi` of a set of wavefront error modes:
+
+    `E_out = static_field + field_response * phi`
+
+    Parameters
+    ----------
+    static_field : Field
+        The complex electric field on the output grid for zero mode coefficients (E_0).
+    field_response : ModeBasis
+        The per-mode response fields on the output grid (G). The columns of this
+        basis are the derivatives of the output electric field with respect to the
+        mode coefficients.
+    modes : ModeBasis
+        The input wavefront error modes, as passed to
+        :func:`linearize_optical_system`.
+    wavelength : scalar
+        The wavelength for which the model was linearized.
+    mode_type : str
+        The semantics of the modes ('opd', 'phase', 'amplitude' or 'field'),
+        documenting the units of the modes and of the mode coefficients.
+    '''
+    static_field: FieldBase
+    field_response: ModeBasis
+    modes: ModeBasis
+    wavelength: float
+    mode_type: str
+
+    @property
+    def input_grid(self):
+        '''The grid on which the modes are defined.
+        '''
+        return self.modes.grid
+
+    @property
+    def output_grid(self):
+        '''The grid on which the output electric field is defined.
+        '''
+        return self.static_field.grid
+
+    def __call__(self, coefficients):
+        '''Evaluate the linearized output electric field for given mode coefficients.
+
+        This evaluates `E = E_0 + G * phi` on the output grid, using a single
+        matrix-vector product without intermediate copies of the response basis.
+
+        Parameters
+        ----------
+        coefficients : ndarray
+            The mode coefficients `phi`, with one entry per mode.
+
+        Returns
+        -------
+        Field
+            The output electric field on the output grid.
+
+        Raises
+        ------
+        ValueError
+            If the number of coefficients does not match the number of modes.
+        '''
+        coefficients = np.asarray(coefficients)
+
+        if coefficients.shape != (self.modes.num_modes,):
+            raise ValueError('The number of coefficients must match the number of modes.')
+
+        return self.static_field + self.field_response.transformation_matrix @ coefficients
+
+def linearize_optical_system(optical_system, aperture, modes, wavelength=1, mode_type='opd'):
+    '''Linearize an optical system with respect to wavefront error modes.
+
+    This function computes the first-order response of an optical system to a
+    set of wavefront error (WFE) modes: `E_out = E_0 + G * phi`, where `phi`
+    are the WFE-mode coefficients and `G` is the complex electric-field
+    sensitivity of the output plane to each mode.
+
+    The linearization is exact: for each mode, a single propagation is used to
+    compute the corresponding response field, with no step size and no finite
+    differences, exploiting the complex-linearity of the optical system.
+
+    Parameters
+    ----------
+    optical_system : OpticalElement or callable
+        The optical system to linearize. This can be anything callable that
+        maps a :class:`Wavefront` to a :class:`Wavefront`. Since
+        `OpticalElement.__call__` is aliased to `forward`, an
+        :class:`OpticalSystem` can be passed as-is. The system must be
+        complex-linear in the electric field; all standard HCIPy optical
+        elements are.
+    aperture : Field or callable
+        The entrance electric field `A`, as a :class:`Field` or a callable
+        (e.g. an HCIPy aperture generator) evaluated on the input grid. The
+        field may be complex.
+    modes : ModeBasis
+        The wavefront error modes. Their semantics are defined by `mode_type`.
+    wavelength : scalar
+        The wavelength for which the model is linearized.
+    mode_type : str
+        The semantics of the modes, and hence the units of the mode
+        coefficients and of the returned response:
+
+        ==============  ==============================================  =====================================
+        `mode_type`     Semantics of a mode `m_j`                      Response column
+        ==============  ==============================================  =====================================
+        'opd'           Optical path difference shape, in meters       `G[:, j] = 1j * k * F(A * m_j)`
+        'phase'         Phase shape, in radians                        `G[:, j] = 1j * F(A * m_j)`
+        'amplitude'     Dimensionless multiplicative amplitude         `G[:, j] = F(A * m_j)`
+        'field'         Additive complex field perturbation, with      `G[:, j] = F(m_j)`
+                        the support included in `m_j`
+        ==============  ==============================================  =====================================
+
+        with `k = 2 * pi / wavelength`.
+
+    Returns
+    -------
+    LinearizedOpticalSystem
+        The linearized optical system, carrying the static field `E_0`, the
+        response basis `G`, the modes, the wavelength and the mode type.
+
+    Raises
+    ------
+    ValueError
+        If `mode_type` is not one of the supported values, or if no input grid
+        can be derived from the modes or the aperture, or if the grids of the
+        modes and the aperture do not match.
+    TypeError
+        If `optical_system` is not callable.
+    '''
+    if not callable(optical_system):
+        raise TypeError('The optical system must be callable with a Wavefront.')
+
+    if mode_type not in ('opd', 'phase', 'amplitude', 'field'):
+        raise ValueError('Unknown mode type %r. Mode type must be one of "opd", "phase", "amplitude" or "field".' % mode_type)
+
+    if isinstance(aperture, Field):
+        aperture_grid = aperture.grid
+    else:
+        aperture_grid = None
+
+    modes_grid = getattr(modes, 'grid', None)
+
+    if modes_grid is not None and aperture_grid is not None and modes_grid != aperture_grid:
+        raise ValueError('The grid of the modes and the grid of the aperture must match.')
+
+    input_grid = modes_grid if modes_grid is not None else aperture_grid
+
+    if input_grid is None:
+        raise ValueError('No input grid could be derived from the modes or the aperture. Supply modes with a grid, or an aperture Field.')
+
+    if modes_grid is None and isinstance(modes, ModeBasis):
+        # Attach the derived input grid to a copy of the modes, so that the
+        # model carries the input grid even when the modes were given without one.
+        modes = ModeBasis(modes.transformation_matrix.copy(), input_grid)
+
+    if isinstance(aperture, Field):
+        aperture_field = aperture
+    else:
+        aperture_field = aperture(input_grid)
+        if not isinstance(aperture_field, Field):
+            raise ValueError('The aperture callable did not return a Field.')
+
+    if not aperture_field.is_valid_field:
+        raise ValueError('The aperture field does not have the correct size for its grid.')
+
+    # The unperturbed propagation. This also discovers the output grid.
+    static_field = optical_system(Wavefront(aperture_field, wavelength)).electric_field
+
+    if mode_type == 'opd':
+        factor = 1j * 2 * np.pi / wavelength
+    elif mode_type == 'phase':
+        factor = 1j
+    else:
+        factor = 1
+
+    response_columns = []
+    for j in range(len(modes)):
+        mode = modes[j]
+
+        if not isinstance(mode, Field):
+            mode = Field(np.asarray(mode), input_grid)
+
+        if mode_type == 'field':
+            input_field = mode
+        else:
+            input_field = aperture_field * mode
+
+        response = optical_system(Wavefront(input_field, wavelength)).electric_field
+        response_columns.append(factor * response)
+
+    field_response = ModeBasis(np.stack(response_columns, axis=-1), static_field.grid)
+
+    return LinearizedOpticalSystem(static_field, field_response, modes, wavelength, mode_type)

--- a/hcipy/optics/linearization.py
+++ b/hcipy/optics/linearization.py
@@ -110,18 +110,10 @@ class LinearizedOpticalSystem:
         ValueError
             If `P` is not a vector of length `r` or a matrix of shape `(r, r)`.
         '''
-        P = np.asarray(P)
-
         if P.ndim == 1:
-            if P.shape != (self.modes.num_modes,):
-                raise ValueError('A vector P must have one entry per mode.')
-
             # diag(G diag(P) G^H) = |G|^2 P, a single matrix-vector product.
             variance = (np.abs(self.field_response.transformation_matrix)**2) @ P
         elif P.ndim == 2:
-            if P.shape != (self.modes.num_modes, self.modes.num_modes):
-                raise ValueError('A matrix P must have shape (num_modes, num_modes).')
-
             # diag(G P G^H) = sum_j (G P)_ij conj(G)_ij, computed via one
             # (n_out, r) intermediate instead of the full (n_out, n_out) matrix.
             G = self.field_response.transformation_matrix
@@ -139,7 +131,7 @@ class LinearizedOpticalSystem:
 
         .. math::
 
-            M = G^H W G,
+            M = \\Re[G^H W G],
 
         with ::math::`W = diag(weights)`. See [Leboulleux2018]_.
 
@@ -150,12 +142,6 @@ class LinearizedOpticalSystem:
             model for Segmented Telescopes Imaging from Space (PASTIS) for sensitivity analysis,"
             Journal of Astronomical Telescopes, Instruments, and Systems, 4(3), 035002 (2018).
             https://doi.org/10.1117/1.JATIS.4.3.035002
-
-        The contribution of a mode-coefficient covariance `P` to the weighted
-        intensity is `trace(M P)`. The matrix is Hermitian; for real symmetric
-        `P`, `trace(M P)` is real and the real part of `M` follows the usual
-        PASTIS convention. It is computed with `(n_out, r)` storage, without
-        materializing the weight matrix.
 
         Parameters
         ----------
@@ -172,16 +158,11 @@ class LinearizedOpticalSystem:
         ValueError
             If the weights do not have one entry per point on the output grid.
         '''
-        weights = np.asarray(weights)
-
-        if weights.shape != (self.output_grid.size,):
-            raise ValueError('The weights must have one entry per point on the output grid.')
-
         # M = G^H W G = (W G)^H G, with the weight matrix applied as a
         # column-wise scaling of the response basis.
         G = self.field_response.transformation_matrix
 
-        return np.asarray((G * weights[:, np.newaxis]).conj().T @ G)
+        return np.real((G * weights[:, np.newaxis]).conj().T @ G)
 
 
 def linearize_optical_system(optical_system, aperture, modes, wavelength=1, mode_type='opd'):
@@ -205,106 +186,58 @@ def linearize_optical_system(optical_system, aperture, modes, wavelength=1, mode
         :class:`OpticalSystem` can be passed as-is. The system must be
         complex-linear in the electric field; all standard HCIPy optical
         elements are.
-    aperture : Field or callable
-        The entrance electric field `A`, as a :class:`Field` or a callable
-        (e.g. an HCIPy aperture generator) evaluated on the input grid. The
-        field may be complex.
+    aperture : Field
+        The entrance electric field `A` on the input grid. The field may be complex.
     modes : ModeBasis
         The wavefront error modes. Their semantics are defined by `mode_type`.
     wavelength : scalar
         The wavelength for which the model is linearized.
     mode_type : str
         The semantics of the modes, and hence the units of the mode
-        coefficients and of the returned response:
-
-        ==============  ==============================================  =====================================
-        `mode_type`     Semantics of a mode `m_j`                      Response column
-        ==============  ==============================================  =====================================
-        'opd'           Optical path difference shape, in meters       `G[:, j] = 1j * k * F(A * m_j)`
-        'phase'         Phase shape, in radians                        `G[:, j] = 1j * F(A * m_j)`
-        'amplitude'     Dimensionless multiplicative amplitude         `G[:, j] = F(A * m_j)`
-        'field'         Additive complex field perturbation, with      `G[:, j] = F(m_j)`
-                        the support included in `m_j`
-        ==============  ==============================================  =====================================
-
-        with `k = 2 * pi / wavelength`.
+        coefficients and of the returned response. With 'opd', each mode
+        describes an optical path difference shape in meters, and the response
+        column is `G[:, j] = 1j * k * F(A * m_j)` with `k = 2 * pi / wavelength`.
+        With 'phase', each mode describes a phase shape in radians, and the
+        response column is `G[:, j] = 1j * F(A * m_j)`. With 'amplitude', each
+        mode is a dimensionless multiplicative amplitude perturbation, and the
+        response column is `G[:, j] = F(A * m_j)`. With 'field', each mode is an
+        additive complex field perturbation whose support is included in the
+        mode itself, and the response column is `G[:, j] = F(m_j)`.
 
     Returns
     -------
     LinearizedOpticalSystem
-        The linearized optical system, carrying the static field `E_0`, the
-        response basis `G`, the modes, the wavelength and the mode type.
+        The linearized optical system.
 
     Raises
     ------
     ValueError
-        If `mode_type` is not one of the supported values, or if no input grid
-        can be derived from the modes or the aperture, or if the grids of the
-        modes and the aperture do not match.
-    TypeError
-        If `optical_system` is not callable.
+        If `mode_type` is not one of the supported values.
     '''
-    if not callable(optical_system):
-        raise TypeError('The optical system must be callable with a Wavefront.')
-
     if mode_type not in ('opd', 'phase', 'amplitude', 'field'):
         raise ValueError('Unknown mode type %r. Mode type must be one of "opd", "phase", "amplitude" or "field".' % mode_type)
 
-    if isinstance(aperture, Field):
-        aperture_grid = aperture.grid
-    else:
-        aperture_grid = None
-
-    modes_grid = getattr(modes, 'grid', None)
-
-    if modes_grid is not None and aperture_grid is not None and modes_grid != aperture_grid:
-        raise ValueError('The grid of the modes and the grid of the aperture must match.')
-
-    input_grid = modes_grid if modes_grid is not None else aperture_grid
-
-    if input_grid is None:
-        raise ValueError('No input grid could be derived from the modes or the aperture. Supply modes with a grid, or an aperture Field.')
-
-    if modes_grid is None and isinstance(modes, ModeBasis):
-        # Attach the derived input grid to a copy of the modes, so that the
-        # model carries the input grid even when the modes were given without one.
-        modes = ModeBasis(modes.transformation_matrix.copy(), input_grid)
-
-    if isinstance(aperture, Field):
-        aperture_field = aperture
-    else:
-        aperture_field = aperture(input_grid)
-        if not isinstance(aperture_field, Field):
-            raise ValueError('The aperture callable did not return a Field.')
-
-    if not aperture_field.is_valid_field:
-        raise ValueError('The aperture field does not have the correct size for its grid.')
-
     # The unperturbed propagation. This also discovers the output grid.
-    static_field = optical_system(Wavefront(aperture_field, wavelength)).electric_field
+    static_field = optical_system(Wavefront(aperture, wavelength)).electric_field
 
     if mode_type == 'opd':
         factor = 1j * 2 * np.pi / wavelength
     elif mode_type == 'phase':
         factor = 1j
     else:
+        # for "amplitude" and "field"
         factor = 1
 
     response_columns = []
-    for j in range(len(modes)):
-        mode = modes[j]
-
-        if not isinstance(mode, Field):
-            mode = Field(np.asarray(mode), input_grid)
-
+    for mode in modes:
         if mode_type == 'field':
             input_field = mode
         else:
-            input_field = aperture_field * mode
+            input_field = aperture * mode
 
         response = optical_system(Wavefront(input_field, wavelength)).electric_field
         response_columns.append(factor * response)
 
-    field_response = ModeBasis(np.stack(response_columns, axis=-1), static_field.grid)
+    field_response = ModeBasis(response_columns, static_field.grid)
 
     return LinearizedOpticalSystem(static_field, field_response, modes, wavelength, mode_type)

--- a/hcipy/optics/linearization.py
+++ b/hcipy/optics/linearization.py
@@ -54,7 +54,7 @@ class LinearizedOpticalSystem:
     def __call__(self, coefficients):
         '''Evaluate the linearized output electric field for given mode coefficients.
 
-        This evaluates `E = E_0 + G * phi` on the output grid, using a single
+        This evaluates :math:`E = E_0 + G * \\phi` on the output grid, using a single
         matrix-vector product without intermediate copies of the response basis.
 
         Parameters
@@ -78,6 +78,111 @@ class LinearizedOpticalSystem:
             raise ValueError('The number of coefficients must match the number of modes.')
 
         return self.static_field + self.field_response.transformation_matrix @ coefficients
+
+    def intensity_from_covariance(self, P):
+        '''The mean intensity on the output grid for mode coefficients with covariance `P`.
+
+        For mode coefficients `phi` with zero mean and covariance `P`, the mean
+        intensity of the linearized field is:
+
+        .. math::
+
+            E[I] = |E_0|^2 + diag(G P G^H)
+
+        If `P` is given as a vector, it is interpreted as the diagonal of the
+        covariance matrix (the per-mode variances). The diagonal of :math:`G P G^H` is
+        computed without materializing the `(n_out, n_out)` covariance matrix of
+        the output field, requiring only `(n_out, r)` storage.
+
+        Parameters
+        ----------
+        P : ndarray
+            The covariance matrix of the mode coefficients, of shape `(r, r)`,
+            or a vector of length `r` containing its diagonal.
+
+        Returns
+        -------
+        Field
+            The mean intensity on the output grid.
+
+        Raises
+        ------
+        ValueError
+            If `P` is not a vector of length `r` or a matrix of shape `(r, r)`.
+        '''
+        P = np.asarray(P)
+
+        if P.ndim == 1:
+            if P.shape != (self.modes.num_modes,):
+                raise ValueError('A vector P must have one entry per mode.')
+
+            # diag(G diag(P) G^H) = |G|^2 P, a single matrix-vector product.
+            variance = (np.abs(self.field_response.transformation_matrix)**2) @ P
+        elif P.ndim == 2:
+            if P.shape != (self.modes.num_modes, self.modes.num_modes):
+                raise ValueError('A matrix P must have shape (num_modes, num_modes).')
+
+            # diag(G P G^H) = sum_j (G P)_ij conj(G)_ij, computed via one
+            # (n_out, r) intermediate instead of the full (n_out, n_out) matrix.
+            G = self.field_response.transformation_matrix
+            variance = np.sum((G @ P) * np.conj(G), axis=1).real
+        else:
+            raise ValueError('P must be a vector of length r or a matrix of shape (r, r).')
+
+        return Field(np.abs(self.static_field)**2 + variance, self.output_grid)
+
+    def pastis_matrix(self, weights):
+        '''The PASTIS matrix of this linearized optical system, weighted per output point.
+
+        The PASTIS matrix describes the second-order response of the weighted
+        sum of the intensity on the output grid to the mode coefficients:
+
+        .. math::
+
+            M = G^H W G,
+
+        with ::math::`W = diag(weights)`. See [Leboulleux2018]_.
+
+        .. [Leboulleux2018]
+
+            L. Leboulleux, J.-F. Sauvage, L. A. Pueyo, T. Fusco, R. Soummer,
+            J. Mazoyer, A. Sivaramakrishnan, M. N'Diaye, and O. Fauvarque, "Pair-based Analytical
+            model for Segmented Telescopes Imaging from Space (PASTIS) for sensitivity analysis,"
+            Journal of Astronomical Telescopes, Instruments, and Systems, 4(3), 035002 (2018).
+            https://doi.org/10.1117/1.JATIS.4.3.035002
+
+        The contribution of a mode-coefficient covariance `P` to the weighted
+        intensity is `trace(M P)`. The matrix is Hermitian; for real symmetric
+        `P`, `trace(M P)` is real and the real part of `M` follows the usual
+        PASTIS convention. It is computed with `(n_out, r)` storage, without
+        materializing the weight matrix.
+
+        Parameters
+        ----------
+        weights : Field or ndarray
+            The weights for each point on the output grid, e.g. a dark hole mask.
+
+        Returns
+        -------
+        ndarray
+            The weighted PASTIS matrix, of shape `(r, r)`.
+
+        Raises
+        ------
+        ValueError
+            If the weights do not have one entry per point on the output grid.
+        '''
+        weights = np.asarray(weights)
+
+        if weights.shape != (self.output_grid.size,):
+            raise ValueError('The weights must have one entry per point on the output grid.')
+
+        # M = G^H W G = (W G)^H G, with the weight matrix applied as a
+        # column-wise scaling of the response basis.
+        G = self.field_response.transformation_matrix
+
+        return np.asarray((G * weights[:, np.newaxis]).conj().T @ G)
+
 
 def linearize_optical_system(optical_system, aperture, modes, wavelength=1, mode_type='opd'):
     '''Linearize an optical system with respect to wavefront error modes.

--- a/hcipy/optics/linearization.py
+++ b/hcipy/optics/linearization.py
@@ -66,17 +66,7 @@ class LinearizedOpticalSystem:
         -------
         Field
             The output electric field on the output grid.
-
-        Raises
-        ------
-        ValueError
-            If the number of coefficients does not match the number of modes.
         '''
-        coefficients = np.asarray(coefficients)
-
-        if coefficients.shape != (self.modes.num_modes,):
-            raise ValueError('The number of coefficients must match the number of modes.')
-
         return self.static_field + self.field_response.transformation_matrix @ coefficients
 
     def intensity_from_covariance(self, P):
@@ -152,11 +142,6 @@ class LinearizedOpticalSystem:
         -------
         ndarray
             The weighted PASTIS matrix, of shape `(r, r)`.
-
-        Raises
-        ------
-        ValueError
-            If the weights do not have one entry per point on the output grid.
         '''
         # M = G^H W G = (W G)^H G, with the weight matrix applied as a
         # column-wise scaling of the response basis.

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -27,6 +27,33 @@ class OpticalElement(object):
         '''
         return self.forward(wavefront)
 
+    def __matmul__(self, other):
+        '''Compose this optical element with another optical element or optical system.
+
+        The composition `self @ other` returns a new :class:`OpticalSystem`,
+        which propagates the incoming wavefront first through `other` (or
+        through the elements of `other`, if `other` is an
+        :class:`OpticalSystem`), and then through `self`. That is,
+        `(self @ other)(wavefront)` is equivalent to `self(other(wavefront))`.
+
+        Parameters
+        ----------
+        other : OpticalElement or OpticalSystem
+            The optical element or system to propagate the wavefront through
+            before this element.
+
+        Returns
+        -------
+        OpticalSystem
+            A new optical system composed of the two.
+        '''
+        if isinstance(other, OpticalElement):
+            return OpticalSystem([other, self])
+        elif isinstance(other, OpticalSystem):
+            return OpticalSystem(other.optical_elements + [self])
+
+        return NotImplemented
+
     def forward(self, wavefront):
         '''Propagate a wavefront forward through the optical element.
 
@@ -845,7 +872,8 @@ def _get_optical_element_input_grid(optical_element):
 
     raise ValueError('Could not determine the input grid of the optical element.')
 
-class OpticalSystem(OpticalElement):
+
+class OpticalSystem(object):
     '''An linear path of optical elements.
 
     Parameters
@@ -855,6 +883,48 @@ class OpticalSystem(OpticalElement):
     '''
     def __init__(self, optical_elements):
         self.optical_elements = optical_elements
+
+    def __call__(self, wavefront):
+        '''Propagate a wavefront forward through the optical system.
+
+        Parameters
+        ----------
+        wavefront : Wavefront
+            The wavefront to propagate.
+
+        Returns
+        -------
+        Wavefront
+            The propagated wavefront.
+        '''
+        return self.forward(wavefront)
+
+    def __matmul__(self, other):
+        '''Compose this optical system with another optical element or optical system.
+
+        The composition `self @ other` returns a new :class:`OpticalSystem`,
+        which propagates the incoming wavefront first through `other` (or
+        through the elements of `other`, if `other` is an
+        :class:`OpticalSystem`), and then through the elements of `self`. That
+        is, `(self @ other)(wavefront)` is equivalent to `self(other(wavefront))`.
+
+        Parameters
+        ----------
+        other : OpticalElement or OpticalSystem
+            The optical element or system to propagate the wavefront through
+            before this system.
+
+        Returns
+        -------
+        OpticalSystem
+            A new optical system composed of the two.
+        '''
+        if isinstance(other, OpticalElement):
+            return OpticalSystem([other] + self.optical_elements)
+        elif isinstance(other, OpticalSystem):
+            return OpticalSystem(other.optical_elements + self.optical_elements)
+
+        return NotImplemented
 
     def forward(self, wavefront):
         '''Propagate a wavefront forward through the optical system.

--- a/tests/test_optical_system.py
+++ b/tests/test_optical_system.py
@@ -1,0 +1,342 @@
+import numpy as np
+
+import pytest
+
+import hcipy
+
+
+class FourierTransformElement(hcipy.OpticalElement):
+    def __init__(self, input_grid, output_grid):
+        self.transform = hcipy.make_fourier_transform(input_grid, output_grid)
+
+    def forward(self, wavefront):
+        return hcipy.Wavefront(self.transform.forward(wavefront.electric_field), wavefront.wavelength)
+
+
+class RecordingElement(hcipy.OpticalElement):
+    def __init__(self, name, log):
+        self.name = name
+        self.log = log
+
+    def forward(self, wavefront):
+        self.log.append(self.name)
+        return wavefront
+
+    def backward(self, wavefront):
+        self.log.append(self.name)
+        return wavefront
+
+
+def make_system():
+    pupil_grid = hcipy.make_pupil_grid(64, 1)
+    focal_grid = hcipy.make_focal_grid(64, 8, 1)
+    system = hcipy.OpticalSystem([hcipy.FresnelPropagator(pupil_grid, 1), FourierTransformElement(pupil_grid, focal_grid)])
+    return pupil_grid, system
+
+
+def perturbed_input(aperture, mode, mode_type, coefficient, wavelength):
+    k = 2 * np.pi / wavelength
+
+    if mode_type == 'opd':
+        return aperture * np.exp(1j * k * coefficient * mode)
+    elif mode_type == 'phase':
+        return aperture * np.exp(1j * coefficient * mode)
+    elif mode_type == 'amplitude':
+        return aperture * (1 + coefficient * mode)
+    elif mode_type == 'field':
+        return aperture + coefficient * mode
+    else:
+        raise ValueError('Unknown mode type.')
+
+
+def central_difference_response(optical_system, aperture, mode, mode_type, wavelength, step):
+    plus = perturbed_input(aperture, mode, mode_type, step, wavelength)
+    minus = perturbed_input(aperture, mode, mode_type, -step, wavelength)
+
+    response = optical_system(hcipy.Wavefront(plus, wavelength)).electric_field - optical_system(hcipy.Wavefront(minus, wavelength)).electric_field
+
+    return response / (2 * step)
+
+
+def make_modes(pupil_grid, aperture_field, mode_type):
+    zernike_modes = hcipy.make_zernike_basis(4, 1, pupil_grid)
+
+    if mode_type == 'field':
+        return hcipy.ModeBasis([hcipy.Field(mode * aperture_field, pupil_grid) for mode in zernike_modes])
+    else:
+        return zernike_modes
+
+
+@pytest.mark.parametrize('mode_type', ['opd', 'phase', 'amplitude', 'field'])
+def test_static_field(mode_type):
+    pupil_grid, system = make_system()
+    aperture_field = hcipy.make_circular_aperture(1)(pupil_grid)
+
+    modes = make_modes(pupil_grid, aperture_field, mode_type)
+
+    model = hcipy.linearize_optical_system(system, aperture_field, modes, wavelength=1, mode_type=mode_type)
+
+    E0 = system(hcipy.Wavefront(aperture_field, 1)).electric_field
+
+    assert np.allclose(model.static_field, E0)
+
+
+@pytest.mark.parametrize('mode_type', ['opd', 'phase', 'amplitude', 'field'])
+def test_field_response(mode_type):
+    pupil_grid, system = make_system()
+    aperture_field = hcipy.make_circular_aperture(1)(pupil_grid)
+
+    modes = make_modes(pupil_grid, aperture_field, mode_type)
+
+    step = 1e-3
+    if mode_type == 'opd':
+        step = 1e-6
+
+    model = hcipy.linearize_optical_system(system, aperture_field, modes, wavelength=1, mode_type=mode_type)
+
+    G = model.field_response.transformation_matrix
+
+    for j in range(len(modes)):
+        G_fd = central_difference_response(system, aperture_field, modes[j], mode_type, 1, step)
+        assert np.allclose(G[..., j], G_fd, rtol=1e-5, atol=1e-9 * np.abs(G[..., j]).max())
+
+
+@pytest.mark.parametrize('mode_type', ['opd', 'phase', 'amplitude', 'field'])
+def test_superposition(mode_type):
+    rng = np.random.default_rng(0)
+
+    pupil_grid, system = make_system()
+    aperture = hcipy.make_circular_aperture(1)(pupil_grid)
+
+    modes = make_modes(pupil_grid, aperture, mode_type)
+
+    wavelength = 1
+    coefficients = 1e-4 * rng.normal(size=len(modes))
+
+    model = hcipy.linearize_optical_system(system, aperture, modes, wavelength=wavelength, mode_type=mode_type)
+
+    field = aperture.copy()
+    if mode_type == 'field':
+        field = aperture + modes.linear_combination(coefficients)
+    elif mode_type == 'opd':
+        opd = modes.linear_combination(coefficients)
+        field = aperture * np.exp(1j * 2 * np.pi / wavelength * opd)
+    elif mode_type == 'phase':
+        phase = modes.linear_combination(coefficients)
+        field = aperture * np.exp(1j * phase)
+    else:  # amplitude
+        field = aperture + modes.linear_combination(coefficients)
+
+    E = system(hcipy.Wavefront(field, wavelength)).electric_field
+    E_lin = model(coefficients)
+
+    assert np.allclose(E, E_lin, rtol=1e-4, atol=1e-10)
+
+
+def test_chaining():
+    pupil_grid, system = make_system()
+    aperture_field = hcipy.make_circular_aperture(1)(pupil_grid)
+
+    modes = hcipy.make_zernike_basis(4, 1, pupil_grid)
+
+    tel_system, coro_system = system.optical_elements
+    wavelength = 1
+
+    tel = hcipy.linearize_optical_system(tel_system, aperture_field, modes, wavelength=wavelength)
+    coro = hcipy.linearize_optical_system(coro_system, aperture=tel.static_field, modes=tel.field_response, mode_type='field', wavelength=wavelength)
+
+    single = hcipy.linearize_optical_system(system, aperture_field, modes, wavelength=wavelength)
+
+    assert np.allclose(coro.static_field, single.static_field, rtol=1e-8, atol=1e-12)
+    assert np.allclose(coro.field_response.transformation_matrix, single.field_response.transformation_matrix, rtol=1e-8, atol=1e-12)
+
+
+def test_unknown_mode_type():
+    pupil_grid, system = make_system()
+    aperture_field = hcipy.make_circular_aperture(1)(pupil_grid)
+    modes = hcipy.make_zernike_basis(4, 1, pupil_grid)
+
+    with pytest.raises(ValueError):
+        hcipy.linearize_optical_system(system, aperture_field, modes, mode_type='bogus')
+
+
+def test_bookkeeping():
+    pupil_grid, system = make_system()
+    aperture_field = hcipy.make_circular_aperture(1)(pupil_grid)
+    modes = hcipy.make_zernike_basis(4, 1, pupil_grid)
+
+    model = hcipy.linearize_optical_system(system, aperture_field, modes, wavelength=2, mode_type='phase')
+
+    assert model.mode_type == 'phase'
+    assert model.wavelength == 2
+    assert model.modes is modes
+
+
+def make_elements():
+    pupil_grid = hcipy.make_pupil_grid(32, 1)
+    apodizer = hcipy.Apodizer(hcipy.make_circular_aperture(1)(pupil_grid))
+    phase_apodizer = hcipy.PhaseApodizer(hcipy.zernike(2, 0)(pupil_grid))
+    return pupil_grid, apodizer, phase_apodizer
+
+
+def make_recording_elements(*names):
+    log = []
+    return [RecordingElement(name, log) for name in names], log
+
+
+def make_wavefront():
+    return hcipy.Wavefront(hcipy.make_pupil_grid(1, 1).ones(), 1)
+
+
+def test_matmul_composition():
+    wf = make_wavefront()
+
+    (a, b), log = make_recording_elements('a', 'b')
+    system = a @ b
+    assert system.optical_elements == [b, a]
+    system(wf)
+    assert log == ['b', 'a']
+
+    (a, b, c), log = make_recording_elements('a', 'b', 'c')
+    inner = hcipy.OpticalSystem([b, c])
+    composed = a @ inner
+    assert composed.optical_elements == [b, c, a]
+    assert inner.optical_elements == [b, c]
+    composed(wf)
+    assert log == ['b', 'c', 'a']
+
+    (a, b, c), log = make_recording_elements('a', 'b', 'c')
+    inner = hcipy.OpticalSystem([a, b])
+    composed = inner @ c
+    assert composed.optical_elements == [c, a, b]
+    assert inner.optical_elements == [a, b]
+    composed(wf)
+    assert log == ['c', 'a', 'b']
+
+    (a, b, c, d), log = make_recording_elements('a', 'b', 'c', 'd')
+    system1 = hcipy.OpticalSystem([a, b])
+    system2 = hcipy.OpticalSystem([c, d])
+    composed = system1 @ system2
+    assert composed.optical_elements == [c, d, a, b]
+    assert system1.optical_elements == [a, b]
+    assert system2.optical_elements == [c, d]
+    composed(wf)
+    assert log == ['c', 'd', 'a', 'b']
+
+
+def test_matmul_associativity():
+    (a, b, c), log = make_recording_elements('a', 'b', 'c')
+
+    left = (a @ b) @ c
+    right = a @ (b @ c)
+
+    assert left.optical_elements == right.optical_elements == [c, b, a]
+
+
+def test_matmul_application_order():
+    (a, b), log = make_recording_elements('a', 'b')
+    system = a @ b
+
+    system.forward(make_wavefront())
+    assert log == ['b', 'a']
+
+    log.clear()
+
+    system.backward(make_wavefront())
+    assert log == ['a', 'b']
+
+
+def test_matmul_not_implemented():
+    _, apodizer, _ = make_elements()
+
+    with pytest.raises(TypeError):
+        apodizer @ 5
+
+
+def make_linear_model():
+    pupil_grid = hcipy.make_pupil_grid(12, 1)
+    aperture = hcipy.make_circular_aperture(1)(pupil_grid)
+    system = hcipy.FresnelPropagator(pupil_grid, 1)
+    modes = hcipy.make_zernike_basis(3, 1, pupil_grid)
+
+    return hcipy.linearize_optical_system(system, aperture, modes, wavelength=1)
+
+
+def test_linearized_model_call():
+    model = make_linear_model()
+    rng = np.random.default_rng(0)
+
+    phi = rng.normal(size=3) * 1e-3
+
+    E = model(phi)
+
+    assert isinstance(E, hcipy.Field)
+    assert E.grid == model.output_grid
+    assert np.allclose(E, model.static_field + model.field_response.transformation_matrix @ phi)
+
+
+def test_intensity_from_covariance():
+    model = make_linear_model()
+    rng = np.random.default_rng(1)
+
+    r = model.modes.num_modes
+    P = rng.normal(size=(r, r))
+    P = P @ P.T + np.eye(r)
+
+    I = model.intensity_from_covariance(P)
+
+    assert isinstance(I, hcipy.Field)
+    assert I.grid == model.output_grid
+
+    # Brute force: diag(G P G^H) plus the static intensity.
+    G = model.field_response.transformation_matrix
+    expected = np.abs(model.static_field)**2 + np.diag(G @ P @ G.conj().T).real
+    assert np.allclose(I, expected)
+
+    # A diagonal covariance given as a vector must equal the full-matrix version.
+    p = rng.uniform(0.5, 2, r)
+    assert np.allclose(model.intensity_from_covariance(p), model.intensity_from_covariance(np.diag(p)))
+
+    with pytest.raises(ValueError):
+        model.intensity_from_covariance(np.zeros((r + 1, r)))
+
+
+def test_intensity_from_covariance_monte_carlo():
+    model = make_linear_model()
+    rng = np.random.default_rng(2)
+
+    r = model.modes.num_modes
+    P = np.diag(rng.uniform(0.5, 2, r))
+
+    I_true = model.intensity_from_covariance(P)
+
+    samples = rng.multivariate_normal(np.zeros(r), P, size=20000)
+    I_mc = np.mean([np.abs(model(phi))**2 for phi in samples], axis=0)
+
+    assert np.allclose(I_mc, I_true, rtol=0.05, atol=0.01 * np.max(I_true))
+
+
+def test_pastis_matrix():
+    model = make_linear_model()
+    rng = np.random.default_rng(3)
+
+    G = model.field_response.transformation_matrix
+    n_out = model.output_grid.size
+    weights = hcipy.Field(rng.uniform(size=n_out), model.output_grid)
+
+    M = model.pastis_matrix(weights)
+
+    assert M.shape == (model.modes.num_modes, model.modes.num_modes)
+
+    # Brute force: M = sum_i w_i Re(conj(G_i) G_i^T)
+    M_brute = sum(weights[i] * np.outer(np.conj(G[i]), G[i]) for i in range(n_out)).real
+    assert np.allclose(M, M_brute)
+
+    # M is real and symmetric.
+    assert np.allclose(M, M.T)
+
+    # trace(M P) equals the weighted sum of the covariance contribution.
+    r = model.modes.num_modes
+    P = np.diag(rng.uniform(0.5, 2, r))
+    variance = model.intensity_from_covariance(P) - np.abs(model.static_field)**2
+    assert np.allclose(np.sum(weights * variance), np.trace(M @ P))


### PR DESCRIPTION
## Summary

Simulation of wavefront sensing and control (e.g. coronagraphic contrast prediction) often requires the sensitivity of the output electric field to (wavefront) error modes. This PR adds functionality to compute these sensitivity matrices and linearized models for you. It adds exact first-order linearization of optical systems with respect to wavefront error modes, plus easier composition of optical elements with the `@` operator.

@ivalaginja @laurentpueyo FYI

## New function and class

- `linearize_optical_system(optical_system, aperture, modes, wavelength=1, mode_type='opd')`: exact first-order linearization of an optical system: returns `E_out = E_0 + G·φ` by propagating each WFE mode once (no finite differences). `mode_type` sets mode semantics: `'opd'`, `'phase'`, `'amplitude'`, or `'field'` for optical path difference, phase-only, amplitude-only and electric field aberrations.
- `LinearizedOpticalSystem`: dataclass holding `static_field` ($$E_0$$), `field_response` ($$G$$), `modes`, `wavelength`, `mode_type`, with `input_grid`/`output_grid` properties and:
  - `__call__(φ)`: evaluate the linearized output field.
  - `intensity_from_covariance(P)`: mean intensity `|E_0|² + diag(G P Gᴴ)` for coefficient covariance `P` (vector or matrix), in `O(n_out·r)` storage.
  - `pastis_matrix(weights)`: weighted PASTIS matrix `Gᴴ W G` (real, symmetric), for contrast prediction via `trace(M P)`.

I also added easier composition for optical elements and systems using the `@` matmul operator. Composition is associative but not commutative. Note: `OpticalSystem` no longer subclasses `OpticalElement`, keeping the two interfaces independent.

Tests were added for all functionality. I used Deepseek V4 Flash and Pro for writing docstrings and tests.

## Todo

- [X] ~Consider deprecation of `get_transformation_matrix_forward()` and `get_transformation_matrix_backward()`. These functions are a weak and memory intensive alternative to the functionality that is introduced in this PR.~ Made #363 to deprecate this if we want to.