### PR TITLE
Add ray transfer (ABCD) matrices and Gaussian beam propagation

### DIFF
--- a/hcipy/optics/__init__.py
+++ b/hcipy/optics/__init__.py
@@ -1,4 +1,11 @@
 __all__ = [
+    'RayTransferMatrix',
+    'make_abcd_refractive_interface',
+    'make_abcd_fraunhofer',
+    'make_abcd_free_space',
+    'make_abcd_magnifier',
+    'make_abcd_mirror',
+    'make_abcd_thin_lens',
     'make_power_law_error',
     'make_high_pass_power_law_error',
     'SurfaceAberration',
@@ -73,6 +80,7 @@ __all__ = [
 from .optical_element import *
 from .wavefront import *
 
+from .abcd import *
 from .aberration import *
 from .apodization import *
 from .deformable_mirror import *

--- a/hcipy/optics/abcd.py
+++ b/hcipy/optics/abcd.py
@@ -102,6 +102,50 @@ class RayTransferMatrix:
 
         return (abs(a - 1.0) < tol) and (abs(c) < tol) and (abs(d - 1.0) < tol)
 
+    def forward(self, beam):
+        '''Transform a Gaussian beam through this matrix, returning a new beam.
+
+        The complex beam parameter of the beam is transformed according to the
+        ABCD law
+
+            q' = (A q + B) / (C q + D).
+
+        A new GaussianBeam is returned; the input beam is not modified. A
+        dispersive matrix is evaluated at the wavelength of the beam.
+
+        Parameters
+        ----------
+        beam : GaussianBeam
+            The Gaussian beam to transform.
+
+        Returns
+        -------
+        GaussianBeam
+            The transformed Gaussian beam.
+        '''
+        return beam.propagate(self(beam.wavelength))
+
+    def backward(self, beam):
+        '''Inverse-transform a Gaussian beam through this matrix.
+
+        The numerical inverse of the matrix is applied, so this works for any
+        invertible matrix.
+
+        Parameters
+        ----------
+        beam : GaussianBeam
+            The Gaussian beam to transform.
+
+        Returns
+        -------
+        GaussianBeam
+            The inverse-transformed Gaussian beam.
+        '''
+        M = self(beam.wavelength)
+        xp = infer_xp(M)
+
+        return beam.propagate(xp.linalg.inv(M))
+
     def __matmul__(self, other):
         '''Compose two ray-transfer matrices: self is applied after other.'''
         other = other if isinstance(other, RayTransferMatrix) else RayTransferMatrix(other)

--- a/hcipy/optics/abcd.py
+++ b/hcipy/optics/abcd.py
@@ -1,0 +1,290 @@
+from .._math.backends import infer_xp
+
+__all__ = [
+    'RayTransferMatrix',
+    'make_abcd_free_space',
+    'make_abcd_thin_lens',
+    'make_abcd_mirror',
+    'make_abcd_fraunhofer',
+    'make_abcd_magnifier',
+    'make_abcd_refractive_interface',
+]
+
+class RayTransferMatrix:
+    '''A 2x2 ray-transfer (ABCD) matrix, optionally dispersive.
+
+    Wraps either a fixed 2x2 array or a function of the wavelength (in
+    meters) that returns one.
+
+    Parameters
+    ----------
+    matrix : Array or callable
+        The 2x2 matrix, or a callable ``matrix(wavelength)`` returning one.
+
+    Examples
+    --------
+    >>> M = make_abcd_free_space(0.5)
+    >>> M(500e-9)
+    array([[1. , 0.5],
+           [0. , 1. ]])
+    '''
+    __slots__ = ('_matrix')
+
+    def __init__(self, matrix):
+        if not callable(matrix):
+            if matrix.shape != (2, 2):
+                raise ValueError('RayTransferMatrix requires a 2x2 matrix.')
+
+        self._matrix = matrix
+
+    @property
+    def is_dispersive(self):
+        '''Whether the matrix depends on the wavelength.'''
+        return callable(self._matrix)
+
+    def __call__(self, wavelength):
+        '''The 2x2 matrix evaluated at the given wavelength (in meters).'''
+        if self.is_dispersive:
+            return self._matrix(wavelength)
+        return self._matrix
+
+    def _elements(self, wavelength):
+        '''The four matrix elements A, B, C, D as backend arrays.'''
+        M = self(wavelength)
+        return (M[0, 0], M[0, 1], M[1, 0], M[1, 1])
+
+    def effective_focal_length(self, wavelength):
+        '''The effective focal length f_eff = -1 / C of the ABCD system.'''
+        _, _, c, _ = self._elements(wavelength)
+        return -1.0 / c
+
+    def paraxial_power(self, wavelength):
+        '''The paraxial optical power Phi = -C of the ABCD system.'''
+        _, _, c, _ = self._elements(wavelength)
+        return -c
+
+    def geometric_magnification(self, wavelength):
+        '''The transverse geometric magnification m = A of the ABCD system.'''
+        a, _, _, _ = self._elements(wavelength)
+        return a
+
+    def angular_magnification(self, wavelength):
+        '''The angular magnification m_theta = D of the ABCD system.'''
+        _, _, _, d = self._elements(wavelength)
+        return d
+
+    def distance(self, wavelength):
+        '''The effective propagation distance z_eff = B of the ABCD system.'''
+        _, b, _, _ = self._elements(wavelength)
+        return b
+
+    def front_focal_length(self, wavelength):
+        '''The front focal length FFL = -A / C of the ABCD system.'''
+        a, _, c, _ = self._elements(wavelength)
+        return -a / c
+
+    def back_focal_length(self, wavelength):
+        '''The back focal length BFL = -D / C of the ABCD system.'''
+        _, _, c, d = self._elements(wavelength)
+        return -d / c
+
+    def is_surface(self, wavelength, tol=1e-8):
+        '''Whether the ABCD matrix is a pure powered surface (B ~ 0).'''
+        _, b, _, _ = self._elements(wavelength)
+        return abs(b) < tol
+
+    def is_free_space(self, wavelength, tol=1e-8):
+        '''Whether the ABCD matrix corresponds to free-space propagation.'''
+        a, b, c, d = self._elements(wavelength)
+
+        if abs(b) < tol:
+            return False
+
+        return (abs(a - 1.0) < tol) and (abs(c) < tol) and (abs(d - 1.0) < tol)
+
+    def __matmul__(self, other):
+        '''Compose two ray-transfer matrices: self is applied after other.'''
+        other = other if isinstance(other, RayTransferMatrix) else RayTransferMatrix(other)
+
+        if not (self.is_dispersive or other.is_dispersive):
+            return RayTransferMatrix(self._matrix @ other._matrix)
+
+        def composition(wavelength):
+            return self(wavelength) @ other(wavelength)
+
+        return RayTransferMatrix(composition)
+
+    def __repr__(self):
+        if self.is_dispersive:
+            return 'RayTransferMatrix(dispersive)'
+        return f'RayTransferMatrix({self._matrix!r})'
+
+def make_abcd_free_space(distance, xp=None):
+    '''The ABCD (ray-transfer) matrix for free-space propagation.
+
+    Parameters
+    ----------
+    distance : scalar
+        The propagation distance.
+    xp : module, optional
+        The Array API namespace to use. If not given, it will be inferred from
+        the other parameters.
+
+    Returns
+    -------
+    RayTransferMatrix
+        The 2x2 ABCD matrix for free-space propagation.
+    '''
+    if xp is None:
+        xp = infer_xp(distance)
+
+    return RayTransferMatrix(xp.asarray([[1.0, distance], [0.0, 1.0]]))
+
+def make_abcd_thin_lens(focal_length, xp=None):
+    '''The ABCD (ray-transfer) matrix for a thin refractive lens in air.
+
+    Parameters
+    ----------
+    focal_length : scalar
+        The focal length of the lens.
+    xp : module, optional
+        The Array API namespace to use. If not given, it will be inferred from
+        the other parameters.
+
+    Returns
+    -------
+    RayTransferMatrix
+        The 2x2 ABCD matrix for a thin lens.
+    '''
+    if xp is None:
+        xp = infer_xp(focal_length)
+
+    return RayTransferMatrix(xp.asarray([[1.0, 0.0], [-1.0 / focal_length, 1.0]]))
+
+def make_abcd_mirror(radius=None, xp=None):
+    '''The ABCD (ray-transfer) matrix for a spherical mirror.
+
+    A radius of curvature of None (the default) corresponds to a plane
+    mirror.
+
+    Parameters
+    ----------
+    radius : scalar, optional
+        The radius of curvature of the mirror. A positive radius corresponds
+        to a concave (focusing) mirror. If None (default), the mirror is
+        plane.
+    xp : module, optional
+        The Array API namespace to use. If not given, it will be inferred from
+        the other parameters.
+
+    Returns
+    -------
+    RayTransferMatrix
+        The 2x2 ABCD matrix for a spherical mirror.
+    '''
+    if xp is None:
+        xp = infer_xp(radius)
+
+    if radius is None:
+        return RayTransferMatrix(xp.asarray([[1.0, 0.0], [0.0, 1.0]]))
+
+    return RayTransferMatrix(xp.asarray([[1.0, 0.0], [-2.0 / radius, 1.0]]))
+
+def make_abcd_fraunhofer(focal_length, xp=None):
+    '''The ABCD (ray-transfer) matrix for an ideal Fraunhofer (Fourier) transform.
+
+    This matrix describes the propagation between two conjugate planes, giving
+    the classic 'pupil-focal plane' Fourier relationship.
+
+    Parameters
+    ----------
+    focal_length : scalar
+        The effective focal length that defines the conjugate-plane transform.
+    xp : module, optional
+        The Array API namespace to use. If not given, it will be inferred from
+        the other parameters.
+
+    Returns
+    -------
+    RayTransferMatrix
+        The 2x2 ABCD matrix for a Fraunhofer (Fourier) transform.
+    '''
+    if xp is None:
+        xp = infer_xp(focal_length)
+
+    return RayTransferMatrix(xp.asarray([[0.0, focal_length], [-1.0 / focal_length, 0.0]]))
+
+def make_abcd_magnifier(magnification, xp=None):
+    '''The ABCD (ray-transfer) matrix for an ideal magnifier (afocal telescope).
+
+    Parameters
+    ----------
+    magnification : scalar
+        The transverse geometric magnification of the system.
+    xp : module, optional
+        The Array API namespace to use. If not given, it will be inferred from
+        the other parameters.
+
+    Returns
+    -------
+    RayTransferMatrix
+        The 2x2 ABCD matrix for an ideal magnifier.
+    '''
+    if xp is None:
+        xp = infer_xp(magnification)
+
+    return RayTransferMatrix(xp.asarray([[magnification, 0.0], [0.0, 1.0 / magnification]]))
+
+def make_abcd_refractive_interface(refractive_index_in, refractive_index_out, radius=None, xp=None):
+    '''The ABCD (ray-transfer) matrix for refraction at a dielectric interface.
+
+    A positive radius corresponds to a surface whose center of curvature lies
+    to the right of the interface. A radius of None (the default) corresponds
+    to a flat interface. Note that this matrix has determinant
+    refractive_index_in / refractive_index_out, since it accounts for the
+    change of the ray angle due to refraction.
+
+    A dispersive matrix is returned if either refractive index is a callable
+    function of the wavelength (in meters).
+
+    Parameters
+    ----------
+    refractive_index_in : scalar or callable
+        The refractive index of the medium the ray is coming from, or a
+        function of the wavelength (in meters) returning it.
+    refractive_index_out : scalar or callable
+        The refractive index of the medium the ray is going to, or a function
+        of the wavelength (in meters) returning it.
+    radius : scalar, optional
+        The radius of curvature of the interface. If None (default), the
+        interface is flat.
+    xp : module, optional
+        The Array API namespace to use. If not given, it will be inferred from
+        the other parameters.
+
+    Returns
+    -------
+    RayTransferMatrix
+        The 2x2 ABCD matrix for refraction at a dielectric interface.
+    '''
+    if callable(refractive_index_in) or callable(refractive_index_out):
+        n_in, n_out = refractive_index_in, refractive_index_out
+
+        def matrix(wavelength):
+            n1 = n_in(wavelength) if callable(n_in) else n_in
+            n2 = n_out(wavelength) if callable(n_out) else n_out
+
+            return make_abcd_refractive_interface(n1, n2, radius=radius, xp=xp)(wavelength)
+
+        return RayTransferMatrix(matrix)
+
+    if xp is None:
+        xp = infer_xp(refractive_index_in, refractive_index_out, radius)
+
+    n1 = refractive_index_in
+    n2 = refractive_index_out
+
+    if radius is None:
+        return RayTransferMatrix(xp.asarray([[1.0, 0.0], [0.0, n1 / n2]]))
+
+    return RayTransferMatrix(xp.asarray([[1.0, 0.0], [(n1 - n2) / (radius * n2), n1 / n2]]))

--- a/hcipy/optics/gaussian_beam.py
+++ b/hcipy/optics/gaussian_beam.py
@@ -1,4 +1,5 @@
 import numpy as np
+from .._math.backends import infer_xp
 from ..field import Field
 from .wavefront import Wavefront
 
@@ -113,6 +114,50 @@ class GaussianBeam(object):
         self.wavelength = 2 * np.pi / k
 
     wavenumber = k
+
+    def propagate(self, matrix):
+        '''Propagate the Gaussian beam through an ABCD (ray-transfer) matrix.
+
+        The complex beam parameter of the beam is transformed according to the
+        ABCD law
+
+            q' = (A q + B) / (C q + D),
+
+        and a new GaussianBeam with the propagated parameters is returned.
+        The beam itself is not modified.
+
+        Parameters
+        ----------
+        matrix : Array or callable
+            The 2x2 ABCD (ray-transfer) matrix to propagate the beam through,
+            or a function of the wavelength (in meters) that returns one. A
+            callable is evaluated at the wavelength of the beam.
+
+        Returns
+        -------
+        GaussianBeam
+            The propagated Gaussian beam.
+
+        Raises
+        ------
+        ValueError
+            If the matrix is not 2x2.
+        '''
+        if callable(matrix):
+            matrix = matrix(self.wavelength)
+
+        xp = infer_xp(matrix)
+        matrix = xp.asarray(matrix)
+
+        if matrix.shape != (2, 2):
+            raise ValueError('The ABCD matrix should be a 2x2 array.')
+
+        q = self.q
+        q_new = (float(matrix[0, 0]) * q + float(matrix[0, 1])) / (float(matrix[1, 0]) * q + float(matrix[1, 1]))
+
+        new_beam = GaussianBeam(self.w0, self.z, self.wavelength)
+        new_beam.q = q_new
+        return new_beam
 
     def evaluate(self, grid):
         '''Evaluate the wavefront of the Gaussian beam at the current position on

--- a/hcipy/optics/gaussian_beam.py
+++ b/hcipy/optics/gaussian_beam.py
@@ -1,69 +1,123 @@
-import numpy as np
-from .._math.backends import infer_xp
+import math
+from array_api_compat import is_array_api_obj
+from .._math.backends import array_namespace
 from ..field import Field
 from .wavefront import Wavefront
+
+class _ScalarNamespace:
+    '''Array API-style namespace backed by the math module, used when all beam
+    parameters are plain Python scalars. Its functions return Python floats.
+    '''
+    real = staticmethod(lambda x: x.real)
+    imag = staticmethod(lambda x: x.imag)
+    sqrt = staticmethod(math.sqrt)
+    atan = staticmethod(math.atan)
+    exp = staticmethod(math.exp)
+    log = staticmethod(math.log)
+    inf = math.inf
 
 class GaussianBeam(object):
     '''An analytical description of a light beam with a Gaussian profile.
 
     Parameters
     ----------
-    w0 : scalar
-        The beam waist.
-    z : scalar
-        The current distance from the beam waist.
-    wavelength : scalar
-        The wavelength of the light.
+    q : scalar or Array
+        The complex beam parameter of the Gaussian beam.
+    wavelength : scalar or Array
+        The vacuum wavelength of the light.
+    n : scalar or Array
+        The refractive index of the medium in which the beam propagates.
     '''
-    def __init__(self, w0, z, wavelength):
-        self.w0 = w0
-        self.z = z
+    def __init__(self, q, wavelength, n=1.0):
+        self.q = q
         self.wavelength = wavelength
+        self.n = n
 
     @property
-    def beam_waist(self):
-        '''The beam waist of the Gaussian beam.
-        '''
-        return self.w0
-
-    @beam_waist.setter
-    def beam_waist(self, w0):
-        self.w0 = w0
-
-    @property
-    def zR(self):  # noqa: N802
-        '''The Rayleigh distance of the Gaussian beam.
-        '''
-        return np.pi * self.w0**2 / self.wavelength
-
-    @zR.setter
-    def zR(self, zR):  # noqa: N802
-        self.w0 = np.sqrt(zR * self.wavelength / np.pi)
-
-    rayleigh_distance = zR
+    def _xp(self):
+        params = (self.q, self.wavelength, self.n)
+        if any(is_array_api_obj(p) for p in params):
+            return array_namespace(*params)
+        else:
+            return _ScalarNamespace
 
     @property
     def q(self):
         '''The complex beam parameter of the Gaussian beam.
         '''
-        return self.z + 1j * self.zR
+        return self._q
 
     @q.setter
     def q(self, q):
-        self.z = np.real(q)
-        self.zR = np.imag(q)
+        self._q = q
 
     complex_beam_parameter = q
 
     @property
-    def theta(self):
-        '''The beam divergence of the Gaussian beam.
+    def n(self):
+        '''The refractive index of the medium in which the beam propagates.
         '''
-        return self.wavelength / (np.pi * self.w0)
+        return self._n
+
+    @n.setter
+    def n(self, n):
+        self._n = n
+
+    refractive_index = n
+
+    @property
+    def wavelength(self):
+        '''The vacuum wavelength of the light.
+        '''
+        return self._wavelength
+
+    @wavelength.setter
+    def wavelength(self, wavelength):
+        self._wavelength = wavelength
+
+    @property
+    def z(self):
+        '''The current distance from the beam waist.
+        '''
+        return self._xp.real(self.q)
+
+    @z.setter
+    def z(self, z):
+        self.q = z + 1j * self._xp.imag(self.q)
+
+    @property
+    def zR(self):  # noqa: N802
+        '''The Rayleigh distance of the Gaussian beam.
+        '''
+        return self._xp.imag(self.q)
+
+    @zR.setter
+    def zR(self, zR):  # noqa: N802
+        self.q = self._xp.real(self.q) + 1j * zR
+
+    rayleigh_distance = zR
+
+    @property
+    def w0(self):
+        '''The beam waist of the Gaussian beam.
+        '''
+        return self._xp.sqrt(self.zR * self.wavelength / (math.pi * self.n))
+
+    @w0.setter
+    def w0(self, w0):
+        self.zR = math.pi * self.n * w0**2 / self.wavelength
+
+    beam_waist = w0
+
+    @property
+    def theta(self):
+        '''The beam divergence of the Gaussian beam in the medium.
+        '''
+        return self.wavelength / (math.pi * self.n * self.w0)
 
     @theta.setter
     def theta(self, theta):
-        self.w0 = self.wavelength / (theta * np.pi)
+        self.w0 = self.wavelength / (theta * math.pi * self.n)
 
     beam_divergence = theta
 
@@ -73,7 +127,7 @@ class GaussianBeam(object):
         '''
         epsilon = 1e-16
         if abs(self.z) < epsilon:
-            return np.inf
+            return self._xp.inf
         else:
             return self.z * (1 + (self.zR / self.z)**2)
 
@@ -83,7 +137,7 @@ class GaussianBeam(object):
     def psi(self):
         '''The current Gouy phase of the Gaussian beam.
         '''
-        return np.arctan(self.z / self.zR)
+        return self._xp.atan(self.z / self.zR)
 
     gouy_phase = psi
 
@@ -91,7 +145,7 @@ class GaussianBeam(object):
     def w(self):
         '''The current beam radius of the Gaussian beam.
         '''
-        return self.w0 * np.sqrt(1 + (self.z / self.zR)**2)
+        return self.w0 * self._xp.sqrt(1 + (self.z / self.zR)**2)
 
     beam_radius = w
 
@@ -99,19 +153,19 @@ class GaussianBeam(object):
     def FWHM(self):  # noqa: N802
         '''The current FWHM of the Gaussian beam.
         '''
-        return self.w * np.sqrt(2 * np.log(2))
+        return self.w * self._xp.sqrt(2 * self._xp.log(2.0))
 
     full_width_half_maximum = FWHM
 
     @property
     def k(self):
-        '''The wavenumber of the Gaussian beam.
+        '''The wavenumber of the Gaussian beam in the medium.
         '''
-        return 2 * np.pi / self.wavelength
+        return 2 * math.pi * self.n / self.wavelength
 
     @k.setter
     def k(self, k):
-        self.wavelength = 2 * np.pi / k
+        self.wavelength = 2 * math.pi * self.n / k
 
     wavenumber = k
 
@@ -123,15 +177,19 @@ class GaussianBeam(object):
 
             q' = (A q + B) / (C q + D),
 
-        and a new GaussianBeam with the propagated parameters is returned.
+        and the refractive index as
+
+            n' = n / det(M).
+
+        A new GaussianBeam with the propagated parameters is returned.
         The beam itself is not modified.
 
         Parameters
         ----------
         matrix : Array or callable
-            The 2x2 ABCD (ray-transfer) matrix to propagate the beam through,
-            or a function of the wavelength (in meters) that returns one. A
-            callable is evaluated at the wavelength of the beam.
+            The 2x2 ABCD (ray-transfer) matrix of the optical system, in the
+            physical-angle convention. If callable, it will be evaluated at the
+            wavelength of the beam (in meters).
 
         Returns
         -------
@@ -140,24 +198,27 @@ class GaussianBeam(object):
 
         Raises
         ------
+        NotImplementedError
+            If the ABCD matrix contains complex elements.
         ValueError
             If the matrix is not 2x2.
         '''
         if callable(matrix):
             matrix = matrix(self.wavelength)
 
-        xp = infer_xp(matrix)
-        matrix = xp.asarray(matrix)
+        xp = array_namespace(matrix)
+
+        if xp.isdtype(matrix.dtype, 'complex floating'):
+            raise NotImplementedError('Propagation through systems with complex ABCD matrices (e.g. Gaussian apertures) is not implemented.')
 
         if matrix.shape != (2, 2):
             raise ValueError('The ABCD matrix should be a 2x2 array.')
 
-        q = self.q
-        q_new = (float(matrix[0, 0]) * q + float(matrix[0, 1])) / (float(matrix[1, 0]) * q + float(matrix[1, 1]))
+        A, B, C, D = matrix[0, 0], matrix[0, 1], matrix[1, 0], matrix[1, 1]
+        q = (A * self.q + B) / (C * self.q + D)
+        n = self.n / (A * D - B * C)
 
-        new_beam = GaussianBeam(self.w0, self.z, self.wavelength)
-        new_beam.q = q_new
-        return new_beam
+        return GaussianBeam(q, self.wavelength, n)
 
     def evaluate(self, grid):
         '''Evaluate the wavefront of the Gaussian beam at the current position on
@@ -178,9 +239,13 @@ class GaussianBeam(object):
         else:
             r2 = grid.as_('polar').r**2
 
+        xp = array_namespace(r2)
+
+        # Note: this can be computed faster if the grids are separated and Cartesian,
+        # but we can optimize when/if needed.
         K1 = self.w0 / self.w
-        K2 = np.exp(-r2 / self.w**2)
-        K3 = np.exp(-1j * (self.k * self.z + self.k * r2 / (2 * self.R) - self.psi))
+        K2 = xp.exp(-r2 / self.w**2)
+        K3 = xp.exp(-1j * (self.k * self.z + self.k * r2 / (2 * self.R) - self.psi))
 
         return Wavefront(Field(K1 * K2 * K3, grid), self.wavelength)
 

--- a/hcipy/optics/gaussian_beam.py
+++ b/hcipy/optics/gaussian_beam.py
@@ -32,7 +32,7 @@ class GaussianBeam(object):
 
     @property
     def zR(self):  # noqa: N802
-        '''The Rayleight distance of the Gaussian beam.
+        '''The Rayleigh distance of the Gaussian beam.
         '''
         return np.pi * self.w0**2 / self.wavelength
 

--- a/hcipy/optics/gaussian_beam.py
+++ b/hcipy/optics/gaussian_beam.py
@@ -19,6 +19,10 @@ class _ScalarNamespace:
 class GaussianBeam(object):
     '''An analytical description of a light beam with a Gaussian profile.
 
+    The complex beam parameter q and the refractive index n of the medium
+    are the primary parameters of the beam, from which all other quantities
+    are derived. The beam is immutable.
+
     Parameters
     ----------
     q : scalar or Array
@@ -29,27 +33,21 @@ class GaussianBeam(object):
         The refractive index of the medium in which the beam propagates.
     '''
     def __init__(self, q, wavelength, n=1.0):
-        self.q = q
-        self.wavelength = wavelength
-        self.n = n
+        self._q = q
+        self._wavelength = wavelength
+        self._n = n
 
-    @property
-    def _xp(self):
-        params = (self.q, self.wavelength, self.n)
+        params = (q, wavelength, n)
         if any(is_array_api_obj(p) for p in params):
-            return array_namespace(*params)
+            self._xp = array_namespace(*params)
         else:
-            return _ScalarNamespace
+            self._xp = _ScalarNamespace
 
     @property
     def q(self):
         '''The complex beam parameter of the Gaussian beam.
         '''
         return self._q
-
-    @q.setter
-    def q(self, q):
-        self._q = q
 
     complex_beam_parameter = q
 
@@ -59,10 +57,6 @@ class GaussianBeam(object):
         '''
         return self._n
 
-    @n.setter
-    def n(self, n):
-        self._n = n
-
     refractive_index = n
 
     @property
@@ -71,29 +65,17 @@ class GaussianBeam(object):
         '''
         return self._wavelength
 
-    @wavelength.setter
-    def wavelength(self, wavelength):
-        self._wavelength = wavelength
-
     @property
     def z(self):
         '''The current distance from the beam waist.
         '''
         return self._xp.real(self.q)
 
-    @z.setter
-    def z(self, z):
-        self.q = z + 1j * self._xp.imag(self.q)
-
     @property
     def zR(self):  # noqa: N802
         '''The Rayleigh distance of the Gaussian beam.
         '''
         return self._xp.imag(self.q)
-
-    @zR.setter
-    def zR(self, zR):  # noqa: N802
-        self.q = self._xp.real(self.q) + 1j * zR
 
     rayleigh_distance = zR
 
@@ -103,10 +85,6 @@ class GaussianBeam(object):
         '''
         return self._xp.sqrt(self.zR * self.wavelength / (math.pi * self.n))
 
-    @w0.setter
-    def w0(self, w0):
-        self.zR = math.pi * self.n * w0**2 / self.wavelength
-
     beam_waist = w0
 
     @property
@@ -114,10 +92,6 @@ class GaussianBeam(object):
         '''The beam divergence of the Gaussian beam in the medium.
         '''
         return self.wavelength / (math.pi * self.n * self.w0)
-
-    @theta.setter
-    def theta(self, theta):
-        self.w0 = self.wavelength / (theta * math.pi * self.n)
 
     beam_divergence = theta
 
@@ -162,10 +136,6 @@ class GaussianBeam(object):
         '''The wavenumber of the Gaussian beam in the medium.
         '''
         return 2 * math.pi * self.n / self.wavelength
-
-    @k.setter
-    def k(self, k):
-        self.wavelength = 2 * math.pi * self.n / k
 
     wavenumber = k
 

--- a/tests/test_abcd.py
+++ b/tests/test_abcd.py
@@ -1,0 +1,219 @@
+import pytest
+import array_api_compat
+from hcipy import *
+import array_api_strict as xp
+from hcipy._math.backends import all_close
+
+WL = 500e-9
+
+def test_make_abcd_free_space():
+    z = 0.5
+    M = make_abcd_free_space(z, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[1, z], [0, 1]]))
+
+def test_make_abcd_thin_lens():
+    f = 2.0
+    M = make_abcd_thin_lens(f, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[1, 0], [-1 / f, 1]]))
+
+def test_make_abcd_mirror():
+    radius = 4.0
+    M = make_abcd_mirror(radius, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[1, 0], [-2 / radius, 1]]))
+
+    # A plane mirror (radius=None) is the identity.
+    M = make_abcd_mirror(xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.eye(2))
+
+def test_make_abcd_fraunhofer():
+    f = 2.0
+    M = make_abcd_fraunhofer(f, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[0, f], [-1 / f, 0]]))
+
+def test_make_abcd_magnifier():
+    magnification = 3.0
+    M = make_abcd_magnifier(magnification, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[magnification, 0], [0, 1 / magnification]]))
+
+def test_make_abcd_refractive_interface():
+    n1, n2, radius = 1.0, 1.5, 2.0
+    M = make_abcd_refractive_interface(n1, n2, radius, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[1, 0], [(n1 - n2) / (radius * n2), n1 / n2]]))
+
+    # A flat interface is obtained with radius=None (the default).
+    M = make_abcd_refractive_interface(n1, n2, xp=xp)
+
+    assert isinstance(M, RayTransferMatrix)
+    assert all_close(M(WL), xp.asarray([[1, 0], [0, n1 / n2]]))
+
+def test_ray_transfer_matrix_composition():
+    f, z = 2.0, 0.5
+
+    M_sys = make_abcd_free_space(z, xp=xp) @ make_abcd_thin_lens(f, xp=xp)
+
+    expected = make_abcd_free_space(z, xp=xp)(WL) @ make_abcd_thin_lens(f, xp=xp)(WL)
+    assert all_close(M_sys(WL), expected)
+    assert not M_sys.is_dispersive
+    assert array_api_compat.array_namespace(M_sys(WL)) is xp
+
+    # Composition with a raw array works as well.
+    M = make_abcd_thin_lens(f, xp=xp) @ xp.eye(2)
+    assert all_close(M(WL), make_abcd_thin_lens(f, xp=xp)(WL))
+
+def test_ray_transfer_matrix_predicates():
+    assert make_abcd_thin_lens(1.0, xp=xp).is_surface(WL)
+    assert not make_abcd_free_space(1.0, xp=xp).is_surface(WL)
+
+    assert make_abcd_free_space(0.5, xp=xp).is_free_space(WL)
+    assert not make_abcd_thin_lens(1.0, xp=xp).is_free_space(WL)
+
+def test_ray_transfer_matrix_derived_scalars():
+    f = 2.0
+    M = make_abcd_thin_lens(f, xp=xp)
+
+    assert float(M.effective_focal_length(WL)) == pytest.approx(f)
+    assert float(M.paraxial_power(WL)) == pytest.approx(1 / f)
+    assert float(M.geometric_magnification(WL)) == pytest.approx(1.0)
+    assert float(M.angular_magnification(WL)) == pytest.approx(1.0)
+    assert float(M.distance(WL)) == pytest.approx(0.0)
+    assert float(M.front_focal_length(WL)) == pytest.approx(f)
+    assert float(M.back_focal_length(WL)) == pytest.approx(f)
+
+    M = make_abcd_free_space(0.5, xp=xp)
+    assert float(M.distance(WL)) == pytest.approx(0.5)
+
+    M = make_abcd_magnifier(2.0, xp=xp)
+    assert float(M.geometric_magnification(WL)) == pytest.approx(2.0)
+    assert float(M.angular_magnification(WL)) == pytest.approx(0.5)
+
+def test_ray_transfer_matrix_requires_wavelength():
+    M = make_abcd_free_space(0.5, xp=xp)
+
+    with pytest.raises(TypeError):
+        M()
+    with pytest.raises(TypeError):
+        M.effective_focal_length()
+    with pytest.raises(TypeError):
+        M.is_surface()
+
+    M = make_abcd_refractive_interface(lambda wl: 1.5, 1.0, xp=xp)
+    with pytest.raises(TypeError):
+        M()
+
+def test_ray_transfer_matrix_shape_validation():
+    with pytest.raises(ValueError):
+        RayTransferMatrix(xp.eye(3))
+
+def test_ray_transfer_matrix_wraps_array_and_callable():
+    M = RayTransferMatrix(xp.asarray([[1.0, 0.5], [0.0, 1.0]]))
+    assert not M.is_dispersive
+    assert all_close(M(WL), xp.asarray([[1, 0.5], [0, 1]]))
+
+    M = RayTransferMatrix(lambda wl: xp.asarray([[1.0, wl], [0.0, 1.0]]))
+    assert M.is_dispersive
+    assert all_close(M(WL), xp.asarray([[1, WL], [0, 1]]))
+
+def test_dispersive_ray_transfer_matrix():
+    n = make_sellmeier_glass(1, [0.6961663, 0.4079426, 0.8974794], [0.0684043**2, 0.1162414**2, 9.896161**2])
+
+    M = make_abcd_refractive_interface(n, 1.0, xp=xp)
+    assert isinstance(M, RayTransferMatrix)
+    assert M.is_dispersive
+    assert all_close(M(WL), xp.asarray([[1, 0], [0, n(WL)]]))
+
+    # A mixed static + dispersive composition stays dispersive.
+    M_sys = make_abcd_free_space(0.1, xp=xp) @ M
+    assert M_sys.is_dispersive
+
+    expected = make_abcd_free_space(0.1, xp=xp)(WL) @ M(WL)
+    assert all_close(M_sys(WL), expected)
+
+    # A constant callable is still dispersive.
+    M = make_abcd_refractive_interface(lambda wl: 1.5, 1.0, 2.0, xp=xp)
+    assert isinstance(M, RayTransferMatrix)
+    assert M.is_dispersive
+
+    # Dispersive derived scalars evaluate at the requested wavelength.
+    M = make_abcd_refractive_interface(lambda wl: (wl + 2.25) ** 0.5, 1.0, 2.0, xp=xp)
+    assert float(M.angular_magnification(WL)) == pytest.approx((WL + 2.25) ** 0.5)
+
+def test_gaussian_beam_forward():
+    w0 = 1e-3
+    z = 0.5
+    wavelength = 500e-9
+    beam = GaussianBeam(w0, z, wavelength)
+
+    # Free-space propagation by a distance d forwards z by d and leaves zR unchanged.
+    d = 0.3
+    zR = beam.zR
+    new_beam = make_abcd_free_space(d, xp=xp).forward(beam)
+    assert new_beam is not beam
+    assert new_beam.z == pytest.approx(z + d)
+    assert new_beam.zR == pytest.approx(zR)
+    assert beam.z == pytest.approx(z)
+
+    # A thin lens transforms q as q' = q f / (f - q).
+    beam = GaussianBeam(w0, z, wavelength)
+    f = 2.0
+    q = z + 1j * beam.zR
+    new_beam = make_abcd_thin_lens(f, xp=xp).forward(beam)
+    assert new_beam.q == pytest.approx((q * f) / (f - q))
+
+    # Composing matrices is equivalent to forwarding through each consecutively.
+    beam1 = make_abcd_free_space(d, xp=xp).forward(make_abcd_thin_lens(f, xp=xp).forward(beam))
+    beam2 = (make_abcd_free_space(d, xp=xp) @ make_abcd_thin_lens(f, xp=xp)).forward(beam)
+    assert beam1.q == pytest.approx(beam2.q)
+
+def test_gaussian_beam_backward():
+    w0 = 1e-3
+    z = 0.5
+    wavelength = 500e-9
+    beam = GaussianBeam(w0, z, wavelength)
+
+    # Backward through a free space of distance d moves z by -d.
+    d = 0.3
+    new_beam = make_abcd_free_space(d, xp=xp).backward(beam)
+    assert new_beam.z == pytest.approx(z - d)
+
+    # Forward then backward returns (numerically) to the original beam.
+    M = make_abcd_refractive_interface(1.0, 1.5, 2.0, xp=xp)
+    back = M.backward(M.forward(beam))
+    assert back.q == pytest.approx(beam.q)
+
+def test_gaussian_beam_forward_uses_beam_wavelength():
+    beam = GaussianBeam(1e-3, 0.5, 500e-9)
+
+    # Forwarding through 'distance' B = wavelength * 1e6 equals 0.5 at 500 nm.
+    M = RayTransferMatrix(lambda wl: xp.asarray([[1.0, wl * 1e6], [0.0, 1.0]]))
+
+    new_beam = M.forward(beam)
+    assert new_beam.z == pytest.approx(1.0)
+
+def test_gaussian_beam_propagate():
+    beam = GaussianBeam(1e-3, 0.5, 500e-9)
+
+    # A raw 2x2 matrix propagates directly.
+    new_beam = beam.propagate(xp.asarray([[1.0, 0.3], [0.0, 1.0]]))
+    assert new_beam is not beam
+    assert new_beam.z == pytest.approx(0.8)
+
+    # A callable is evaluated at the wavelength of the beam.
+    new_beam = beam.propagate(lambda wl: xp.asarray([[1.0, wl * 1e6], [0.0, 1.0]]))
+    assert new_beam.z == pytest.approx(1.0)
+
+    with pytest.raises(ValueError):
+        beam.propagate(xp.eye(3))

