### PR TITLE
Add refractive index materials module.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,7 @@ The banner above shows a number of simulations done with HCIPy. From left to rig
    modules/field
    modules/fourier
    modules/interpolation
+   modules/materials
    modules/metrics
    modules/mode_basis
    modules/optics

--- a/doc/modules/materials.rst
+++ b/doc/modules/materials.rst
@@ -1,0 +1,9 @@
+materials - Optical Materials
+=============================
+
+.. currentmodule:: hcipy.materials
+
+.. automodapi:: hcipy.materials
+    :no-inheritance-diagram:
+    :include-all-objects:
+    :no-heading:

--- a/hcipy/__init__.py
+++ b/hcipy/__init__.py
@@ -13,6 +13,7 @@ from . import coronagraphy
 from . import field
 from . import fourier
 from . import interpolation
+from . import materials
 from . import metrics
 from . import mode_basis
 from . import optics
@@ -30,6 +31,7 @@ from .coronagraphy import *
 from .field import *
 from .fourier import *
 from .interpolation import *
+from .materials import *
 from .metrics import *
 from .mode_basis import *
 from .optics import *
@@ -48,6 +50,7 @@ __all__.extend(coronagraphy.__all__)
 __all__.extend(field.__all__)
 __all__.extend(fourier.__all__)
 __all__.extend(interpolation.__all__)
+__all__.extend(materials.__all__)
 __all__.extend(metrics.__all__)
 __all__.extend(mode_basis.__all__)
 __all__.extend(optics.__all__)

--- a/hcipy/materials/__init__.py
+++ b/hcipy/materials/__init__.py
@@ -1,0 +1,21 @@
+__all__ = [
+    'AmbiguousMaterialError',
+    'MaterialCatalog',
+    'RefractiveIndexMaterial',
+    'download_rii_database',
+    'get_material',
+    'make_cauchy_index',
+    'make_exotic_index',
+    'make_gases_index',
+    'make_herzberger_index',
+    'make_polynomial_index',
+    'make_retro_index',
+    'make_rii_index',
+    'make_sellmeier2_index',
+    'make_sellmeier_index',
+    'search_material'
+]
+
+from .catalog import *
+from .formulas import *
+from .material import *

--- a/hcipy/materials/catalog.py
+++ b/hcipy/materials/catalog.py
@@ -104,7 +104,6 @@ class _PageSpec:
         n_grid = None
         k_grid = None
         formula = None
-        constant = None
         wavelength_range = None
 
         for data in doc.get('DATA', []):
@@ -130,8 +129,6 @@ class _PageSpec:
                 elif subtype == 'nk':
                     n_grid = (wl, c1)
                     k_grid = (wl, c2)
-            elif category == 'refractive_index':
-                constant = float(data['refractive_index'])
 
         if formula is not None:
             fid, coefficients = formula
@@ -143,8 +140,6 @@ class _PageSpec:
             n_wavelengths, n_values = n_grid
             def n_function(wavelength, _x=n_wavelengths, _y=n_values):
                 return np.interp(wavelength, _x, _y)
-        elif constant is not None:
-            n_function = _constant_refractive_index(constant)
         else:
             n_function = None
 
@@ -163,14 +158,6 @@ class _PageSpec:
             book=self.book,
             wavelength_range=wavelength_range
         )
-
-
-def _constant_refractive_index(constant):
-    def f(wavelength):
-        if np.isscalar(wavelength):
-            return float(constant)
-        return np.full(np.shape(wavelength), constant, dtype=float)
-    return f
 
 
 class MaterialCatalog:

--- a/hcipy/materials/catalog.py
+++ b/hcipy/materials/catalog.py
@@ -98,7 +98,7 @@ class _PageSpec:
         self.filepath = filepath
 
     def load(self):
-        with open(self.filepath) as f:
+        with open(self.filepath, encoding='utf-8') as f:
             doc = yaml.load(f, Loader=_YAML_LOADER)
 
         n_grid = None
@@ -190,7 +190,7 @@ class MaterialCatalog:
         self._index = {}
         self._pages = []
 
-        with open(catalog_file) as f:
+        with open(catalog_file, encoding='utf-8') as f:
             catalog = yaml.load(f, Loader=_YAML_LOADER)
 
         for shelf_entry in catalog:

