### PR TITLE
Add fractional order support to the PerfectCoronagraph

### DIFF
--- a/hcipy/coronagraphy/perfect_coronagraph.py
+++ b/hcipy/coronagraphy/perfect_coronagraph.py
@@ -28,16 +28,16 @@ class PerfectCoronagraph(OpticalElement):
     ----------
     aperture : Field
         The reference aperture. The perfect coronagraph is designed for this aperture.
-    order : integer
-        The order of the perfect coronagraph. This must be even.
+    order : scalar
+        The order of the perfect coronagraph. This can be any non-negative value; non-integer
+        values are used for fractional orders, which are implemented by partially suppressing the
+        highest-order modes [Guyon2006]_.
     coeffs : list or ndarray or None
         The coefficients that are used for subtraction. This allows for partial suppression of certain
         modes, which can be used to design perfect coronagraphs that are insensitive to stellar
         radius [Guyon2006]_. If it is None, all modes are completely suppressed.
     '''
     def __init__(self, aperture, order=2, coeffs=None):
-        assert order % 2 == 0, "The coronagraph order has to be even."
-
         self.pupil_grid = aperture.grid
         modes = []
 
@@ -45,7 +45,18 @@ class PerfectCoronagraph(OpticalElement):
             order = int(2 * np.ceil(0.5 * (np.sqrt(8 * len(coeffs) + 1) - 1)))
             self.coeffs = coeffs
         else:
-            self.coeffs = np.ones(int(order * (order / 2 + 1) / 4))
+            N = int(order // 2)
+            d = order / 2 - N
+
+            if abs(d) < 1e-6:
+                order = int(2 * N)
+                self.coeffs = np.ones(int(order * (order / 2 + 1) / 4))
+            else:
+                T = (d**2 + (2 * N + 1) * d) / (2 * (N + 1))
+
+                order = int(2 * N + 2)
+                self.coeffs = np.ones(int(order * (order / 2 + 1) / 4))
+                self.coeffs[-(order // 2):] = T
 
         for i in range(order // 2):
             for j in range(i + 1):

--- a/tests/test_coronagraphy.py
+++ b/tests/test_coronagraphy.py
@@ -221,7 +221,7 @@ def test_perfect_coronagraph():
 
     tilts = np.logspace(-3, -1, 51)
 
-    for order in [2, 4, 6, 8]:
+    for order in [2, 2.5, 3.5, 4, 6, 6.5, 8]:
         coro = PerfectCoronagraph(aperture, order)
 
         # Test suppression for on-axis point source
@@ -241,7 +241,22 @@ def test_perfect_coronagraph():
 
         # Do a linear fit on the log-log data to get the power-law coefficient
         beta = ((x * y).sum() - x.sum() * y.sum() / n) / ((x * x).sum() - x.sum()**2 / n)
-        assert np.abs(beta - order) / order < 1e-3
+
+        # Fractional orders only partially suppress the highest-order modes, so the
+        # power-law coefficient is that of the previous even order, while the
+        # leakage amplitude is reduced.
+        even_order = 2 * (order // 2)
+        assert np.abs(beta - even_order) / even_order < 1e-2
+
+        # For fractional orders, the leakage amplitude should be between those of
+        # the neighbouring even orders.
+        if order % 2 != 0:
+            coro_even = PerfectCoronagraph(aperture, even_order)
+            coro_next = PerfectCoronagraph(aperture, even_order + 2)
+            leak = coro(Wavefront(aperture * np.exp(2j * np.pi * pupil_grid.x * tilts[-1]))).total_power
+            leak_even = coro_even(Wavefront(aperture * np.exp(2j * np.pi * pupil_grid.x * tilts[-1]))).total_power
+            leak_next = coro_next(Wavefront(aperture * np.exp(2j * np.pi * pupil_grid.x * tilts[-1]))).total_power
+            assert leak_even > leak > leak_next
 
 def test_lyot_coronagraph():
     pupil_grid = make_pupil_grid(128, 1.1)


### PR DESCRIPTION
### Summary
Extends `PerfectCoronagraph` to accept fractional (non-integer even) orders, following the implementation in the CDS pipeline. Fractional orders are achieved by partially suppressing the highest-order modes rather than fully subtracting them, as described in Guyon et al. (2006).

Fractional orders do **not** yield a fractional power-law slope in the off-axis leakage: the slope corresponds to the previous even order, but the leakage amplitude is reduced continuously between integer orders.