### PR TITLE
Lyot fpm fix

### DIFF
--- a/hcipy/coronagraphy/knife_edge.py
+++ b/hcipy/coronagraphy/knife_edge.py
@@ -55,11 +55,11 @@ class KnifeEdgeLyotCoronagraph(OpticalElement):
         # FIXME: not necessary when 1D FFTs on 2D grids are implemented.
         self.focal_mask = np.fft.fftshift(self.focal_mask)
 
-        if apodizer is not None and not hasattr(apodizer, 'input_grid'):
+        if apodizer is not None and not isinstance(apodizer, OpticalElement):
             apodizer = Apodizer(apodizer)
         self.apodizer = apodizer
 
-        if lyot_stop is not None and not hasattr(lyot_stop, 'input_grid'):
+        if lyot_stop is not None and not isinstance(lyot_stop, OpticalElement):
             lyot_stop = Apodizer(lyot_stop)
         self.lyot_stop = lyot_stop
 

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -3,6 +3,26 @@ import numpy as np
 from ..optics import Apodizer, OpticalElement
 from ..propagation import FraunhoferPropagator
 
+
+def _get_optical_element_input_grid(optical_element):
+    grid = getattr(optical_element, 'input_grid', None)
+    if grid is not None and not callable(grid):
+        return grid
+
+    try:
+        return optical_element.get_input_grid(None, None)
+    except (AttributeError, TypeError, ValueError):
+        pass
+
+    apodization = getattr(optical_element, 'apodization', None)
+    if apodization is not None:
+        grid = getattr(apodization, 'grid', None)
+        if grid is not None:
+            return grid
+
+    raise ValueError('Could not determine the input grid of the optical element. Please pass focal_plane_mask_grid explicitly.')
+
+
 class LyotCoronagraph(OpticalElement):
     '''A Lyot coronagraph with a small focal-plane mask.
 
@@ -36,10 +56,10 @@ class LyotCoronagraph(OpticalElement):
         the grid will be determined from the focal plane mask. The default value is None.
     '''
     def __init__(self, input_grid, focal_plane_mask, lyot_stop=None, focal_length=1, focal_plane_mask_grid=None):
