### PR TITLE
Add `FraunhoferPropagator.closest_fft_wavelength`.

### DIFF
--- a/hcipy/propagation/fraunhofer.py
+++ b/hcipy/propagation/fraunhofer.py
@@ -1,8 +1,8 @@
-import numpy as np
-
 from ..optics import Wavefront, AgnosticOpticalElement, make_agnostic_forward, make_agnostic_backward
 from ..field import Field
 from ..fourier import make_fourier_transform
+
+import math
 
 class FraunhoferPropagator(AgnosticOpticalElement):
     '''A monochromatic perfect lens propagator.
@@ -32,7 +32,7 @@ class FraunhoferPropagator(AgnosticOpticalElement):
     def make_instance(self, instance_data, input_grid, output_grid, wavelength):
         focal_length = self.evaluate_parameter(self.focal_length, input_grid, output_grid, wavelength)
 
-        instance_data.uv_grid = output_grid.scaled(2 * np.pi / (focal_length * wavelength))
+        instance_data.uv_grid = output_grid.scaled(2 * math.pi / (focal_length * wavelength))
         instance_data.fourier_transform = make_fourier_transform(input_grid, instance_data.uv_grid)
 
         instance_data.norm_factor = 1 / (1j * focal_length * wavelength)

--- a/hcipy/propagation/fraunhofer.py
+++ b/hcipy/propagation/fraunhofer.py
@@ -86,3 +86,52 @@ class FraunhoferPropagator(AgnosticOpticalElement):
         '''
         U_new = instance_data.fourier_transform.backward(wavefront.electric_field) / instance_data.norm_factor
         return Wavefront(Field(U_new, instance_data.input_grid), wavefront.wavelength, wavefront.input_stokes_vector)
+
+    def closest_fft_wavelength(self, target_wavelength):
+        '''Find the wavelength closest to `target_wavelength` for which the
+        propagation could be performed with a Fast Fourier Transform.
+
+        .. note::
+            A Fast Fourier Transform is not necessarily used for the returned
+            wavelength; the transform to use is decided by
+            :func:`~hcipy.fourier.make_fourier_transform`. The returned
+            wavelength only guarantees that an FFT is a valid option, and will
+            be used if it is estimated to be the fastest.
+
+        Parameters
+        ----------
+        target_wavelength : scalar or array_like
+            The wavelength(s) of interest.
+
+        Returns
+        -------
+        Array
+            The wavelength(s) closest to `target_wavelength` that can be
+            propagated with an FFT.
+
+        Raises
+        ------
+        ValueError
+            If appropriate wavelengths could not be found.
+        '''
+        if not self._input_grid.is_regular or not self._output_grid.is_regular:
+            raise ValueError('The input and output grid need to be regular for an FFT to be possible.')
+
+        xp = self._input_grid.xp
+        z = self._input_grid.delta * self._output_grid.delta
+
+        eps = xp.finfo(z.dtype).eps * 1e2
+
+        if not xp.all(xp.abs(z / z[0] - 1) < eps):
+            raise ValueError('input_grid.delta * output_grid.delta needs to be equal for all axes for an FFT to be possible.')
+
+        b = self.focal_length / z[0]
+
+        # The zero-padding zp = b * wavelength needs to be an integer (and to
+        # cover both grids, so at least the largest of their dims).
+        zp_min = max(max(self._input_grid.dims), max(self._output_grid.dims))
+
+        targets = xp.asarray(target_wavelength)
+        zp = xp.maximum(xp.round(b * targets), zp_min)
+
+        return zp / b

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -61,6 +61,61 @@ def test_fraunhofer_propagation_rectangular():
                         # This should never happen.
                         assert False
 