--- a/tests/test_abcd.py
+++ b/tests/test_abcd.py
@@ -3,6 +3,7 @@ import array_api_compat
 from hcipy import *
 import array_api_strict as xp
 from hcipy._math.backends import all_close
+import math
 
 WL = 500e-9
 
@@ -155,65 +156,65 @@ def test_gaussian_beam_forward():
     w0 = 1e-3
     z = 0.5
     wavelength = 500e-9
-    beam = GaussianBeam(w0, z, wavelength)
+    beam = GaussianBeam(z + 1j * math.pi * w0**2 / wavelength, wavelength)
 
     # Free-space propagation by a distance d forwards z by d and leaves zR unchanged.
     d = 0.3
     zR = beam.zR
     new_beam = make_abcd_free_space(d, xp=xp).forward(beam)
     assert new_beam is not beam
-    assert new_beam.z == pytest.approx(z + d)
-    assert new_beam.zR == pytest.approx(zR)
-    assert beam.z == pytest.approx(z)
+    assert float(new_beam.z) == pytest.approx(z + d)
+    assert float(new_beam.zR) == pytest.approx(zR)
+    assert float(beam.z) == pytest.approx(z)
 
     # A thin lens transforms q as q' = q f / (f - q).
-    beam = GaussianBeam(w0, z, wavelength)
+    beam = GaussianBeam(z + 1j * math.pi * w0**2 / wavelength, wavelength)
     f = 2.0
     q = z + 1j * beam.zR
     new_beam = make_abcd_thin_lens(f, xp=xp).forward(beam)