--- a/hcipy/materials/catalog.py
+++ b/hcipy/materials/catalog.py
@@ -1,0 +1,445 @@
+import functools
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import yaml
+import difflib
+
+from tqdm import tqdm
+
+from .formulas import (
+    make_cauchy_index,
+    make_exotic_index,
+    make_gases_index,
+    make_herzberger_index,
+    make_polynomial_index,
+    make_retro_index,
+    make_rii_index,
+    make_sellmeier2_index,
+    make_sellmeier_index
+)
+from .material import RefractiveIndexMaterial
+
+_YAML_LOADER = getattr(yaml, 'CSafeLoader', None) or yaml.SafeLoader
+
+__all__ = [
+    'AmbiguousMaterialError',
+    'MaterialCatalog',
+    'download_rii_database',
+    'get_material',
+    'search_material'
+]
+
+DEFAULT_DATABASE_PATH = Path.home() / '.hcipy' / 'rii_database'
+EXCLUDED_SHELVES = ('3d', 'popular_glass')
+DATABASE_URL = 'https://github.com/polyanskiy/refractiveindex.info-database/releases/download/v2026-05-24/rii-database-2026-05-24.zip'
+
+
+class AmbiguousMaterialError(ValueError):
+    '''Raised when a material name resolves to multiple pages.
+
+    The candidates are available through the ``candidates`` attribute, as a
+    list of the page_info dictionaries of all matching pages.
+    '''
+    def __init__(self, message, candidates=None):
+        super().__init__(message)
+        self.candidates = candidates
+
+
+_FORMULAS = {
+    1: make_sellmeier_index,
+    2: make_sellmeier2_index,
+    3: make_polynomial_index,
+    4: make_rii_index,
+    5: make_cauchy_index,
+    6: make_gases_index,
+    7: make_herzberger_index,
+    8: make_retro_index,
+    9: make_exotic_index
+}
+
+def _make_formula_refractive_index(formula_id, coefficients):
+    '''Create a refractive index function from a formula id (1-9) and coefficients.'''
+    if formula_id not in _FORMULAS:
+        raise ValueError(f'Unknown dispersion formula {formula_id!r}.')
+    return _FORMULAS[formula_id](coefficients)
+
+
+def _parse_tabulated(data_str):
+    rows = data_str.strip().splitlines()
+    wavelength = []
+    col1 = []
+    col2 = []
+    for row in rows:
+        parts = row.split()
+        if not parts or parts[0].startswith('#'):
+            continue
+        wavelength.append(float(parts[0]))
+        col1.append(float(parts[1]))
+        if len(parts) > 2:
+            col2.append(float(parts[2]))
+    wavelength = np.array(wavelength)
+    col1 = np.array(col1)
+    col2 = np.array(col2) if col2 else None
+    return wavelength, col1, col2
+
+
+class _PageSpec:
+    __slots__ = ('shelf', 'book', 'page', 'filepath')
+
+    def __init__(self, shelf, book, page, filepath):
+        self.shelf = shelf
+        self.book = book
+        self.page = page
+        self.filepath = filepath
+
+    def load(self):
+        with open(self.filepath) as f:
+            doc = yaml.load(f, Loader=_YAML_LOADER)
+
+        n_grid = None
+        k_grid = None
+        formula = None
+        constant = None
+        wavelength_range = None
+
+        for data in doc.get('DATA', []):
+            parts = data['type'].split()
+            category = parts[0]
+            subtype = parts[1] if len(parts) > 1 else None
+
+            if category == 'formula':
+                fid = int(subtype)
+                coefficients = [float(c) for c in data['coefficients'].split()]
+                rng = data.get('range', data.get('wavelength_range'))
+                if rng is not None:
+                    lo, hi = (float(x) for x in rng.split())
+                    wavelength_range = (lo * 1e-6, hi * 1e-6)
+                formula = (fid, coefficients)
+            elif category == 'tabulated':
+                wl, c1, c2 = _parse_tabulated(data['data'])
+                wl = wl * 1e-6
+                if subtype == 'n':
+                    n_grid = (wl, c1)
+                elif subtype == 'k':
+                    k_grid = (wl, c1)
+                elif subtype == 'nk':
+                    n_grid = (wl, c1)
+                    k_grid = (wl, c2)
+            elif category == 'refractive_index':
+                constant = float(data['refractive_index'])
+
+        if formula is not None:
+            fid, coefficients = formula
+            try:
+                n_function = _make_formula_refractive_index(fid, coefficients)
+            except ValueError as e:
+                raise ValueError(f'{self.shelf}/{self.book}/{self.page}: {e}') from e
+        elif n_grid is not None:
+            n_wavelengths, n_values = n_grid
+            def n_function(wavelength, _x=n_wavelengths, _y=n_values):
+                return np.interp(wavelength, _x, _y)
+        elif constant is not None:
+            n_function = _constant_refractive_index(constant)
+        else:
+            n_function = None
+
+        if k_grid is not None:
+            k_wavelengths, k_values = k_grid
+            def k_function(wavelength, _x=k_wavelengths, _y=k_values):
+                return np.interp(wavelength, _x, _y)
+        else:
+            k_function = None
+
+        return RefractiveIndexMaterial(
+            self.page,
+            n_function,
+            k_function,
+            shelf=self.shelf,
+            book=self.book,
+            wavelength_range=wavelength_range
+        )
+
+
+def _constant_refractive_index(constant):
+    def f(wavelength):
+        if np.isscalar(wavelength):
+            return float(constant)
+        return np.full(np.shape(wavelength), constant, dtype=float)
+    return f
+
+
+class MaterialCatalog:
+    '''A catalog of materials from the refractiveindex.info database.
+
+    Parameters
+    ----------
+    path : str or Path, optional
+        The path of the refractiveindex.info database. Defaults to
+        ~/.hcipy/rii_database. When the path is omitted, the database is
+        downloaded automatically on first use.
+
+    Notes
+    -----
+    The '3d' and 'popular_glass' shelves are excluded, as they contain no
+    data that is not already present in the other shelves.
+    '''
+    def __init__(self, path=None):
+        self.path = Path(path) if path is not None else DEFAULT_DATABASE_PATH
+
+        catalog_file = self.path / 'catalog-nk.yml'
+        if not catalog_file.exists():
+            if path is None:
+                download_rii_database(self.path)
+            else:
+                raise FileNotFoundError(
+                    f'The refractiveindex.info database was not found at {self.path}. '
+                    'Download it with hcipy.materials.download_rii_database().')
+
+        self._index = {}
+        self._pages = []
+
+        with open(catalog_file) as f:
+            catalog = yaml.load(f, Loader=_YAML_LOADER)
+
+        for shelf_entry in catalog:
+            if 'SHELF' not in shelf_entry:
+                continue
+
+            shelf = shelf_entry['SHELF']
+            if shelf in EXCLUDED_SHELVES:
+                continue
+
+            for book_entry in shelf_entry.get('content', []):
+                if 'BOOK' not in book_entry:
+                    continue
+
+                book = book_entry['BOOK']
+                for page_entry in book_entry.get('content', []):
+                    if 'PAGE' not in page_entry:
+                        continue
+
+                    page = page_entry['PAGE']
+                    data_path = page_entry.get('data')
+                    if data_path is None:
+                        continue
+
+                    filepath = self.path / 'data' / Path(data_path)
+                    if not filepath.exists():
+                        continue
+
+                    spec = _PageSpec(shelf, book, page, filepath)
+                    self._pages.append(spec)
+                    self._index.setdefault(page, []).append(spec)
+
+    @staticmethod
+    def _matches(spec, shelf, book, page):
+        if shelf is not None and spec.shelf != shelf:
+            return False
+
+        if book is not None and spec.book != book:
+            return False
+
+        if page is not None and spec.page != page:
+            return False
+
+        return True
+
+    def get(self, page, /, *, shelf=None, book=None):
+        '''Get the unique material matching the given page name.
+
+        The page must match a page name exactly. The search can be narrowed
+        with the shelf and book keywords. Raises a KeyError when no material
+        matches, and an AmbiguousMaterialError when multiple pages match.
+
+        Parameters
+        ----------
+        page : str
+            The name of the page.
+        shelf : str, optional
+            Narrow the search to the given shelf.
+        book : str, optional
+            Narrow the search to the given book.
+
+        Returns
+        -------
+        RefractiveIndexMaterial
+            The material.
+        '''
+        candidates = self._index.get(page, [])
+        candidates = [c for c in candidates if self._matches(c, shelf, book, None)]
+
+        if not candidates:
+            suggestions = difflib.get_close_matches(page, self._index.keys(), n=3)
+
+            if len(suggestions) > 0:
+                suggestion_names = [repr(s) for s in suggestions]
+                raise KeyError(f'No material named {page!r} found in the catalog. Did you mean {" or ".join(suggestion_names)}?')
+
+            raise KeyError(f'No material named {page!r} found in the catalog.')
+
+        if len(candidates) > 1:
+            raise AmbiguousMaterialError(
+                f'The material named {page!r} matches {len(candidates)} pages. Narrow the search '
+                'with the shelf or book keywords.',
+                candidates=[c.load().page_info for c in candidates])
+
+        return candidates[0].load()
+
+    def search(self, page=None, /, *, shelf=None, book=None):
+        '''Get all materials matching the given criteria.
+
+        The page is an exact-case substring match over the page and book
+        names. The search can be narrowed with the shelf and book keywords.
+
+        Parameters
+        ----------
+        page : str, optional
+            A substring of the page or book name.
+        shelf : str, optional
+            Narrow the search to the given shelf.
+        book : str, optional
+            Narrow the search to the given book.
+
+        Returns
+        -------
+        list of RefractiveIndexMaterial
+            The materials matching the criteria.
+        '''
+        results = []
+
+        results = []
+
+        for spec in self._pages:
+            if not self._matches(spec, shelf, book, None):
+                continue
+
+            if page is not None:
+                if page not in spec.page and page not in spec.book:
+                    continue
+            try:
+                results.append(spec.load())
+            except (ValueError, KeyError, IndexError, TypeError):
+                continue
+
+        return results
+
+    def __getitem__(self, page):
+        '''Get the unique material matching the given page.'''
+        return self.get(page)
+
+    def __contains__(self, page):
+        '''Check whether the catalog contains a material with the given page.'''
+        return page in self._index
+
+    def __len__(self):
+        '''Get the number of materials in the catalog.'''
+        return len(self._pages)
+
+    def __repr__(self):
+        return f'MaterialCatalog({str(self.path)!r}, {len(self)} pages)'
+
+
+@functools.cache
+def _default_catalog():
+    return MaterialCatalog()
+
+
+def get_material(page, /, *, shelf=None, book=None):
+    '''Get the unique material matching the given page from the default catalog.
+
+    Parameters
+    ----------
+    page : str
+        The name of the page.
+    shelf : str, optional
+        Narrow the search to the given shelf.
+    book : str, optional
+        Narrow the search to the given book.
+
+    Returns
+    -------
+    RefractiveIndexMaterial
+        The material.
+    '''
+    return _default_catalog().get(page, shelf=shelf, book=book)
+
+
+def search_material(page=None, /, *, shelf=None, book=None):
+    '''Get all materials matching the given criteria from the default catalog.
+
+    Parameters
+    ----------
+    page : str, optional
+        A substring of the page or book name.
+    shelf : str, optional
+        Narrow the search to the given shelf.
+    book : str, optional
+        Narrow the search to the given book.
+
+    Returns
+    -------
+    list of RefractiveIndexMaterial
+        The materials matching the criteria.
+    '''
+    return _default_catalog().search(page, shelf=shelf, book=book)
+
+
+def download_rii_database(path=None):
+    '''Download (or re-download) the refractiveindex.info database.
+
+    Parameters
+    ----------
+    path : str or Path, optional
+        The directory in which to store the database. Defaults to
+        ~/.hcipy/rii_database.
+
+    Returns
+    -------
+    Path
+        The path of the downloaded database.
+    '''
+    if path is None:
+        path = DEFAULT_DATABASE_PATH
+
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        archive_path = tmp / 'rii.zip'
+
+        request = urllib.request.Request(DATABASE_URL)
+
+        with urllib.request.urlopen(request, timeout=60) as response:
+            total = int(response.headers.get('Content-Length', 0))
+
+            with tqdm(total=total, unit='B', unit_scale=True, desc='Downloading refractiveindex.info database') as pbar:
+                with open(archive_path, 'wb') as f:
+                    while True:
+                        chunk = response.read(1024 * 256)
+
+                        if not chunk:
+                            break
+
+                        f.write(chunk)
+                        pbar.update(len(chunk))
+
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(tmp / 'staging')
+
+        database_dir = tmp / 'staging' / 'database'
+        if not database_dir.exists():
+            raise ValueError(f'No database directory found in {DATABASE_URL}.')
+
+        for entry in database_dir.iterdir():
+            if entry.is_dir():
+                shutil.copytree(entry, path / entry.name, dirs_exist_ok=True)
+            else:
+                shutil.copy2(entry, path / entry.name)
+
+    return path

