### PR TITLE
Zernike polynomial fix

### DIFF
--- a/hcipy/mode_basis/__init__.py
+++ b/hcipy/mode_basis/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     'zernike_to_ansi',
     'zernike_radial_indices',
     'zernike_radial',
+    'zernike_azimuthal',
     'disk_harmonic',
     'disk_harmonic_energy',
     'make_disk_harmonic_basis',

--- a/hcipy/mode_basis/__init__.py
+++ b/hcipy/mode_basis/__init__.py
@@ -28,6 +28,8 @@ __all__ = [
     'zernike_to_noll',
     'ansi_to_zernike',
     'zernike_to_ansi',
+    'zernike_radial_indices',
+    'zernike_radial',
     'disk_harmonic',
     'disk_harmonic_energy',
     'make_disk_harmonic_basis',

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -88,7 +88,44 @@ def zernike_to_noll(n, m):
             return j
     raise ValueError(f'Could not find noll index for n={n}, m={m}.')
 
-def zernike_radial(n, m, r, cache=None):
+def zernike_radial_indices(num_modes):
+    """
+    Return the first `num_modes` unique (n, m) pairs for
+    radial Zernike polynomials.
+
+    The ordering is:
+        n = 0, m = 0
+        n = 1, m = 1
+        n = 2, m = 0, 2
+        n = 3, m = 1, 3
+        n = 4, m = 0, 2, 4
+        ...
+
+    Parameters
+    ----------
+    num_modes : int
+        Number of unique radial Zernike polynomials.
+
+    Returns
+    -------
+    list of tuple
+        List of (n, m) pairs.
+    """
+    indices = []
+
+    n = 0
+    while len(indices) < num_modes:
+        for m in range(n % 2, n + 1, 2):
+            indices.append((n, m))
+
+            if len(indices) == num_modes:
+                break
+
+        n += 1
+
+    return indices
+
+def zernike_radial_chong(n, m, r, cache=None):
     '''The radial component of a Zernike polynomial.
 
     We use the q-recursive method, which uses recurrence relations to calculate the radial
@@ -126,8 +163,8 @@ def zernike_radial(n, m, r, cache=None):
     if n == m:
         res = r**n
     elif (n - m) == 2:
-        z1 = zernike_radial(n, n, r, cache)
-        z2 = zernike_radial(n - 2, n - 2, r, cache)
+        z1 = zernike_radial_chong(n, n, r, cache)
+        z2 = zernike_radial_chong(n - 2, n - 2, r, cache)
 
         res = n * z1 - (n - 1) * z2
     else:
@@ -138,13 +175,130 @@ def zernike_radial(n, m, r, cache=None):
         h2 = h3 * (p + q) * (p - q + 2) / float(4 * (q - 1)) + (q - 2)
         h1 = q * (q - 1) / 2.0 - q * h2 + h3 * (p + q + 2) * (p - q) / 8.0
 
-        r2 = zernike_radial(2, 2, r, cache)
-        res = h1 * zernike_radial(p, q, r, cache) + (h2 + h3 / r2) * zernike_radial(n, q - 2, r, cache)
+        r2 = zernike_radial_chong(2, 2, r, cache)
+        res = h1 * zernike_radial_chong(p, q, r, cache) + (h2 + h3 / r2) * zernike_radial_chong(n, q - 2, r, cache)
 
     if cache is not None:
         cache[('rad', n, m)] = res
 
     return res
+
+def zernike_radial_andersen(n, m, r, cache=None):
+    """
+    The radial component of a Zernike polynomial.
+
+    This implementation uses the Cartesian/polar-compatible recurrence
+    described by Andersen [Andersen2018], rather than the q-recursive
+    recurrence that contains a 1/r**2 term.
+
+    In particular, it uses
+
+        R_n^m = r * (R_{n-1}^{m-1} + R_{n-1}^{m+1}) - R_{n-2}^m
+
+    with the appropriate boundary conditions.
+
+    This recurrence contains no division by r and therefore remains
+    well-defined when r == 0.
+
+    .. [Andersen2018] Andersen, T. B. (2018). Efficient and robust recurrence relations
+      for the Zernike circle polynomials and their derivatives in Cartesian coordinates. 
+      Optics Express, 26(15), 18878-18896.
+
+    Parameters
+    ----------
+    n : int
+        The radial Zernike order.
+    m : int
+        The azimuthal Zernike order.
+    r : array_like
+        The (normalized) radial coordinates on which to calculate the polynomial.
+    cache : dict or None
+        A dictionary containing previously calculated Zernike modes on the same grid.
+        This function is for speedup only, and therefore the cache is expected to be
+        valid. You can reuse the cache for future calculations on the same exact grid.
+        The given dictionary is updated with the current calculation.
+
+    Returns
+    -------
+    array_like
+        The radial component of the evaluated Zernike polynomial.
+    """
+
+    m = abs(m)
+
+    # Invalid Zernike combinations.
+    if m > n or (n - m) % 2 != 0:
+        return np.zeros_like(r)
+
+    if cache is not None:
+        key = ('rad', n, m)
+
+        if key in cache:
+            return cache[key]
+
+    # We calculate all radial polynomials up to n.
+    # The Andersen recurrence couples radial orders n-1 and n-2,
+    # so calculating the whole triangular set is considerably simpler
+    # than trying to recursively evaluate individual terms.
+
+    R = {}
+
+    # Starting polynomials:
+    # R_0^0 = 1
+    # R_1^1 = r
+    R[(0, 0)] = np.ones_like(r)
+
+    if n >= 1:
+        R[(1, 1)] = r
+
+    for nn in range(2, n + 1):
+
+        # Only m values with the same parity as n are valid.
+        for mm in range(nn % 2, nn + 1, 2):
+
+            if mm == 0:
+                R[(nn, 0)] = 2 * r * R[(nn - 1, 1)] - R[(nn - 2, 0)]
+            elif mm == nn:
+                R[(nn, mm)] = r * R[(nn - 1, mm - 1)]
+            else:
+                R[(nn, mm)] = r * (R[(nn - 1, mm-1)] + R[(nn - 1, mm + 1)]) - R[(nn - 2, mm)]
+
+    result = R[(n, m)]
+
+    if cache is not None:
+        cache[('rad', n, m)] = result
+
+    return result
+
+def zernike_radial(n, m, r, cache=None, use_andersen=True):
+    """
+    The radial component of a Zernike polynomial.
+
+    Parameters
+    ----------
+    n : int
+        The radial Zernike order.
+    m : int
+        The azimuthal Zernike order.
+    r : array_like
+        The (normalized) radial coordinates on which to calculate the polynomial.
+    cache : dict or None
+        A dictionary containing previously calculated Zernike modes on the same grid.
+        This function is for speedup only, and therefore the cache is expected to be
+        valid. You can reuse the cache for future calculations on the same exact grid.
+        The given dictionary is updated with the current calculation.
+    use_andersen : boolean
+        This function uses the Andersen recurrence relationship if True and otherwise the Chong one.
+
+    Returns
+    -------
+    array_like
+        The radial component of the evaluated Zernike polynomial.
+    """
+    if use_andersen:
+        return zernike_radial_andersen(n, m, r, cache)
+    else:
+        return zernike_radial_chong(n, m, r, cache)
 
 def zernike_azimuthal(m, theta, cache=None):
     '''The azimuthal component of a Zernike polynomial.

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -360,7 +360,7 @@ def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_rel
         The given dictionary is updated with the current calculation.
     recurrence_relationship : str
         Determence which recurrence relationship is used. The default is Andersen.
-        
+
     Returns
     -------
     Field or Field generator

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -226,51 +226,46 @@ def zernike_radial_andersen(n, m, r, cache=None):
 
     m = abs(m)
 
-    # Invalid Zernike combinations.
-    if m > n or (n - m) % 2 != 0:
+    # Invalid Zernike combination.
+    if m > n or (n - m) % 2:
         return np.zeros_like(r)
 
-    if cache is not None:
-        key = ('rad', n, m)
+    # Use a local cache if none was supplied.
+    if cache is None:
+        cache = {}
 
-        if key in cache:
-            return cache[key]
+    key = ('rad', n, m)
 
-    # We calculate all radial polynomials up to n.
-    # The Andersen recurrence couples radial orders n-1 and n-2,
-    # so calculating the whole triangular set is considerably simpler
-    # than trying to recursively evaluate individual terms.
+    if key in cache:
+        return cache[key]
 
-    R = {}
+    # Base cases.
+    if n == 0:
+        result = np.ones_like(r)
 
-    # Starting polynomials:
-    # R_0^0 = 1
-    # R_1^1 = r
-    R[(0, 0)] = np.ones_like(r)
+    elif n == 1:
+        result = r
 
-    if n >= 1:
-        R[(1, 1)] = r
+    # Special case m = 0.
+    elif m == 0:
+        result = 2 * r * zernike_radial_andersen(n - 1, 1, r, cache) - zernike_radial_andersen(n - 2, 0, r, cache)
 
-    for nn in range(2, n + 1):
+    # Highest azimuthal order.
+    elif m == n:
+        result = r * zernike_radial_andersen(n - 1, m - 1, r, cache)
 
-        # Only m values with the same parity as n are valid.
-        for mm in range(nn % 2, nn + 1, 2):
+    # General Andersen recurrence.
+    else:
+        z1 = zernike_radial_andersen(n - 1, m - 1, r, cache)
+        z2 = zernike_radial_andersen(n - 1, m + 1, r, cache)
+        z3 = zernike_radial_andersen(n - 2, m, r, cache)
+        result = r * (z1 + z2) - z3
 
-            if mm == 0:
-                R[(nn, 0)] = 2 * r * R[(nn - 1, 1)] - R[(nn - 2, 0)]
-            elif mm == nn:
-                R[(nn, mm)] = r * R[(nn - 1, mm - 1)]
-            else:
-                R[(nn, mm)] = r * (R[(nn - 1, mm - 1)] + R[(nn - 1, mm + 1)]) - R[(nn - 2, mm)]
-
-    result = R[(n, m)]
-
-    if cache is not None:
-        cache[('rad', n, m)] = result
+    cache[key] = result
 
     return result
 
-def zernike_radial(n, m, r, cache=None, use_andersen=True):
+def zernike_radial(n, m, r, cache=None, recurrence_relationship='andersen'):
     """
     The radial component of a Zernike polynomial.
 
@@ -287,18 +282,20 @@ def zernike_radial(n, m, r, cache=None, use_andersen=True):
         This function is for speedup only, and therefore the cache is expected to be
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
-    use_andersen : boolean
-        This function uses the Andersen recurrence relationship if True and otherwise the Chong one.
+    recurrence_relationship : str
+        Determence which recurrence relationship is used. Default is Andersen.
 
     Returns
     -------
     array_like
         The radial component of the evaluated Zernike polynomial.
     """
-    if use_andersen:
+    if recurrence_relationship == 'andersen':
         return zernike_radial_andersen(n, m, r, cache)
-    else:
+    elif recurrence_relationship == 'chong':
         return zernike_radial_chong(n, m, r, cache)
+    else:
+        raise NotImplementedError("The requested recurrence relationship {:s} is not implemented.".format(recurrence_relationship))
 
 def zernike_azimuthal(m, theta, cache=None):
     '''The azimuthal component of a Zernike polynomial.
@@ -338,7 +335,7 @@ def zernike_azimuthal(m, theta, cache=None):
 
     return res
 
-def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None):
+def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_relationship='andersen'):
     '''Evaluate the Zernike polynomial on a grid.
 
     Parameters
@@ -359,7 +356,9 @@ def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None):
         This function is for speedup only, and therefore the cache is expected to be
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
-
+    recurrence_relationship : str
+        Determence which recurrence relationship is used. The default is Andersen.
+        
     Returns
     -------
     Field or Field generator