-    assert new_beam.q == pytest.approx((q * f) / (f - q))
+    assert complex(new_beam.q) == pytest.approx((q * f) / (f - q))
 
     # Composing matrices is equivalent to forwarding through each consecutively.
     beam1 = make_abcd_free_space(d, xp=xp).forward(make_abcd_thin_lens(f, xp=xp).forward(beam))
     beam2 = (make_abcd_free_space(d, xp=xp) @ make_abcd_thin_lens(f, xp=xp)).forward(beam)
-    assert beam1.q == pytest.approx(beam2.q)
+    assert complex(beam1.q) == pytest.approx(complex(beam2.q))
 
 def test_gaussian_beam_backward():
     w0 = 1e-3
     z = 0.5
     wavelength = 500e-9
-    beam = GaussianBeam(w0, z, wavelength)
+    beam = GaussianBeam(z + 1j * math.pi * w0**2 / wavelength, wavelength)
 
     # Backward through a free space of distance d moves z by -d.
     d = 0.3
     new_beam = make_abcd_free_space(d, xp=xp).backward(beam)
-    assert new_beam.z == pytest.approx(z - d)
+    assert float(new_beam.z) == pytest.approx(z - d)
 
     # Forward then backward returns (numerically) to the original beam.
     M = make_abcd_refractive_interface(1.0, 1.5, 2.0, xp=xp)
     back = M.backward(M.forward(beam))
