### PR TITLE
Add changelog entry for v0.7.1.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.7.1 (Sep 2, 2026)
+--------------------
+
+This HCIPy release provides a bugfix for grid hashing. This version supports Python 3.9-3.13.
+
+What's Changed
+~~~~~~~~~~~~~~
+- Fix Grid hashing with xxhash 4.0.0 in `#366 <https://github.com/ehpor/hcipy/pull/366>`__.
+
+**Full Changelog**: `v0.7.0...v0.7.1 <https://github.com/ehpor/hcipy/compare/v0.7.0...v0.7.1>`__
+
 0.7.0 (Aug 25, 2025)
 --------------------
 


### PR DESCRIPTION
Release of HCIPy 0.7.1.

This release is just to fix the install (see #365 and #366).