### PR TITLE
Deprecate Fourier and OpticalElement transformation matrix methods

### DIFF
--- a/hcipy/coronagraphy/apodizing_phase_plate.py
+++ b/hcipy/coronagraphy/apodizing_phase_plate.py
@@ -2,6 +2,7 @@ import numpy as np
 from ..field import Field
 
 from ..optics import GeometricPhaseElement
+from ..dev import deprecated
 
 def generate_app_keller(wavefront, propagator, contrast, num_iterations, beta=0):
     """
@@ -87,6 +88,7 @@ def generate_app_keller(wavefront, propagator, contrast, num_iterations, beta=0)
 
     return app
 
+@deprecated('This function depends on deprecated functionality.', version='0.9.0')
 def generate_app_por(wavefront, propagator, propagator_max, contrast, num_iterations=1):
     '''Optimize a one-sided APP using a globally optimal algorithm.
 

--- a/hcipy/coronagraphy/perfect_coronagraph.py
+++ b/hcipy/coronagraphy/perfect_coronagraph.py
@@ -2,6 +2,7 @@ import numpy as np
 from ..optics import OpticalElement
 from ..mode_basis import ModeBasis
 from ..util import inverse_truncated
+from ..dev import deprecated
 
 class PerfectCoronagraph(OpticalElement):
     r'''A perfect coronagraph for a certain aperture and order.
@@ -104,6 +105,7 @@ class PerfectCoronagraph(OpticalElement):
         '''
         return self.forward(wavefront)
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_forward(self, wavelength=1):
         '''Get the forward propagation transformation matrix.
 
@@ -119,6 +121,7 @@ class PerfectCoronagraph(OpticalElement):
         '''
         return np.eye(self.pupil_grid.size) - self.transformation.dot(np.expand_dims(self.coeffs, axis=1) * self.transformation_inverse)
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_backward(self, wavelength=1):
         '''Get the backwards propagation transformation matrix.
 

--- a/hcipy/dev.py
+++ b/hcipy/dev.py
@@ -1,13 +1,16 @@
 import functools
 import warnings
 
-def deprecated(reason):  # pragma: no cover
+def deprecated(reason, version=None):  # pragma: no cover
     '''Decorator for deprecating functions.
 
     Parameters
     ----------
     reason : str
         The reason for deprecation. This will be printed with the warning.
+    version : str or None
+        The version in which the function will be removed. If not None, this will be
+        printed with the warning.
 
     Returns
     -------
@@ -17,7 +20,12 @@ def deprecated(reason):  # pragma: no cover
     def decorator(func):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            warnings.warn(f'{func.__name__} is deprecated. {reason}', DeprecationWarning, stacklevel=2)
+            message = f'{func.__name__} is deprecated.'
+            if version is not None:
+                message += f' Will be removed in hcipy {version}.'
+            if reason:
+                message += ' ' + reason
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wrapped

--- a/hcipy/fourier/fourier_transform.py
+++ b/hcipy/fourier/fourier_transform.py
@@ -1,5 +1,6 @@
 import numpy as np
 from ..field import Field
+from ..dev import deprecated
 
 from dataclasses import dataclass
 import math
@@ -54,6 +55,7 @@ class FourierTransform(object):
         '''
         raise NotImplementedError()
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_forward(self):
         '''Returns the transformation matrix corresonding to the
         Fourier transform.
@@ -71,6 +73,7 @@ class FourierTransform(object):
 
         return A
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_backward(self):
         '''Returns the transformation matrix corresonding to the
         Fourier transform.

--- a/hcipy/fourier/naive_fourier_transform.py
+++ b/hcipy/fourier/naive_fourier_transform.py
@@ -59,10 +59,10 @@ class NaiveFourierTransform(FourierTransform):
         '''The cached forward propagation matrix.
         '''
         if not self.precompute_matrices:
-            return self.get_transformation_matrix_forward()
+            return self._get_transformation_matrix_forward()
 
         if self._matrix_forward is None:
-            self._matrix_forward = self.get_transformation_matrix_forward()
+            self._matrix_forward = self._get_transformation_matrix_forward()
 
         return self._matrix_forward
 
@@ -71,12 +71,47 @@ class NaiveFourierTransform(FourierTransform):
         '''The cached backward propagation matrix.
         '''
         if not self.precompute_matrices:
-            return self.get_transformation_matrix_backward()
+            return self._get_transformation_matrix_backward()
 
         if self._matrix_backward is None:
-            self._matrix_backward = self.get_transformation_matrix_backward()
+            self._matrix_backward = self._get_transformation_matrix_backward()
 
         return self._matrix_backward
+
+    def _get_transformation_matrix_forward(self):
+        '''Returns the transformation matrix corresponding to the
+        Fourier transform.
+
+        Returns
+        -------
+        ndarray
+            A matrix representing the Fourier transform.
+        '''
+        coords_in = self.input_grid.as_('cartesian').coords
+        coords_out = self.output_grid.as_('cartesian').coords
+
+        A = np.exp(-1j * np.dot(np.array(coords_out).T, coords_in))
+        A *= self.input_grid.weights
+
+        return A
+
+    def _get_transformation_matrix_backward(self):
+        '''Returns the transformation matrix corresponding to the
+        Fourier transform.
+
+        Returns
+        -------
+        ndarray
+            A matrix representing the Fourier transform.
+        '''
+        coords_in = self.input_grid.as_('cartesian').coords
+        coords_out = self.output_grid.as_('cartesian').coords
+
+        A = np.exp(1j * np.dot(np.array(coords_in).T, coords_out))
+        A *= self.output_grid.weights
+        A /= (2 * np.pi)**self.input_grid.ndim
+
+        return A
 
     @multiplex_for_tensor_fields
     def forward(self, field):

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -3,6 +3,8 @@ import inspect
 import collections
 import itertools
 
+from ..dev import deprecated
+
 class OpticalElement(object):
     '''Base class for all optical elements.
 
@@ -92,6 +94,7 @@ class OpticalElement(object):
         '''
         raise NotImplementedError()
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_forward(self, wavelength=1):
         '''Calculate the linear transformation matrix that corresponds
         to a forward propagation.
@@ -119,6 +122,7 @@ class OpticalElement(object):
         '''
         raise NotImplementedError()
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_backward(self, wavelength=1):
         '''Calculate the linear transformation matrix that corresponds
         to a backward propagation.
@@ -214,8 +218,9 @@ class EmptyOpticalElement(OpticalElement):
         '''
         return wavefront
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_forward(self, wavelength=1):
-        '''Calculate the backward linear transformation matrix for the empty optical element.
+        '''Calculate the linear transformation matrix for the empty optical element.
 
         Parameters
         ----------
@@ -229,6 +234,7 @@ class EmptyOpticalElement(OpticalElement):
         '''
         return np.array(1)
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_backward(self, wavelength=1):
         '''Calculate the backward linear transformation matrix for the empty optical element.
 
@@ -968,6 +974,7 @@ class OpticalSystem(object):
 
         return wf
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_forward(self, wavelength=1):
         '''Calculate the forward linear transformation matrix.
 
@@ -988,8 +995,9 @@ class OpticalSystem(object):
 
         return matrix
 
+    @deprecated('This method is too memory-intensive for practical use.', version='0.9.0')
     def get_transformation_matrix_backward(self, wavelength=1):
-        '''Calculate the forward linear transformation matrix.
+        '''Calculate the backward linear transformation matrix.
 
         Parameters
         ----------


### PR DESCRIPTION
Deprecate `get_transformation_matrix_forward()` and `get_transformation_matrix_backward()` on `OpticalElement` and its child classes and on the `FourierTransform` class. Corrolary is the deprecation of `generate_app_por()`. I do not think any people are using this functionality.

These transformation matrix methods are extremely memory-intensive, too much for practical use, and are only viable for toy models or for small grids / big machines.

See #360 for functionality that replaces it, but in a much better way.