-    assert back.q == pytest.approx(beam.q)
+    assert complex(back.q) == pytest.approx(complex(beam.q))
 
 def test_gaussian_beam_forward_uses_beam_wavelength():
-    beam = GaussianBeam(1e-3, 0.5, 500e-9)
+    beam = GaussianBeam(0.5 + 1j * math.pi * (1e-3)**2 / 500e-9, 500e-9)
 
     # Forwarding through 'distance' B = wavelength * 1e6 equals 0.5 at 500 nm.
     M = RayTransferMatrix(lambda wl: xp.asarray([[1.0, wl * 1e6], [0.0, 1.0]]))
 
     new_beam = M.forward(beam)
-    assert new_beam.z == pytest.approx(1.0)
+    assert float(new_beam.z) == pytest.approx(1.0)
 
 def test_gaussian_beam_propagate():
-    beam = GaussianBeam(1e-3, 0.5, 500e-9)
+    beam = GaussianBeam(0.5 + 1j * math.pi * (1e-3)**2 / 500e-9, 500e-9)
 
     # A raw 2x2 matrix propagates directly.
     new_beam = beam.propagate(xp.asarray([[1.0, 0.3], [0.0, 1.0]]))
     assert new_beam is not beam
-    assert new_beam.z == pytest.approx(0.8)
+    assert float(new_beam.z) == pytest.approx(0.8)
 
     # A callable is evaluated at the wavelength of the beam.
     new_beam = beam.propagate(lambda wl: xp.asarray([[1.0, wl * 1e6], [0.0, 1.0]]))
