### PR TITLE
Strip linebreaks before installing optional dependencies

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Install optional dependencies if available
       run: |
         while read requirement; do
-          conda install --yes $requirement || true
-        done < ./.github/conda_environments/optional_dependencies.txt
+          conda install --yes "$requirement" || true
+        done < <(tr -d '\r' < ./.github/conda_environments/optional_dependencies.txt)
       shell: bash -l {0}
 
     - name: Install our package

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Install optional dependencies if available
       run: |
         while read requirement; do
-          conda install --yes $requirement || true
-        done < .github/conda_environments/optional_dependencies.txt
+          conda install --yes "$requirement" || true
+        done < <(tr -d '\r' < .github/conda_environments/optional_dependencies.txt)
       shell: bash -l {0}
     - name: Install our package
       run: |


### PR DESCRIPTION
Fixes optional-dependency install on Windows where the file is checked out with CRLF line endings, causing conda to reject specs like `mkl_fft\r`.

- Pipe `optional_dependencies.txt` through `tr -d '\r'` in both workflows (`testing.yml`, `array_api.yml`)
- Quote `$requirement` when passing to conda