--- a/hcipy/materials/formulas.py
+++ b/hcipy/materials/formulas.py
@@ -1,0 +1,391 @@
+import numpy as np
+
+__all__ = [
+    'make_sellmeier_index',
+    'make_sellmeier2_index',
+    'make_polynomial_index',
+    'make_rii_index',
+    'make_cauchy_index',
+    'make_gases_index',
+    'make_herzberger_index',
+    'make_retro_index',
+    'make_exotic_index'
+]
+
+
+def _check_pairs(coefficients, formula):
+    n = len(coefficients)
+
+    if n < 3 or n % 2 == 0:
+        raise ValueError(
+            f'The {formula} formula requires the constant C0 followed by coefficient pairs, '
+            f'got {n} coefficients.')
+
+
+def _check_count(coefficients, n, formula):
+    if len(coefficients) != n:
+        raise ValueError(f'The {formula} formula requires exactly {n} coefficients, got {len(coefficients)}.')
+
+
+def make_sellmeier_index(coefficients):
+    r'''The Sellmeier dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the Sellmeier formula is [Sellmeier1871]_,
+
+    .. math:: n^2 = 1 + C_0 + \sum_{i}{\frac{K_i \lambda^2}{\lambda^2 - L_i^2}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the coefficients do not consist of C0 followed by coefficient pairs.
+
+    .. [Sellmeier1871] W. Sellmeier 1871, Zur Erklärung der abnormen Farbenfolge im
+        Spectrum einiger Substanzen, Annalen der Physik und Chemie. 143, 272–282 (1871)
+    '''
+    _check_pairs(coefficients, 'Sellmeier')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+        nsq = 1.0 + coefficients[0]
+
+        for i in range(1, len(coefficients) - 1, 2):
+            nsq = nsq + coefficients[i] * wl**2 / (wl**2 - coefficients[i + 1]**2)
+
+        return np.sqrt(nsq)
+
+    return refractive_index
+
+
+def make_sellmeier2_index(coefficients):
+    r'''The Sellmeier-2 dispersion formula for the refractive index of materials.
+
+    In this form the resonance terms are given in um**2 directly. The dispersion
+    relation of the Sellmeier-2 formula is [SchottTIE29]_,
+
+    .. math:: n^2 = 1 + C_0 + \sum_{i}{\frac{K_i \lambda^2}{\lambda^2 - L_i}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the coefficients do not consist of C0 followed by coefficient pairs.
+
+    .. [SchottTIE29] Schott AG 2023, Refractive Index and Dispersion, Technical
+        Information Advanced Optics TIE-29, Mainz, Germany (2023)
+    '''
+    _check_pairs(coefficients, 'Sellmeier-2')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+        nsq = 1.0 + coefficients[0]
+
+        for i in range(1, len(coefficients) - 1, 2):
+            nsq = nsq + coefficients[i] * wl**2 / (wl**2 - coefficients[i + 1])
+
+        return np.sqrt(nsq)
+
+    return refractive_index
+
+
+def make_polynomial_index(coefficients):
+    r'''The polynomial dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the polynomial formula is [Polyanskiy2024]_,
+
+    .. math:: n^2 = \sum_{i}{C_i \lambda^{k_i}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula. Coefficients come in
+        (coefficient, exponent) pairs after the leading C0 term.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the coefficients do not consist of C0 followed by coefficient pairs.
+
+    .. [Polyanskiy2024] M. N. Polyanskiy 2024, Refractiveindex.info database of optical
+        constants, Scientific Data. 11, 94 (2024)
+    '''
+    _check_pairs(coefficients, 'polynomial')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+        nsq = coefficients[0]
+
+        for i in range(1, len(coefficients) - 1, 2):
+            nsq = nsq + coefficients[i] * wl**coefficients[i + 1]
+
+        return np.sqrt(nsq)
+
+    return refractive_index
+
+
+def make_rii_index(coefficients):
+    r'''The RefractiveIndex.INFO dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the RefractiveIndex.INFO formula is [Polyanskiy2024]_,
+
+    .. math:: n^2 = C_0 + \sum_{i}{\frac{C_i \lambda^{C_{i+1}}}{\lambda^2 - C_{i+2}^{C_{i+3}}}} + \sum_{j}{C_j \lambda^{C_{j+1}}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the coefficients do not consist of C0, four coefficients per
+        resonance term, followed by coefficient pairs.
+
+    .. [Polyanskiy2024] M. N. Polyanskiy 2024, Refractiveindex.info database of optical
+        constants, Scientific Data. 11, 94 (2024)
+    '''
+    n = len(coefficients)
+
+    if n < 9 or (n - 9) % 2 != 0:
+        raise ValueError(
+            f'The RefractiveIndex.INFO formula requires at least 9 coefficients, followed by '
+            f'coefficient pairs, got {n}.')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+        nsq = coefficients[0]
+
+        for i in range(1, 9, 4):
+            nsq = nsq + coefficients[i] * wl**coefficients[i + 1] / (wl**2 - coefficients[i + 2]**coefficients[i + 3])
+
+        for i in range(9, len(coefficients) - 1, 2):
+            nsq = nsq + coefficients[i] * wl**coefficients[i + 1]
+
+        return np.sqrt(nsq)
+
+    return refractive_index
+
+
+def make_cauchy_index(coefficients):
+    r'''The Cauchy dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the Cauchy formula is [Cauchy1836]_,
+
+    .. math:: n = \sum_{i}{C_i \lambda^{k_i}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula. Coefficients come in
+        (coefficient, exponent) pairs after the leading C0 term.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the coefficients do not consist of C0 followed by coefficient pairs.
+
+    .. [Cauchy1836] A.-L. Cauchy 1836, Mémoire sur la dispersion de la lumière, J. G.
+        Calve, Prague (1836)
+    '''
+    _check_pairs(coefficients, 'Cauchy')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+        n = coefficients[0]
+
+        for i in range(1, len(coefficients) - 1, 2):
+            n = n + coefficients[i] * wl**coefficients[i + 1]
+
+        return n
+
+    return refractive_index
+
+
+def make_gases_index(coefficients):
+    r'''The gases dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the gases formula is [PeckReeder1972]_,
+
+    .. math:: n = 1 + C_0 + \sum_{i}{\frac{C_i}{C_{i+1} - \lambda^{-2}}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the coefficients do not consist of C0 followed by coefficient pairs.
+
+    .. [PeckReeder1972] E. R. Peck and K. Reeder 1972, Dispersion of air, J. Opt. Soc.
+        Am. 62, 958–962 (1972)
+    '''
+    _check_pairs(coefficients, 'gases')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+        n = 1.0 + coefficients[0]
+
+        for i in range(1, len(coefficients) - 1, 2):
+            n = n + coefficients[i] / (coefficients[i + 1] - wl**(-2))
+
+        return n
+
+    return refractive_index
+
+
+def make_herzberger_index(coefficients):
+    r'''The Herzberger dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the Herzberger formula is [HerzbergerSalzberg1962]_,
+
+    .. math:: n = C_0 + \frac{C_1}{\lambda^2 - 0.028} + \frac{C_2}{(\lambda^2 - 0.028)^2} + \sum_{i \geq 3}{C_i \lambda^{2(i-2)}}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the number of coefficients is not 5.
+
+    .. [HerzbergerSalzberg1962] M. Herzberger and C. D. Salzberg 1962, Refractive indices
+        of infrared optical materials and color correction of infrared lenses, J. Opt.
+        Soc. Am. 52, 420–427 (1962)
+    '''
+    _check_count(coefficients, 5, 'Herzberger')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+
+        n = coefficients[0]
+        n = n + coefficients[1] / (wl**2 - 0.028)
+        n = n + coefficients[2] / (wl**2 - 0.028)**2
+
+        for i in range(3, len(coefficients)):
+            n = n + coefficients[i] * wl**(2 * (i - 2))
+
+        return n
+
+    return refractive_index
+
+
+def make_retro_index(coefficients):
+    r'''The retro dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the retro formula is [Polyanskiy2024]_,
+
+    .. math:: n = \sqrt{\frac{2T + 1}{1 - T}}, \quad T = C_0 + \frac{C_1 \lambda^2}{\lambda^2 - C_2} + C_3 \lambda^2
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the number of coefficients is not 4.
+
+    .. [Polyanskiy2024] M. N. Polyanskiy 2024, Refractiveindex.info database of optical
+        constants, Scientific Data. 11, 94 (2024)
+    '''
+    _check_count(coefficients, 4, 'retro')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+
+        T = coefficients[0] + coefficients[1] * wl**2 / (wl**2 - coefficients[2]) + coefficients[3] * wl**2
+
+        return np.sqrt((2 * T + 1) / (1 - T))
+
+    return refractive_index
+
+
+def make_exotic_index(coefficients):
+    r'''The exotic dispersion formula for the refractive index of materials.
+
+    The dispersion relation of the exotic formula is [Rosker1985]_,
+
+    .. math:: n^2 = C_0 + \frac{C_1}{\lambda^2 - C_2} + \frac{C_3 (\lambda - C_4)}{(\lambda - C_4)^2 + C_5}
+
+    Parameters
+    ----------
+    coefficients : array_like
+        The coefficients C0, C1, ... of the formula.
+
+    Returns
+    -------
+    function
+        The refractive index as a function of wavelength in meters.
+
+    Raises
+    ------
+    ValueError
+        If the number of coefficients is not 6.
+
+    .. [Rosker1985] M. J. Rosker, K. Cheng, and C. L. Tang 1985, Practical urea optical
+        parametric oscillator for tunable generation throughout the visible and
+        near-infrared, IEEE J. Quantum Electron. 21, 1600–1606 (1985)
+    '''
+    _check_count(coefficients, 6, 'exotic')
+
+    def refractive_index(wavelength):
+        wl = wavelength * 1e6
+
+        return np.sqrt(
+            coefficients[0] + coefficients[1] / (wl**2 - coefficients[2]) + coefficients[3] * (wl - coefficients[4]) / ((wl - coefficients[4])**2 + coefficients[5])
+        )
+
+    return refractive_index