-    assert new_beam.z == pytest.approx(1.0)
+    assert float(new_beam.z) == pytest.approx(1.0)
 
     with pytest.raises(ValueError):
         beam.propagate(xp.eye(3))

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -955,40 +955,6 @@ def test_gaussian_beam_initialization_and_properties(w0, z, wavelength):
     assert np.isclose(beam.k, k)
     assert np.isclose(beam.wavenumber, k)
 
-def test_gaussian_beam_setters():
-    wavelength = 500e-9
-    q = 0.5 + 1j * math.pi * (1e-3)**2 / wavelength
-    beam = GaussianBeam(q, wavelength)
-
-    zR_old = beam.zR
-    beam.beam_waist = 2e-3
-    assert np.isclose(beam.w0, 2e-3)
-    assert beam.zR != zR_old
-    assert np.isclose(beam.zR, np.pi * (2e-3)**2 / wavelength)
-
-    beam.w0 = 1e-3
-    new_zR = 2 * beam.zR
-    beam.zR = new_zR
-    assert np.isclose(beam.w0, np.sqrt(new_zR * wavelength / np.pi))
-
-    beam.w0 = 1e-3
-    new_q = 1.0 + 2.0j * beam.zR
-    beam.q = new_q
-    assert np.isclose(beam.z, 1.0)
-    assert np.isclose(beam.zR, np.imag(new_q))
-
-    beam.w0 = 1e-3
-    beam.z = 0.5
-    new_theta = 2 * beam.theta
-    beam.theta = new_theta
-    assert np.isclose(beam.w0, wavelength / (new_theta * np.pi))
-
-    beam.w0 = 1e-3
-    beam.z = 0.5
-    new_k = 2 * beam.k
-    beam.k = new_k
-    assert np.isclose(beam.wavelength, 2 * np.pi / new_k)
-
 def test_gaussian_beam_propagate():
     wavelength = 500e-9
     w0 = 1e-3

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,9 +1,16 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from hcipy import *
+from hcipy._math.backends import all_close
 import pytest
 import os
 import warnings