+def test_closest_fft_wavelength():
+    num_pix, num_pix2 = 512, 1024
+    dx, dxp = 10.0 / num_pix, 0.025
+    f = 1000.0
+
+    pupil_grid = CartesianGrid(RegularCoords([dx, dx], [num_pix, num_pix], [-dx * num_pix / 2, -dx * num_pix / 2]))
+    focal_grid = CartesianGrid(RegularCoords([dxp, dxp], [num_pix2, num_pix2], [-dxp * num_pix2 / 2, -dxp * num_pix2 / 2]))
+    prop = FraunhoferPropagator(pupil_grid, focal_grid, focal_length=f)
+
+    b = f / (dx * dxp)
+    zp_min = max(num_pix, num_pix2)
+
+    # A scalar input returns a scalar.
+    wavelength = prop.closest_fft_wavelength(5.5e-4)
+    assert isinstance(wavelength, float)
+    assert np.isclose(wavelength, np.round(b * 5.5e-4) / b)
+
+    # An array input returns an array of the same shape.
+    targets = np.array([5.0e-4, 5.5e-4, 6.0e-4, 4.5e-4])
+    wavelengths = prop.closest_fft_wavelength(targets)
+    assert isinstance(wavelengths, np.ndarray)
+    assert wavelengths.shape == targets.shape
+    assert np.allclose(wavelengths, np.maximum(np.round(b * targets), zp_min) / b)
+
+    # The returned wavelength is the closest native FFT grid.
+    for target in np.linspace(5.1e-4, 6.5e-4, 10):
+        wavelength = prop.closest_fft_wavelength(target)
+        uv_grid = focal_grid.scaled(2 * np.pi / (f * wavelength))
+        assert is_fft_grid(uv_grid, pupil_grid)
+        assert isinstance(make_fourier_transform(pupil_grid, uv_grid), FastFourierTransform)
+
+        # No closer wavelength that is a native FFT grid exists.
+        for k in range(max(zp_min, int(np.floor(b * target)) - 5), int(np.ceil(b * target)) + 6):
+            candidate = k / b
+            if abs(candidate - target) >= abs(wavelength - target):
+                continue
+            uv_candidate = focal_grid.scaled(2 * np.pi / (f * candidate))
+            assert not is_fft_grid(uv_candidate, pupil_grid)
+
+    # Wavelengths that would round below the minimum are clamped to it.
+    assert np.isclose(prop.closest_fft_wavelength(4.5e-4), zp_min / b)
+    assert np.isclose(prop.closest_fft_wavelength(4.99e-4), zp_min / b)
+
+    # An anisotropic grid with a consistent delta product works as well.
+    pupil_aniso = CartesianGrid(RegularCoords([0.02, 0.03], [256, 512], [0, 0]))
+    focal_aniso = CartesianGrid(RegularCoords([1.0, 2.0 / 3.0], [256, 512], [0, 0]))
+    prop_aniso = FraunhoferPropagator(pupil_aniso, focal_aniso, focal_length=500.0)
+    assert prop_aniso.closest_fft_wavelength([1e-3, 2e-3]).shape == (2,)
+
+    # A delta product that is not equal over the axes raises a ValueError.
+    focal_inconsistent = CartesianGrid(RegularCoords([0.05, 0.05], [512, 1024], [0, 0]))
+    prop_bad = FraunhoferPropagator(pupil_aniso, focal_inconsistent, focal_length=500.0)
+    with pytest.raises(ValueError):
+        prop_bad.closest_fft_wavelength(1e-3)
+
 @pytest.mark.parametrize('propagator', [FresnelPropagator, AngularSpectrumPropagator])
 @pytest.mark.parametrize('number_of_pixels', [
     pytest.param(512),


### PR DESCRIPTION
## Summary

Adds `FraunhoferPropagator.closest_fft_wavelength(target_wavelength)` and tests for it.

## Motivation

For a monochromatic Fraunhofer propagation the uv-grid is the output grid scaled by `2π / (f · λ)`. This grid is a *native FFT grid* of the input grid only when, for every axis, the number of zero-padding pixels

```
zp = f · λ / (input_grid.delta[i] · output_grid.delta[i])
```

is an integer of at least `max(input_grid.dims, output_grid.dims)`. In that case `make_fourier_transform` _can_, but doesn't have to, select the fast `FastFourierTransform`; otherwise it falls back to a `MatrixFourierTransform`.

Using FFTs _can_ be faster than MFTs and using the correct wavelength enables this potential performance improvement, provided that the user is amenable to changing their wavelengths slightly.

I used Deepseek V4 Flash to generate a draft of the code which was then rewritten.