### PR TITLE
Fix Grid hashing with xxhash 4.0.0

### DIFF
--- a/hcipy/field/grid.py
+++ b/hcipy/field/grid.py
@@ -460,7 +460,7 @@ class Grid(object):
 
     def __hash__(self):
         h = xxhash.xxh64()
-        h.update(self._coordinate_system)
+        h.update(self._coordinate_system.encode())
 
         if self.is_regular:
             h.update(to_numpy(self.delta).tobytes())


### PR DESCRIPTION
xxhash 4.0.0 rejects strings passed to `update()` (TypeError: Strings must be encoded before hashing). Encode the coordinate system name in `Grid.__hash__` before hashing.

See #365. This PR fixes the root cause of issue, but I'll leave the issue open until I update PyPI.