-        if hasattr(focal_plane_mask, 'input_grid'):
+        if isinstance(focal_plane_mask, OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
-                grid = focal_plane_mask.apodization.grid
+                grid = _get_optical_element_input_grid(focal_plane_mask)
             else:
                 grid = focal_plane_mask_grid
 
@@ -53,7 +73,7 @@ class LyotCoronagraph(OpticalElement):
 
             self.focal_plane_mask = Apodizer(focal_plane_mask)
 
-        if lyot_stop is not None and not hasattr(lyot_stop, 'input_grid'):
+        if lyot_stop is not None and not isinstance(lyot_stop, OpticalElement):
             lyot_stop = Apodizer(lyot_stop)
         self.lyot_stop = lyot_stop
 
@@ -147,10 +167,10 @@ class OccultedLyotCoronagraph(OpticalElement):
     '''
     def __init__(self, input_grid, focal_plane_mask, focal_length=1, focal_plane_mask_grid=None):
 
-        if hasattr(focal_plane_mask, 'input_grid'):
+        if isinstance(focal_plane_mask, OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
-                grid = focal_plane_mask.apodization.grid
+                grid = _get_optical_element_input_grid(focal_plane_mask)
             else:
                 grid = focal_plane_mask_grid
 

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from ..optics import Apodizer, OpticalElement, get_optical_element_input_grid
+from ..optics import Apodizer, OpticalElement
+from ..optics.optical_element import _get_optical_element_input_grid
 from ..propagation import FraunhoferPropagator
 
 class LyotCoronagraph(OpticalElement):
@@ -40,7 +41,7 @@ class LyotCoronagraph(OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
                 try:
-                    grid = get_optical_element_input_grid(focal_plane_mask)
+                    grid = _get_optical_element_input_grid(focal_plane_mask)
                 except ValueError:
                     raise ValueError('Could not determine the input grid of the focal plane mask. Please pass focal_plane_mask_grid explicitly.')
             else:
@@ -154,7 +155,7 @@ class OccultedLyotCoronagraph(OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
                 try:
-                    grid = get_optical_element_input_grid(focal_plane_mask)
+                    grid = _get_optical_element_input_grid(focal_plane_mask)
                 except ValueError:
                     raise ValueError('Could not determine the input grid of the focal plane mask. Please pass focal_plane_mask_grid explicitly.')
             else:

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -39,7 +39,10 @@ class LyotCoronagraph(OpticalElement):
         if isinstance(focal_plane_mask, OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
-                grid = get_optical_element_input_grid(focal_plane_mask)
+                try:
+                    grid = get_optical_element_input_grid(focal_plane_mask)
+                except ValueError:
+                    raise ValueError('Could not determine the input grid of the focal plane mask. Please pass focal_plane_mask_grid explicitly.')
             else:
                 grid = focal_plane_mask_grid
 
@@ -150,7 +153,10 @@ class OccultedLyotCoronagraph(OpticalElement):
         if isinstance(focal_plane_mask, OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
-                grid = get_optical_element_input_grid(focal_plane_mask)
+                try:
+                    grid = get_optical_element_input_grid(focal_plane_mask)
+                except ValueError:
+                    raise ValueError('Could not determine the input grid of the focal plane mask. Please pass focal_plane_mask_grid explicitly.')
             else:
                 grid = focal_plane_mask_grid
 

--- a/hcipy/coronagraphy/lyot.py
+++ b/hcipy/coronagraphy/lyot.py
@@ -1,27 +1,7 @@
 import numpy as np
 
-from ..optics import Apodizer, OpticalElement
+from ..optics import Apodizer, OpticalElement, get_optical_element_input_grid
 from ..propagation import FraunhoferPropagator
-
-
-def _get_optical_element_input_grid(optical_element):
-    grid = getattr(optical_element, 'input_grid', None)
-    if grid is not None and not callable(grid):
-        return grid
-
-    try:
-        return optical_element.get_input_grid(None, None)
-    except (AttributeError, TypeError, ValueError):
-        pass
-
-    apodization = getattr(optical_element, 'apodization', None)
-    if apodization is not None:
-        grid = getattr(apodization, 'grid', None)
-        if grid is not None:
-            return grid
-
-    raise ValueError('Could not determine the input grid of the optical element. Please pass focal_plane_mask_grid explicitly.')
-
 
 class LyotCoronagraph(OpticalElement):
     '''A Lyot coronagraph with a small focal-plane mask.
@@ -59,7 +39,7 @@ class LyotCoronagraph(OpticalElement):
         if isinstance(focal_plane_mask, OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
-                grid = _get_optical_element_input_grid(focal_plane_mask)
+                grid = get_optical_element_input_grid(focal_plane_mask)
             else:
                 grid = focal_plane_mask_grid
 
@@ -170,7 +150,7 @@ class OccultedLyotCoronagraph(OpticalElement):
         if isinstance(focal_plane_mask, OpticalElement):
             # Focal plane mask is an optical element.
             if focal_plane_mask_grid is None:
-                grid = _get_optical_element_input_grid(focal_plane_mask)
+                grid = get_optical_element_input_grid(focal_plane_mask)
             else:
                 grid = focal_plane_mask_grid
 

--- a/hcipy/optics/__init__.py
+++ b/hcipy/optics/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     'AgnosticOpticalElement',
     'make_agnostic_forward',
     'make_agnostic_backward',
+    'get_optical_element_input_grid',
     'OpticalSystem',
     'PeriodicOpticalElement',
     'jones_to_mueller',

--- a/hcipy/optics/__init__.py
+++ b/hcipy/optics/__init__.py
@@ -37,7 +37,6 @@ __all__ = [
     'AgnosticOpticalElement',
     'make_agnostic_forward',
     'make_agnostic_backward',
-    'get_optical_element_input_grid',
     'OpticalSystem',
     'PeriodicOpticalElement',
     'jones_to_mueller',

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -818,7 +818,7 @@ def _get_optical_element_input_grid(optical_element):
             return grid
     except (AttributeError, TypeError, ValueError):
         pass
-    
+
     for attribute_name in [
         'grid',
         'apodization',

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -789,12 +789,13 @@ def make_agnostic_backward(backward):
         return backward(self, instance_data, wavefront, *args, **kwargs)
     return res
 
-def get_optical_element_input_grid(optical_element):
+def _get_optical_element_input_grid(optical_element):
     '''Get the input grid of an optical element.
 
-    This function tries to get the input grid of an optical element by
-    checking its attributes and methods. If the input grid cannot be
-    determined, a ValueError is raised.
+    This function checks a small, explicit list of the grid-bearing properties that
+    are used throughout this module. The order is intentional: direct input-grid
+    information is preferred, followed by the most common field-like properties that
+    carry their own grid metadata.
 
     Parameters
     ----------
@@ -805,10 +806,44 @@ def get_optical_element_input_grid(optical_element):
     -------
     Grid
         The input grid of the optical element.
+
+    Raises
+    ------
+    ValueError
+        If no supported input-grid property could be determined.
     '''
-    grid = getattr(optical_element, 'input_grid', None)
-    if grid is not None and not callable(grid):
-        return grid
+    for attribute_name in [
+        'input_grid',
+        'grid',
+        'apodization',
+        'phase',
+        'surface_sag',
+        'amplitude',
+        'surface',
+        'phase_retardation',
+        'fast_axis_orientation',
+        'jones_matrix',
+    ]:
+        try:
+            value = getattr(optical_element, attribute_name)
+        except AttributeError:
+            continue
+
+        if value is None or callable(value):
+            continue
+
+        if hasattr(value, 'grid'):
+            grid = value.grid
+            if grid is not None and not callable(grid):
+                return grid
+
+        if hasattr(value, 'input_grid'):
+            grid = value.input_grid
+            if grid is not None and not callable(grid):
+                return grid
+
+        if not isinstance(value, (str, bytes)):
+            return value
 
     try:
         grid = optical_element.get_input_grid(None, None)
@@ -817,27 +852,7 @@ def get_optical_element_input_grid(optical_element):
     except (AttributeError, TypeError, ValueError):
         pass
 
-    seen = set()
-    stack = [optical_element]
-    while stack:
-        value = stack.pop()
-        if value is None or id(value) in seen:
-            continue
-        seen.add(id(value))
-
-        grid = getattr(value, 'grid', None)
-        if grid is not None and not callable(grid):
-            return grid
-
-        if isinstance(value, dict):
-            stack.extend(value.values())
-        elif isinstance(value, (list, tuple, set)):
-            stack.extend(value)
-        else:
-            try:
-                stack.extend(vars(value).values())
-            except TypeError:
-                pass
+    raise ValueError('Could not determine the input grid of the optical element.')
 
 class OpticalSystem(OpticalElement):
     '''An linear path of optical elements.

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -800,7 +800,7 @@ def get_optical_element_input_grid(optical_element):
     ----------
     optical_element : OpticalElement
         The optical element for which to get the input grid.
-    
+
     Returns
     -------
     Grid

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -789,6 +789,56 @@ def make_agnostic_backward(backward):
         return backward(self, instance_data, wavefront, *args, **kwargs)
     return res
 
+def get_optical_element_input_grid(optical_element):
+    '''Get the input grid of an optical element.
+
+    This function tries to get the input grid of an optical element by
+    checking its attributes and methods. If the input grid cannot be
+    determined, a ValueError is raised.
+
+    Parameters
+    ----------
+    optical_element : OpticalElement
+        The optical element for which to get the input grid.
+    
+    Returns
+    -------
+    Grid
+        The input grid of the optical element.
+    '''
+    grid = getattr(optical_element, 'input_grid', None)
+    if grid is not None and not callable(grid):
+        return grid
+
+    try:
+        return optical_element.get_input_grid(None, None)
+    except (AttributeError, TypeError, ValueError):
+        pass
+
+    seen = set()
+    stack = [optical_element]
+    while stack:
+        value = stack.pop()
+        if value is None or id(value) in seen:
+            continue
+        seen.add(id(value))
+
+        grid = getattr(value, 'grid', None)
+        if grid is not None and not callable(grid):
+            return grid
+
+        if isinstance(value, dict):
+            stack.extend(value.values())
+        elif isinstance(value, (list, tuple, set)):
+            stack.extend(value)
+        else:
+            try:
+                stack.extend(vars(value).values())
+            except TypeError:
+                pass
+
+    raise ValueError('Could not determine the input grid of the optical element. Please pass focal_plane_mask_grid explicitly.')
+
 class OpticalSystem(OpticalElement):
     '''An linear path of optical elements.
 

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -812,6 +812,13 @@ def _get_optical_element_input_grid(optical_element):
     ValueError
         If no supported input-grid property could be determined.
     '''
+    try:
+        grid = optical_element.get_input_grid(None, None)
+        if grid is not None and not callable(grid):
+            return grid
+    except (AttributeError, TypeError, ValueError):
+        pass
+    
     for attribute_name in [
         'grid',
         'apodization',
@@ -835,13 +842,6 @@ def _get_optical_element_input_grid(optical_element):
             grid = value.grid
             if grid is not None and not callable(grid):
                 return grid
-
-    try:
-        grid = optical_element.get_input_grid(None, None)
-        if grid is not None and not callable(grid):
-            return grid
-    except (AttributeError, TypeError, ValueError):
-        pass
 
     raise ValueError('Could not determine the input grid of the optical element.')
 

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -811,7 +811,9 @@ def get_optical_element_input_grid(optical_element):
         return grid
 
     try:
-        return optical_element.get_input_grid(None, None)
+        grid = optical_element.get_input_grid(None, None)
+        if grid is not None and not callable(grid):
+            return grid
     except (AttributeError, TypeError, ValueError):
         pass
 
@@ -836,8 +838,6 @@ def get_optical_element_input_grid(optical_element):
                 stack.extend(vars(value).values())
             except TypeError:
                 pass
-
-    raise ValueError('Could not determine the input grid of the optical element. Please pass focal_plane_mask_grid explicitly.')
 
 class OpticalSystem(OpticalElement):
     '''An linear path of optical elements.

--- a/hcipy/optics/optical_element.py
+++ b/hcipy/optics/optical_element.py
@@ -813,7 +813,6 @@ def _get_optical_element_input_grid(optical_element):
         If no supported input-grid property could be determined.
     '''
     for attribute_name in [
-        'input_grid',
         'grid',
         'apodization',
         'phase',
@@ -836,14 +835,6 @@ def _get_optical_element_input_grid(optical_element):
             grid = value.grid
             if grid is not None and not callable(grid):
                 return grid
-
-        if hasattr(value, 'input_grid'):
-            grid = value.input_grid
-            if grid is not None and not callable(grid):
-                return grid
-
-        if not isinstance(value, (str, bytes)):
-            return value
 
     try:
         grid = optical_element.get_input_grid(None, None)

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -1,34 +1,6 @@
 from hcipy import *
 import numpy as np
 
-def test_lyot_coronagraph_with_agnostic_mask_uses_mask_grid():
-    pupil_grid = make_pupil_grid(32)
-    focal_grid = make_focal_grid(4, 16)
-
-    class Mask(AgnosticOpticalElement):
-        def __init__(self, grid):
-            self._grid = grid
-            super().__init__()
-
-        def get_input_grid(self, output_grid, wavelength):
-            return self._grid
-
-        def get_output_grid(self, input_grid, wavelength):
-            return self._grid
-
-        @make_agnostic_forward
-        def forward(self, instance_data, wavefront):
-            return wavefront
-
-        @make_agnostic_backward
-        def backward(self, instance_data, wavefront):
-            return wavefront
-
-    mask = Mask(focal_grid)
-    coro = LyotCoronagraph(pupil_grid, mask)
-
-    assert coro.prop is not None
-
 def test_vortex_coronagraph():
     pupil_grid = make_pupil_grid(256)
     focal_grid = make_focal_grid(4, 32)
@@ -287,6 +259,9 @@ def test_lyot_coronagraph():
     fpm2 = 1 - evaluate_supersampled(make_circular_aperture(5 * focal_length), fpm_grid2, 8)
     cor2 = LyotCoronagraph(pupil_grid, fpm2, lyot_stop, focal_length=focal_length)
 
+    # Coronagraph 3 with optical element for focal plane mask
+    cor3 = LyotCoronagraph(pupil_grid, Apodizer(fpm), lyot_stop)
+
     # The grid on which the performance is evaluated
     focal_grid = make_focal_grid(q=3, num_airy=25)
     prop = FraunhoferPropagator(pupil_grid, focal_grid)
@@ -296,10 +271,11 @@ def test_lyot_coronagraph():
     norm = prop(wf).power.max()
     wf_foc = prop(cor(wf))
     wf_foc2 = prop(cor2(wf))
-
+    wf_foc3 = prop(cor3(wf))
     # Checks performance of the coronagraph and if the focal length does not introduce artifacts
     assert (wf_foc.power.max() / norm) < 5e-3
     np.testing.assert_allclose(wf_foc.power, wf_foc2.power)
+    np.testing.assert_allclose(wf_foc.power, wf_foc3.power)
 
 def test_vortex_fiber_nuller():
     pupil_grid = make_pupil_grid(256)

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -1,6 +1,34 @@
 from hcipy import *
 import numpy as np
 
+def test_lyot_coronagraph_with_agnostic_mask_uses_mask_grid():
+    pupil_grid = make_pupil_grid(32)
+    focal_grid = make_focal_grid(4, 16)
+
+    class Mask(AgnosticOpticalElement):
+        def __init__(self, grid):
+            self._grid = grid
+            super().__init__()
+
+        def get_input_grid(self, output_grid, wavelength):
+            return self._grid
+
+        def get_output_grid(self, input_grid, wavelength):
+            return self._grid
+
+        @make_agnostic_forward
+        def forward(self, instance_data, wavefront):
+            return wavefront
+
+        @make_agnostic_backward
+        def backward(self, instance_data, wavefront):
+            return wavefront
+
+    mask = Mask(focal_grid)
+    coro = LyotCoronagraph(pupil_grid, mask)
+
+    assert coro.prop is not None
+
 def test_vortex_coronagraph():
     pupil_grid = make_pupil_grid(256)
     focal_grid = make_focal_grid(4, 32)

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -52,6 +52,32 @@ def test_fqpm_coronagraph():
     assert img.total_power < 1e-6
     assert img.intensity.max() / img_ref.intensity.max() < 4e-8
 
+
+def test_lyot_coronagraph_with_phase_apodizer_mask():
+    pupil_grid = make_pupil_grid(32)
+    focal_grid = make_focal_grid(4, 16)
+
+    phase = make_circular_aperture(1.0)(focal_grid) * 0.3
+    mask = PhaseApodizer(phase)
+
+    coro = LyotCoronagraph(pupil_grid, mask)
+
+    assert coro.prop.get_instance_data(pupil_grid, None, 1).output_grid is focal_grid
+
+
+def test_lyot_coronagraph_with_polarization_mask():
+    pupil_grid = make_pupil_grid(32)
+    focal_grid = make_focal_grid(4, 16)
+
+    phase_retardation = make_circular_aperture(1.0)(focal_grid) * 0.3
+    fast_axis_orientation = Field(np.zeros(focal_grid.size), focal_grid)
+    mask = LinearRetarder(phase_retardation, fast_axis_orientation)
+
+    coro = LyotCoronagraph(pupil_grid, mask)
+
+    assert coro.prop.get_instance_data(pupil_grid, None, 1).output_grid is focal_grid
+
+
 def test_vector_vortex_coronagraph():
     pupil_grid = make_pupil_grid(256)
     focal_grid = make_focal_grid(4, 32)


### PR DESCRIPTION
This PR fixes the bug from #177 . This PR was developed together with MAI-Code-1.1-Flash.

This PR adds a new function `get_optical_element_input_grid` that tries to determine the input grid from the optical element. It works on all apodizers and polarization optics. This will remove the need to explicitly passing the coronagraph grid in the LyotCoronagraph. I kept the explicit parameter `focal_plane_mask_grid` to keep backwards compatibility.

Several test functions have been added to test the interface for various optical elements.

Let me know if this is an agreeable solution, I really get messed up by this particular bug very often.

Fixes #177.