@@ -369,7 +368,7 @@ def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None):
     from ..field import Field
 
     if grid is None:
-        return lambda grid: zernike(n, m, D, grid, radial_cutoff, cache)
+        return lambda grid: zernike(n, m, D, grid, radial_cutoff, cache, recurrence_relationship)
 
     if grid.is_separated and grid.is_('polar'):
         R, Theta = grid.separated_coords
@@ -379,13 +378,13 @@ def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None):
         z = sqrt(n + 1) * np.outer(zernike_azimuthal(m, Theta, cache), z_r).flatten()
     else:
         r, theta = grid.as_('polar').coords
-        z = sqrt(n + 1) * zernike_azimuthal(m, theta, cache) * zernike_radial(n, m, 2 * r / D, cache)
+        z = sqrt(n + 1) * zernike_azimuthal(m, theta, cache) * zernike_radial(n, m, 2 * r / D, cache, recurrence_relationship)
         if radial_cutoff:
             z *= (2 * r) < D
 
     return Field(z, grid)
 
-def zernike_ansi(i, D=1, grid=None, radial_cutoff=True, cache=None):
+def zernike_ansi(i, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_relationship='andersen'):
     '''Evaluate the Zernike polynomial on a grid using an ANSI index.
 
     Parameters
@@ -404,6 +403,8 @@ def zernike_ansi(i, D=1, grid=None, radial_cutoff=True, cache=None):
         This function is for speedup only, and therefore the cache is expected to be
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
+    recurrence_relationship : str
+        Determence which recurrence relationship is used. The default is Andersen.
 
     Returns
     -------
@@ -412,9 +413,9 @@ def zernike_ansi(i, D=1, grid=None, radial_cutoff=True, cache=None):
         which evaluates the Zernike polynomial on the supplied grid.
     '''
     n, m = ansi_to_zernike(i)