+import math
+
+if Configuration().core.use_new_style_fields:
+    import array_api_strict as xp
+else:
+    import numpy as xp
 
 def test_agnostic_apodizer():
     aperture_achromatic = make_circular_aperture(1)
@@ -905,19 +912,20 @@ def test_surface_profile_fill_value():
     (1e-3, -0.5, 500e-9),
 ])
 def test_gaussian_beam_initialization_and_properties(w0, z, wavelength):
-    beam = GaussianBeam(w0, z, wavelength)
+    q = z + 1j * np.pi * w0**2 / wavelength
+    beam = GaussianBeam(q, wavelength)
 
-    assert beam.w0 == w0
-    assert beam.z == z
+    assert np.isclose(beam.w0, w0)
+    assert np.isclose(beam.z, z)
     assert beam.wavelength == wavelength
-    assert beam.beam_waist == w0
+    assert np.isclose(beam.beam_waist, w0)
 
     zR = np.pi * w0**2 / wavelength
     assert np.isclose(beam.zR, zR)
     assert np.isclose(beam.rayleigh_distance, zR)
 
-    assert np.isclose(beam.q, z + 1j * zR)
-    assert np.isclose(beam.complex_beam_parameter, z + 1j * zR)
+    assert np.isclose(beam.q, q)
+    assert np.isclose(beam.complex_beam_parameter, q)
 
     theta = wavelength / (np.pi * w0)
     assert np.isclose(beam.theta, theta)
