### PR TITLE
Add codecov configuration.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  notify:
+    after_n_builds: 2
+
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        threshold: 0.5


### PR DESCRIPTION
Adds `.github/codecov.yml` to the repository. Most of the configuration (`coverage.status.patch: false` and `coverage.status.project.default.threshold: 0.5`) was previously set on the Codecov side and is now version-controlled in the repo.

In addition, `codecov.notify.after_n_builds: 2` is newly added: Codecov waits for 2 uploaded reports before posting status checks, so statuses aren't posted based on a single, possibly incomplete report.