### PR TITLE
v0.7.1 hotfix: Fix Grid hashing with xxhash 4.0.0

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.7.1 (unreleased)
+------------------
+
+- Fix Grid hashing with xxhash 4.0.0 in `#366 <https://github.com/ehpor/hcipy/pull/366>`__.
+
 0.7.0 (Aug 25, 2025)
 --------------------
 

--- a/hcipy/field/grid.py
+++ b/hcipy/field/grid.py
@@ -444,7 +444,7 @@ class Grid(object):
 
     def __hash__(self):
         h = xxhash.xxh64()
-        h.update(self._coordinate_system)
+        h.update(self._coordinate_system.encode())
 
         if self.is_regular:
             h.update(self.delta)


### PR DESCRIPTION
Hotfix draft for the 0.7.0 release line.

- Branched from `v0.7.0` tag, cherry-picked the xxhash 4.0.0 fix (`grid.py`: encode coordinate system string before hashing).
- Added changelog entry for 0.7.1.

Once reviewed, merge this, then tag `v0.7.1` (version is derived from tags via setuptools-scm; no manual version bump needed).