@@ -948,12 +956,13 @@ def test_gaussian_beam_initialization_and_properties(w0, z, wavelength):
     assert np.isclose(beam.wavenumber, k)
 
 def test_gaussian_beam_setters():
-    beam = GaussianBeam(1e-3, 0.5, 500e-9)
-    wavelength = beam.wavelength
+    wavelength = 500e-9
+    q = 0.5 + 1j * math.pi * (1e-3)**2 / wavelength
+    beam = GaussianBeam(q, wavelength)
 
     zR_old = beam.zR
     beam.beam_waist = 2e-3
-    assert beam.w0 == 2e-3
+    assert np.isclose(beam.w0, 2e-3)
     assert beam.zR != zR_old
     assert np.isclose(beam.zR, np.pi * (2e-3)**2 / wavelength)
 
@@ -980,11 +989,84 @@ def test_gaussian_beam_setters():
     beam.k = new_k
     assert np.isclose(beam.wavelength, 2 * np.pi / new_k)
 
+def test_gaussian_beam_propagate():
+    wavelength = 500e-9
+    w0 = 1e-3
+    zR = np.pi * w0**2 / wavelength
+    beam = GaussianBeam(1j * zR, wavelength)
+
+    z = 0.3
+    beam_out = beam.propagate(np.array([[1, z], [0, 1.0]]))
+    assert np.isclose(beam_out.z, z)
+    assert np.isclose(beam_out.zR, zR)
+    assert beam_out.n == 1
+    assert np.isclose(beam.z, 0)
+
+    beam = GaussianBeam(1j * zR, wavelength)
+    n = 1.5
+    beam_out = beam.propagate(np.array([[1, 0], [0, 1.0 / n]]))
+    assert np.isclose(beam_out.n, n)
+    assert np.isclose(beam_out.w0, w0)
+
+    beam = GaussianBeam(1j * zR, wavelength)
+    with pytest.raises(NotImplementedError):
+        beam.propagate(np.array([[1, 0], [-1j / (2e-3), 1.0]]))
+
+    beam = GaussianBeam(1j * zR, wavelength)
+    beam_out = beam.propagate(lambda wl: np.array([[1, 0.2], [0, 1.0]]))
+    assert np.isclose(beam_out.z, 0.2)
+
+    with pytest.raises(ValueError):
+        beam.propagate(np.array([[1, 0], [0, 1.0], [0, 0]]))
+
+def test_gaussian_beam_array_api():
+    wavelength = xp.asarray(500e-9)
+    w0 = xp.asarray(1e-3)
+    z = xp.asarray(0.5)
+    zR = math.pi * w0**2 / wavelength
+    q = z + 1j * zR
+
+    beam = GaussianBeam(q, wavelength)
+
+    assert all_close(beam.w0, w0)
+    assert all_close(beam.z, z)
+    assert all_close(beam.zR, zR)
+    assert all_close(beam.theta, wavelength / (math.pi * w0))
+    assert all_close(beam.psi, math.atan(z / zR))
+    assert all_close(beam.w, w0 * math.sqrt(1 + (z / zR)**2))
+    assert all_close(beam.k, 2 * math.pi / wavelength)
+
+    beam_at_waist = GaussianBeam(1j * zR, wavelength)
+    assert math.isinf(float(beam_at_waist.R))
+
+    d = xp.asarray(0.3)
+    M = xp.asarray([[1.0, d], [0.0, 1.0]])
+
+    beam_prop = beam.propagate(M)
+    assert all_close(beam_prop.z, z + d)
+    assert all_close(beam_prop.zR, zR)
+    assert all_close(beam_prop.n, xp.asarray(1.0))
+    assert all_close(beam.z, z)
+
+    with pytest.raises(NotImplementedError):
+        beam.propagate(xp.asarray([[1, 0], [-1j, 1]]))
+
+    with pytest.raises(ValueError):
+        beam.propagate(xp.asarray([[1, 0], [0, 1], [0, 0]]))
+
+def test_gaussian_beam_scalar():
+    beam_scalar = GaussianBeam(0.5 + 1j * math.pi * (1e-3)**2 / 500e-9, 500e-9)
+
+    assert type(beam_scalar.z) is float
+    assert type(beam_scalar.w0) is float
+    assert beam_scalar.w0 == pytest.approx(1e-3)
+    assert beam_scalar.z == pytest.approx(0.5)
+
 def test_gaussian_beam_evaluate():
     w0 = 1e-3
     z = 0.5
     wavelength = 500e-9