--- a/hcipy/materials/material.py
+++ b/hcipy/materials/material.py
@@ -1,0 +1,216 @@
+import warnings
+
+import numpy as np
+
+__all__ = [
+    'RefractiveIndexMaterial'
+]
+
+# The d, F and C spectral lines in meters.
+_LINE_D = 0.5875618e-6
+_LINE_F = 0.4861327e-6
+_LINE_C = 0.6562725e-6
+
+class RefractiveIndexMaterial:
+    '''A material from the refractiveindex.info database.
+
+    The refractive index is given by n + 1j*k, with the complex refractive
+    index returned by calling the material. Wavelengths are in meters.
+
+    Parameters
+    ----------
+    page : str
+        The name of the page in the database.
+    n_function : function or None
+        A function of the wavelength (in meters) returning the refractive
+        index. None if the material has no refractive index data.
+    k_function : function or None, optional
+        A function of the wavelength (in meters) returning the extinction
+        coefficient. Defaults to None, in which case the extinction
+        coefficient is assumed to be zero.
+    shelf : str, optional
+        The shelf in the refractiveindex.info database.
+    book : str, optional
+        The book in the refractiveindex.info database.
+    wavelength_range : (float, float) or None, optional
+        The valid wavelength range of the material in meters. Evaluating the
+        material outside this range produces a warning, unless
+        allow_extrapolation is set.
+    '''
+    def __init__(self, page, n_function, k_function=None, *, shelf=None, book=None, wavelength_range=None):
+        self.page = page
+        self.n_function = n_function
+        self.k_function = k_function
+        self.shelf = shelf
+        self.book = book
+        self.wavelength_range = wavelength_range
+
+    def _check_wavelength_range(self, wavelength, allow_extrapolation):
+        if allow_extrapolation or self.wavelength_range is None:
+            return
+
+        lo, hi = self.wavelength_range
+        wl = np.asarray(wavelength)
+
+        if np.any(wl < lo) or np.any(wl > hi):
+            warnings.warn(
+                f'Material {self.page!r} evaluated outside its valid wavelength range '
+                f'[{lo * 1e6:.3g}, {hi * 1e6:.3g}] um.',
+                UserWarning,
+                stacklevel=3)
+
+    def __call__(self, wavelength, allow_extrapolation=False):
+        '''Get the complex refractive index n + 1j*k at the given wavelength.
+
+        Parameters
+        ----------
+        wavelength : scalar or array_like
+            The wavelength in meters.
+        allow_extrapolation : bool, optional
+            Allow evaluation outside the valid wavelength range without
+            a warning. Defaults to False.
+
+        Returns
+        -------
+        scalar or array_like
+            The complex refractive index.
+        '''
+        return self.n(wavelength, allow_extrapolation) + 1j * self.k(wavelength, allow_extrapolation)
+
+    def n(self, wavelength, allow_extrapolation=False):
+        '''Get the real refractive index n at the given wavelength.
+
+        Parameters
+        ----------
+        wavelength : scalar or array_like
+            The wavelength in meters.
+        allow_extrapolation : bool, optional
+            Allow evaluation outside the valid wavelength range without
+            a warning. Defaults to False.
+
+        Returns
+        -------
+        scalar or array_like
+            The real refractive index.
+        '''
+        if self.n_function is None:
+            raise ValueError(f'Material {self.page!r} has no refractive index data.')
+        self._check_wavelength_range(wavelength, allow_extrapolation)
+        return self.n_function(wavelength)
+
+    def k(self, wavelength, allow_extrapolation=False):
+        '''Get the extinction coefficient k at the given wavelength.
+
+        Parameters
+        ----------
+        wavelength : scalar or array_like
+            The wavelength in meters.
+        allow_extrapolation : bool, optional
+            Allow evaluation outside the valid wavelength range without
+            a warning. Defaults to False.
+
+        Returns
+        -------
+        scalar or array_like
+            The extinction coefficient. Zero if no extinction data is
+            available for this material.
+        '''
+        if self.k_function is None:
+            return wavelength * 0
+        self._check_wavelength_range(wavelength, allow_extrapolation)
+        return self.k_function(wavelength)
+
+    def dispersion(self, wavelength_1, wavelength_2):
+        '''Get the difference in refractive index n(wavelength_1) - n(wavelength_2).
+
+        Parameters
+        ----------
+        wavelength_1 : scalar or array_like
+            The first wavelength in meters.
+        wavelength_2 : scalar or array_like
+            The second wavelength in meters.
+
+        Returns
+        -------
+        scalar or array_like
+            The difference in refractive index.
+        '''
+        return self.n(wavelength_1) - self.n(wavelength_2)
+
+    def partial_dispersion(self, wavelength_1, wavelength_2, wavelength_3, wavelength_4):
+        '''Get the partial dispersion ratio.
+
+        The partial dispersion is defined as
+        (n(wavelength_1) - n(wavelength_2)) / (n(wavelength_3) - n(wavelength_4)).
+
+        Parameters
+        ----------
+        wavelength_1 : scalar or array_like
+            The first wavelength in meters.
+        wavelength_2 : scalar or array_like
+            The second wavelength in meters.
+        wavelength_3 : scalar or array_like
+            The third wavelength in meters.
+        wavelength_4 : scalar or array_like
+            The fourth wavelength in meters.
+
+        Returns
+        -------
+        scalar or array_like
+            The partial dispersion ratio.
+        '''
+        return self.dispersion(wavelength_1, wavelength_2) / self.dispersion(wavelength_3, wavelength_4)
+
+    def abbe(self, wavelength_short=None, wavelength_center=None, wavelength_long=None):
+        '''Get the Abbe number.
+
+        The Abbe number is defined as
+        (n(wavelength_center) - 1) / (n(wavelength_short) - n(wavelength_long)).
+        By default, the F, d and C spectral lines are used.
+
+        Parameters
+        ----------
+        wavelength_short : scalar, optional
+            The short wavelength in meters. Defaults to the F spectral line.
+        wavelength_center : scalar, optional
+            The center wavelength in meters. Defaults to the d spectral line.
+        wavelength_long : scalar, optional
+            The long wavelength in meters. Defaults to the C spectral line.
+
+        Returns
+        -------
+        scalar
+            The Abbe number.
+        '''
+        if wavelength_short is None:
+            wavelength_short = _LINE_F
+        if wavelength_center is None:
+            wavelength_center = _LINE_D
+        if wavelength_long is None:
+            wavelength_long = _LINE_C
+
+        n_center = self.n(wavelength_center)
+        n_short = self.n(wavelength_short)
+        n_long = self.n(wavelength_long)
+
+        return (n_center - 1) / (n_short - n_long)
+
+    @property
+    def page_info(self):
+        '''Get the provenance of this material.
+
+        Returns
+        -------
+        dict
+            A dictionary with the keys 'shelf', 'book', 'page' and
+            'wavelength_range'.
+        '''
+        return {
+            'shelf': self.shelf,
+            'book': self.book,
+            'page': self.page,
+            'wavelength_range': self.wavelength_range
+        }
+
+    def __repr__(self):
+        return f'RefractiveIndexMaterial({self.page!r}, shelf={self.shelf!r}, book={self.book!r})'