-    return zernike(n, m, D, grid, radial_cutoff, cache)
+    return zernike(n, m, D, grid, radial_cutoff, cache, recurrence_relationship)
 
-def zernike_noll(i, D=1, grid=None, radial_cutoff=True, cache=None):
+def zernike_noll(i, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_relationship='andersen'):
     '''Evaluate the Zernike polynomial on a grid using a Noll index.
 
     Parameters
@@ -433,6 +434,8 @@ def zernike_noll(i, D=1, grid=None, radial_cutoff=True, cache=None):
         This function is for speedup only, and therefore the cache is expected to be
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
+    recurrence_relationship : str
+        Determence which recurrence relationship is used. The default is Andersen.
 
     Returns
     -------
@@ -441,9 +444,9 @@ def zernike_noll(i, D=1, grid=None, radial_cutoff=True, cache=None):
         which evaluates the Zernike polynomial on the supplied grid.
     '''
     n, m = noll_to_zernike(i)
-    return zernike(n, m, D, grid, radial_cutoff, cache)
+    return zernike(n, m, D, grid, radial_cutoff, cache, recurrence_relationship)
 
-def make_zernike_basis(num_modes, D, grid, starting_mode=1, ansi=False, radial_cutoff=True, use_cache=True, cache=None):
+def make_zernike_basis(num_modes, D, grid, starting_mode=1, ansi=False, radial_cutoff=True, use_cache=True, cache=None, recurrence_relationship='andersen'):
     '''Make a ModeBasis of Zernike polynomials.
 
     Parameters
@@ -465,6 +468,8 @@ def make_zernike_basis(num_modes, D, grid, starting_mode=1, ansi=False, radial_c
     use_cache : boolean
         Whether to use a cache while calculating the modes. A cache uses memory, so turn it
         off when you are limited on memory.
+    recurrence_relationship : str
+        Determence which recurrence relationship is used. The default is Andersen.
 
     Returns
     -------
@@ -486,7 +491,7 @@ def make_zernike_basis(num_modes, D, grid, starting_mode=1, ansi=False, radial_c
     else:
         cache = None
 
-    modes = [f(i, D, polar_grid, radial_cutoff, cache) for i in range(starting_mode, starting_mode + num_modes)]
+    modes = [f(i, D, polar_grid, radial_cutoff, cache, recurrence_relationship) for i in range(starting_mode, starting_mode + num_modes)]
 
     if grid is None:
         return modes

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -285,16 +285,17 @@ def zernike_radial(n, m, r, cache=None, recurrence_relationship='andersen'):
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
     recurrence_relationship : str
-        Determence which recurrence relationship is used. Default is Andersen.
+        Determine which recurrence relationship is used. Currently the options
+        are andersen or chong. The default is andersen.
 
     Returns
     -------
     array_like
         The radial component of the evaluated Zernike polynomial.
     """
-    if recurrence_relationship == 'andersen':
+    if recurrence_relationship.lower() == 'andersen':
         return zernike_radial_andersen(n, m, r, cache)
-    elif recurrence_relationship == 'chong':
+    elif recurrence_relationship.lower() == 'chong':
         return zernike_radial_chong(n, m, r, cache)
     else:
         raise NotImplementedError("The requested recurrence relationship {:s} is not implemented.".format(recurrence_relationship))
@@ -359,7 +360,8 @@ def zernike(n, m, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_rel
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
     recurrence_relationship : str
-        Determence which recurrence relationship is used. The default is Andersen.
+        Determine which recurrence relationship is used. Currently the options
+        are andersen or chong. The default is andersen.
 
     Returns
     -------
@@ -406,7 +408,8 @@ def zernike_ansi(i, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_r
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
     recurrence_relationship : str
-        Determence which recurrence relationship is used. The default is Andersen.
+        Determine which recurrence relationship is used. Currently the options
+        are andersen or chong. The default is andersen.
 
     Returns
     -------
@@ -437,7 +440,8 @@ def zernike_noll(i, D=1, grid=None, radial_cutoff=True, cache=None, recurrence_r
         valid. You can reuse the cache for future calculations on the same exact grid.
         The given dictionary is updated with the current calculation.
     recurrence_relationship : str
-        Determence which recurrence relationship is used. The default is Andersen.
+        Determine which recurrence relationship is used. Currently the options
+        are andersen or chong. The default is andersen.
 
     Returns
     -------
@@ -471,7 +475,8 @@ def make_zernike_basis(num_modes, D, grid, starting_mode=1, ansi=False, radial_c
         Whether to use a cache while calculating the modes. A cache uses memory, so turn it
         off when you are limited on memory.
     recurrence_relationship : str
-        Determence which recurrence relationship is used. The default is Andersen.
+        Determine which recurrence relationship is used. Currently the options
+        are andersen or chong. The default is andersen.
 
     Returns
     -------

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -201,7 +201,7 @@ def zernike_radial_andersen(n, m, r, cache=None):
     well-defined when r == 0.
 
     .. [Andersen2018] Andersen, T. B. (2018). Efficient and robust recurrence relations
-      for the Zernike circle polynomials and their derivatives in Cartesian coordinates. 
+      for the Zernike circle polynomials and their derivatives in Cartesian coordinates.
       Optics Express, 26(15), 18878-18896.
 
     Parameters
@@ -261,7 +261,7 @@ def zernike_radial_andersen(n, m, r, cache=None):
             elif mm == nn:
                 R[(nn, mm)] = r * R[(nn - 1, mm - 1)]
             else:
-                R[(nn, mm)] = r * (R[(nn - 1, mm-1)] + R[(nn - 1, mm + 1)]) - R[(nn - 2, mm)]
+                R[(nn, mm)] = r * (R[(nn - 1, mm - 1)] + R[(nn - 1, mm + 1)]) - R[(nn - 2, mm)]
 
     result = R[(n, m)]
 

--- a/hcipy/mode_basis/zernike.py
+++ b/hcipy/mode_basis/zernike.py
@@ -248,7 +248,9 @@ def zernike_radial_andersen(n, m, r, cache=None):
 
     # Special case m = 0.
     elif m == 0:
-        result = 2 * r * zernike_radial_andersen(n - 1, 1, r, cache) - zernike_radial_andersen(n - 2, 0, r, cache)
+        z1 = zernike_radial_andersen(n - 1, 1, r, cache)
+        z2 = zernike_radial_andersen(n - 2, 0, r, cache)
+        result = 2 * r * z1 - z2
 
     # Highest azimuthal order.
     elif m == n:

--- a/tests/test_mode_basis.py
+++ b/tests/test_mode_basis.py
@@ -225,22 +225,25 @@ def test_radial_zernike():
         z_r_chong = zernike_radial(n, m, 2 * R, cache_chong, 'chong')
         assert np.allclose(z_r_andersen[mask], z_r_chong[mask])
 
-    # Now test for validity of the point at the origin.
+def test_radial_zernike_at_origin():
+    '''
+    This only tests the default recurrence relationship (andersen)
+    The other implemented version (chong) diverges at the origin and
+    is therefore not well defined there.
+    '''
     def zernike_at_origin(n, m):
         """Value of the standard Zernike radial polynomial R_n^m at rho=0."""
-
-        if n < 0 or abs(m) > n or (n - abs(m)) % 2 != 0:
-            raise ValueError("Invalid Zernike indices (n, m).")
-
         if m != 0 or n % 2 != 0:
             return 0
-
         return (-1) ** (n // 2)
 
+    num_radial_max = 16
+    indices = zernike_radial_indices(num_radial_max)
+    
     for k in range(num_radial_max):
         n, m = indices[k]
-        z_r_andersen = zernike_radial(n, m, np.array([0, ]))
-        assert z_r_andersen == zernike_at_origin(n, m)
+        z_r = zernike_radial(n, m, np.array([0, ]))
+        assert z_r == zernike_at_origin(n, m)
 
 @pytest.mark.parametrize('bc', ['dirichlet', 'neumann'])
 def test_disk_harmonic_modes(bc):

--- a/tests/test_mode_basis.py
+++ b/tests/test_mode_basis.py
@@ -220,7 +220,7 @@ def test_radial_zernike():
     cache_chong = {}
     mask = make_circular_aperture(1)(grid) > 0
     for k in range(num_radial_max):
-        n,m = indices[k]
+        n, m = indices[k]
         z_r_andersen = zernike_radial(n, m, 2 * R, cache_andersen, True)
         z_r_chong = zernike_radial(n, m, 2 * R, cache_chong, False)
         assert np.allclose(z_r_andersen[mask], z_r_chong[mask])
@@ -238,8 +238,8 @@ def test_radial_zernike():
         return (-1) ** (n // 2)
 
     for k in range(num_radial_max):
-        n,m = indices[k]
-        z_r_andersen = zernike_radial(n, m, np.array([0,]))
+        n, m = indices[k]
+        z_r_andersen = zernike_radial(n, m, np.array([0, ]))
         assert z_r_andersen == zernike_at_origin(n, m)
 
 @pytest.mark.parametrize('bc', ['dirichlet', 'neumann'])

--- a/tests/test_mode_basis.py
+++ b/tests/test_mode_basis.py
@@ -209,6 +209,39 @@ def test_zernike_cache():
 
     assert np.allclose(m1, m2)
 
+def test_radial_zernike():
+    grid = make_pupil_grid(32)
+    R = grid.as_('polar').r
+
+    num_radial_max = 16
+    indices = zernike_radial_indices(num_radial_max)
+
+    cache_andersen = {}
+    cache_chong = {}
+    mask = make_circular_aperture(1)(grid) > 0
+    for k in range(num_radial_max):
+        n,m = indices[k]
+        z_r_andersen = zernike_radial(n, m, 2 * R, cache_andersen, True)
+        z_r_chong = zernike_radial(n, m, 2 * R, cache_chong, False)
+        assert np.allclose(z_r_andersen[mask], z_r_chong[mask])
+
+    # Now test for validity of the point at the origin.
+    def zernike_at_origin(n, m):
+        """Value of the standard Zernike radial polynomial R_n^m at rho=0."""
+
+        if n < 0 or abs(m) > n or (n - abs(m)) % 2 != 0:
+            raise ValueError("Invalid Zernike indices (n, m).")
+
+        if m != 0 or n % 2 != 0:
+            return 0
+
+        return (-1) ** (n // 2)
+
+    for k in range(num_radial_max):
+        n,m = indices[k]
+        z_r_andersen = zernike_radial(n, m, np.array([0,]))
+        assert z_r_andersen == zernike_at_origin(n, m)
+
 @pytest.mark.parametrize('bc', ['dirichlet', 'neumann'])
 def test_disk_harmonic_modes(bc):
     grid = make_pupil_grid(128)

--- a/tests/test_mode_basis.py
+++ b/tests/test_mode_basis.py
@@ -221,8 +221,8 @@ def test_radial_zernike():
     mask = make_circular_aperture(1)(grid) > 0
     for k in range(num_radial_max):
         n, m = indices[k]
-        z_r_andersen = zernike_radial(n, m, 2 * R, cache_andersen, True)
-        z_r_chong = zernike_radial(n, m, 2 * R, cache_chong, False)
+        z_r_andersen = zernike_radial(n, m, 2 * R, cache_andersen, 'andersen')
+        z_r_chong = zernike_radial(n, m, 2 * R, cache_chong, 'chong')
         assert np.allclose(z_r_andersen[mask], z_r_chong[mask])
 
     # Now test for validity of the point at the origin.

--- a/tests/test_mode_basis.py
+++ b/tests/test_mode_basis.py
@@ -239,7 +239,7 @@ def test_radial_zernike_at_origin():
 
     num_radial_max = 16
     indices = zernike_radial_indices(num_radial_max)
-    
+
     for k in range(num_radial_max):
         n, m = indices[k]
         z_r = zernike_radial(n, m, np.array([0, ]))


### PR DESCRIPTION
This PR fixes the oldest still open issue (#91 ).  What I have added are two new functions  `make_zernike_radial_andersen` and `zernike_radial_indices`. I have renamed the old `make_zernike_radial` to `make_zernike_radial_chong`. The `make_zernike_radial` function is now just an interface to the two actual implementations. I decided to keep the old function in case people use it for backwards compatibility. I created the code together with GPT-5.5.

Fixes #91.