-    beam = GaussianBeam(w0, z, wavelength)
+    beam = GaussianBeam(z + 1j * np.pi * w0**2 / wavelength, wavelength)
 
     for grid in [
         make_pupil_grid(64, 4e-3),


### PR DESCRIPTION
## Add ray transfer (ABCD) matrices and Gaussian beam propagation

Adds a backend-agnostic 2x2 ray-transfer (ABCD) matrix module plus functional Gaussian beam propagation, usable with any Array API backend. Also refactors the `GaussianBeam` class to use the complex beam parameter as main variable.

### Features
- `RayTransferMatrix` wraps a fixed 2x2 array or a wavelength callable (dispersive matrices evaluated at the requested wavelength); supports `@` composition and derived scalars (`effective_focal_length`, `paraxial_power`, `distance`, `front/back_focal_length`, ...) plus `is_surface`/`is_free_space` predicates.
- Constructors: `make_abcd_free_space`, `make_abcd_thin_lens`, `make_abcd_mirror`, `make_abcd_fraunhofer`, `make_abcd_magnifier`, `make_abcd_refractive_interface`.
- `RayTransferMatrix.forward(beam)` / `backward(beam)` transform a `GaussianBeam` via the ABCD law `q' = (Aq+B)/(Cq+D)`, returning a new beam; `backward` applies the numerical inverse.
- `GaussianBeam.propagate(matrix)` accepts a raw matrix or callable (evaluated at the beam's wavelength) and returns a new propagated beam.

### Design notes
Physical-angle convention: (`u = dy/dz`). Under this convention determinants are not restricted to 1. This allows the Gaussian beam to keep track of its refractive index without explicitly telling it what the new one is.

### Testing
All new tests run against `array_api_strict` only, just like the other Array API compatible tests.