--- a/hcipy/optics/glass.py
+++ b/hcipy/optics/glass.py
@@ -2,6 +2,9 @@ import numpy as np
 
 from importlib.resources import files
 
+from ..dev import deprecated
+
+@deprecated('Use hcipy.make_sellmeier_index instead.')
 def make_sellmeier_glass(A, K, L):
     r'''The Sellmeier equation for the dispersion of the refractive index of materials.
 
@@ -36,6 +39,7 @@ def make_sellmeier_glass(A, K, L):
 
     return refractive_index
 
+@deprecated('Use hcipy.make_cauchy_index instead.')
 def make_cauchy_glass(coefficients):
     r'''The Cauchy equation for the dispersion of the refractive index of materials.
 
@@ -63,6 +67,7 @@ def make_cauchy_glass(coefficients):
 
 _glass_catalogue = None
 
+@deprecated('Use hcipy.get_material instead.')
 def get_refractive_index(glass_name):
     '''Get the refractive index for one of the glasses in the catalogue.
 
@@ -90,6 +95,7 @@ def get_refractive_index(glass_name):
 
     return _glass_catalogue[glass_name]
 
+@deprecated('Use hcipy.search_material instead.')
 def get_glasses_in_catalogue():
     '''Get the names of all the glasses in the glass catalogue.
 

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,0 +1,177 @@
+import warnings
+
+import numpy as np
+import pytest
+
+from hcipy.materials import (
+    MaterialCatalog,
+    AmbiguousMaterialError,
+    make_sellmeier_index,
+    make_sellmeier2_index,
+    make_polynomial_index,
+    make_rii_index,
+    make_cauchy_index,
+    make_gases_index,
+    make_herzberger_index,
+    make_retro_index,
+    make_exotic_index
+)
+
+@pytest.fixture(scope='session')
+def catalog():
+    return MaterialCatalog()
+
+def test_sellmeier():
+    f = make_sellmeier_index([0, 0.6961663, 0.0684043, 0.4079426, 0.1162414, 0.8974794, 9.896161])
+    assert f(0.5876e-6) == pytest.approx(1.45847, rel=1e-5)
+
+def test_sellmeier2():
+    f = make_sellmeier2_index([0, 1.03961212, 0.00600069867, 0.231792344, 0.0200179144, 1.01046945, 103.560653])
+    assert f(0.5876e-6) == pytest.approx(1.51680, abs=1e-4)
+
+def test_polynomial():
+    f = make_polynomial_index([4, 0, 2])
+    assert f(0.5e-6) == pytest.approx(2.0)
+
+def test_rii():
+    f = make_rii_index([4, 0, 2, 1, 2, 0, 2, 1, 2])
+    assert f(0.5e-6) == pytest.approx(2.0)
+
+def test_cauchy():
+    f = make_cauchy_index([1.5, 0, -2])
+    assert f(0.5e-6) == pytest.approx(1.5)
+
+def test_gases():
+    f = make_gases_index([0, 0, 1])
+    assert f(0.5e-6) == pytest.approx(1.0)
+
+def test_herzberger():
+    f = make_herzberger_index([1.5, 0, 0, 0, 0])
+    assert f(0.5e-6) == pytest.approx(1.5)
+
+def test_retro():
+    f = make_retro_index([0, 0, 1, 0])
+    assert f(0.5e-6) == pytest.approx(1.0)
+
+def test_exotic():
+    f = make_exotic_index([4, 0, 1, 0, 1, 1])
+    assert f(0.5e-6) == pytest.approx(2.0)
+
+def test_material_formula(catalog):
+    mat = catalog.get('N-BK7')
+
+    assert mat.n(0.5876e-6) == pytest.approx(1.51680, abs=1e-4)
+    assert mat.k(0.5876e-6) == pytest.approx(9.7525e-9)
+    assert mat(0.5876e-6) == pytest.approx(1.51680 + 1j * 9.7525e-9, abs=1e-4)
+
+    wl = np.array([0.4e-6, 0.6e-6])
+    assert np.allclose(mat.n(wl), [mat.n(0.4e-6), mat.n(0.6e-6)])
+
+def test_material_no_k(catalog):
+    mat = catalog.get('Malitson', shelf='main', book='SiO2')
+
+    assert mat.k(0.5e-6) == 0.0
+    assert mat(0.5e-6) == pytest.approx(mat.n(0.5e-6))
+
+def test_material_k_only(catalog):
+    mat = catalog.get('Bosomworth-5K', shelf='main', book='BaF2')
+
+    assert mat.k(3e-6) != 0.0
+    with pytest.raises(ValueError):
+        mat.n(5e-6)
+    with pytest.raises(ValueError):
+        mat(5e-6)
+
+def test_material_tabulated(catalog):
+    mat = catalog.get('Lane')
+
+    assert mat.n(5e-6) == pytest.approx(1.3995)
+    assert mat.k(3e-6) == pytest.approx(0.0369)
+
+def test_material_properties(catalog):
+    mat = catalog.get('N-BK7')
+
+    assert mat.abbe() == pytest.approx(64.17, abs=0.1)
+    assert mat.dispersion(0.4861327e-6, 0.6562725e-6) == pytest.approx(0.00805, abs=1e-3)
+    assert mat.partial_dispersion(0.4861327e-6, 0.6562725e-6, 0.4861327e-6, 0.6562725e-6) == pytest.approx(1.0)
+
+def test_page_info(catalog):
+    info = catalog.get('N-BK7').page_info
+
+    assert info['shelf'] == 'specs'
+    assert info['book'] == 'SCHOTT-optical'
+    assert info['page'] == 'N-BK7'
+    assert info['wavelength_range'][0] == pytest.approx(0.3e-6)
+    assert info['wavelength_range'][1] == pytest.approx(2.5e-6)
+
+def test_get(catalog):
+    mat = catalog.get('N-BK7')
+    assert mat.page == 'N-BK7'
+
+def test_get_ambiguous(catalog):
+    with pytest.raises(AmbiguousMaterialError) as exc:
+        catalog.get('Malitson')
+    assert len(exc.value.candidates) > 1
+
+    mat = catalog.get('Malitson', shelf='main', book='SiO2')
+    assert mat.book == 'SiO2'
+    assert mat.n(0.5876e-6) == pytest.approx(1.45846, rel=1e-5)
+
+def test_get_narrowed_miss(catalog):
+    with pytest.raises(KeyError):
+        catalog.get('N-BK7', book='OHARA-optical')
+
+def test_get_missing(catalog):
+    with pytest.raises(KeyError):
+        catalog.get('N-BK4')
+
+def test_search(catalog):
+    results = catalog.search('BK7')
+    assert len(results) > 0
+    assert all('BK7' in m.page or 'BK7' in m.book for m in results)
+
+    assert catalog.search('nope') == []
+
+def test_search_all(catalog):
+    results = catalog.search()
+
+    assert 0 < len(results) <= len(catalog)
+    assert all(m.page for m in results)
+
+def test_bad_coefficient_counts():
+    with pytest.raises(ValueError):
+        make_sellmeier_index([0, 0.6961663, 0.0684043, 0.4079426])
+
+    with pytest.raises(ValueError):
+        make_herzberger_index([1.5, 0, 0])
+
+    with pytest.raises(ValueError):
+        make_exotic_index([4, 0, 1, 0, 1])
+
+    with pytest.raises(ValueError):
+        make_rii_index([4, 0, 2, 1, 2])
+
+def test_wavelength_range_warning(catalog):
+    mat = catalog.get('N-BK7')
+
+    with pytest.warns(UserWarning, match='outside its valid wavelength range'):
+        mat.n(3e-6)
+
+    with pytest.warns(UserWarning, match='outside its valid wavelength range'):
+        mat.k(3e-6)
+
+    with pytest.warns(UserWarning, match='outside its valid wavelength range'):
+        mat(3e-6)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        mat.n(0.6e-6)
+        mat.k(0.6e-6)
+        mat(0.6e-6)
+        mat.n(3e-6, allow_extrapolation=True)
+        mat.k(3e-6, allow_extrapolation=True)
+        mat(3e-6, allow_extrapolation=True)
+
+def test_explicit_path_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        MaterialCatalog(tmp_path / 'nonexistent')


### PR DESCRIPTION
# Add refractiveindex.info materials module

Adds a new `hcipy/materials` submodule providing optical material data and dispersion formulae from [refractiveindex.info](https://refractiveindex.info). The old `hcipy.optics.glass` material lookup functions are deprecated in favor of it.

## What's new

- **`MaterialCatalog`** — loads the RII database and provides strict lookups:
  - `get(page, shelf=..., book=...)` exact name lookup, with `AmbiguousMaterialError` (with candidate pages) when a name matches multiple pages, and difflib "Did you mean…?" suggestions on a miss.
  - `search(page=..., *, shelf=..., book=...)` substring search over page and book names.
  - `__getitem__` / `__contains__` / `__len__` for convenience.
  - The `'3d'` and `'popular_glass'` shelves are excluded from the catalog since they are duplicates.
  - Can be loaded from a default path or from a user-supplied path. It will auto-download if the default path is used and it has not been downloaded before.
- **`RefractiveIndexMaterial`** — callable material object returning the complex index `n + 1j·k`:
  - `.n()`, `.k()`, `.dispersion()`, `.partial_dispersion()`, `.abbe()`.
  - `page_info` provenance dict (`shelf`, `book`, `page`, `wavelength_range`).
  - Evaluating outside the page's valid wavelength range emits a `UserWarning` unless `allow_extrapolation=True`.
- **Dispersion formula factories** — all nine RII formula types (`make_sellmeier_index`, `make_sellmeier2_index`, `make_polynomial_index`, `make_rii_index`, `make_cauchy_index`, `make_gases_index`, `make_herzberger_index`, `make_retro_index`, `make_exotic_index`).
- **`download_rii_database()`** — downloads the pinned release zip (v2026-05-24) and extracts it; `MaterialCatalog()` auto-downloads to `~/.hcipy/rii_database` on first use. Databases can also be downloaded to a specific path 
- Module-level helpers `get_material()` / `search_material()` using the default catalog.

## Deprecations

I deprecated the four existing glass material functions in `hcipy.optics.glass`. There are a few changes wrt the previous functions.

- Name matching is now strict; case-insensitive matching was dropped. Instead we use suggestions of close names that are in the catalog.
- `get_material('N-BK7')` returns a complex-index material $$n(\lambda) + i k(\lambda)$$ instead of just $$n(\lambda)$$.
- The RII database is downloaded on first use (~13 MB zip). For the previous functions, the database (2 csv files) were shipped alongside the code. Therefore, without an internet connection, this function will fail if not manually downloaded before.